### PR TITLE
FT: set file backend as the default backend

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -150,16 +150,21 @@ class Config {
                 cert: certpath,
             };
         } else if (key || cert) {
-            throw new Error( 'bad config: both certFilePaths.key and ' +
+            throw new Error('bad config: both certFilePaths.key and ' +
                 'certFilePaths.cert must be defined');
         }
         /**
          * Configure the backends for Authentication, Data and Metadata.
          */
-        let auth = '';
-        let data = '';
-        let metadata = '';
+        let auth = 'mem';
+        let data = 'file';
+        let metadata = 'file';
         if (process.env.S3BACKEND) {
+            const validBackends = ['mem', 'file', 'scality'];
+            assert(validBackends.indexOf(process.env.S3BACKEND) > -1,
+                'bad environment variable: S3BACKEND environment variable ' +
+                'should be one of mem/file/scality'
+            );
             auth = process.env.S3BACKEND;
             data = process.env.S3BACKEND;
             metadata = process.env.S3BACKEND;

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -14,7 +14,7 @@ if (config.backends.data === 'mem') {
 } else if (config.backends.data === 'file') {
     client = file;
     implName = 'file';
-} else {
+} else if (config.backends.data === 'scality') {
     client = new Sproxy({
         bootstrap: config.sproxyd.bootstrap,
         log: config.log,

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -13,7 +13,7 @@ if (config.backends.metadata === 'mem') {
 } else if (config.backends.metadata === 'file') {
     client = new BucketFileInterface();
     implName = 'bucketfile';
-} else {
+} else if (config.backends.metadata === 'scality') {
     client = new BucketClientInterface();
     implName = 'bucketclient';
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -100,7 +100,7 @@ class S3Server {
 
 export default function main() {
     let clusters = _config.clusters || 1;
-    if (process.env.S3BACKEND) {
+    if (process.env.S3BACKEND === 'mem') {
         clusters = 1;
     }
     if (cluster.isMaster) {


### PR DESCRIPTION
By default S3 will be using file backend. For in-memory usage, `S3BACKEND` env var should be `mem` and for enterprise/federation usage S3BACKEND should be defined and set to something other than mem/file.