### PR TITLE
[Listing](ft): Set an hard limit to listing

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -52,4 +52,8 @@ export default {
 
     // Number of sub-directories for file backend
     folderHash: 3511, // Prime number
+    // Aws amazon set an hard limit to the listing maxKeys
+    // http://docs.aws.amazon.com/AmazonS3/latest/API/
+    //      RESTBucketGET.html#RESTBucketGET-requests
+    listingHardLimit: 1000,
 };

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -1,6 +1,7 @@
 import services from '../services';
 
 import querystring from 'querystring';
+import constants from '../../constants';
 
 //	Sample XML response:
 /*	<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -41,8 +42,11 @@ export default function bucketGet(authInfo, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
     const encoding = params['encoding-type'];
-    const maxKeys = params['max-keys'] ?
+    let maxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
+    if (maxKeys > constants.listingHardLimit) {
+        maxKeys = constants.listingHardLimit;
+    }
     const metadataValParams = {
         authInfo,
         bucketName,


### PR DESCRIPTION
- Amazon aws set an hard limit to 1000
  This config can be override in constants.js to increase or
  decrease the max keys we will receive

see http://docs.aws.amazon.com/AmazonS3/latest/API/
    RESTBucketGET.html#RESTBucketGET-requests