### PR TITLE
DROPME: temporary change branch for arsenal and vaultclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#rel/1.0",
+    "arsenal": "scality/Arsenal#FT/common-req-auth",
     "async": "~1.4.2",
     "babel-core": "^6.2.1",
     "babel-plugin-transform-es2015-destructuring": "^6.1.18",
@@ -30,7 +30,7 @@
     "node-uuid": "^1.4.3",
     "sproxydclient": "scality/sproxydclient#rel/1.0",
     "utf8": "~2.1.1",
-    "vaultclient": "scality/vaultclient#rel/1.0",
+    "vaultclient": "scality/vaultclient#FT/common-req-auth",
     "werelogs": "scality/werelogs#rel/1.0",
     "xml": "~1.0.0",
     "xml2js": "~0.4.12"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#FT/common-req-auth",
+    "arsenal": "git://github.com/scality/arsenal.git#FT/common-req-auth",
     "async": "~1.4.2",
     "babel-core": "^6.2.1",
     "babel-plugin-transform-es2015-destructuring": "^6.1.18",
@@ -30,7 +30,7 @@
     "node-uuid": "^1.4.3",
     "sproxydclient": "scality/sproxydclient#rel/1.0",
     "utf8": "~2.1.1",
-    "vaultclient": "scality/vaultclient#FT/common-req-auth",
+    "vaultclient": "git://github.com/scality/vaultclient.git#FT/common-req-auth",
     "werelogs": "scality/werelogs#rel/1.0",
     "xml": "~1.0.0",
     "xml2js": "~0.4.12"


### PR DESCRIPTION
Just redirecting Arsenal and vaultclient deps for end-to-end tests in the Vault's admin credentials effort.

Will close after the feature is merged.