### PR TITLE
Perf--gets of objects put by MPU

### DIFF
--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -1,3 +1,5 @@
+import { readySetStream } from 'ready-set-stream';
+
 import data from '../data/wrapper';
 
 /**
@@ -289,55 +291,13 @@ const routesUtils = {
             });
         }
         const parsedLocations = range ? routesUtils
-            .setPartRanges(dataLocations, range) : dataLocations;
-        return routesUtils.responseStreamDataArray(parsedLocations,
-            response, log);
-    },
-
-    /**
-     * @param {string[]} array - keys related to the object
-     * @param {http.ServerResponse} response - response sent to the client
-     * @param {object} log - Werelogs logger
-     * @return {undefined}
-     */
-    responseStreamDataArray(array, response, log) {
-        function finish(msg) {
-            // Having the nulls here prevent the mock response object
-            // in the test from interpreting the callback as data to write
-            response.end(null, null, () => {
-                log.end().info(msg, {
-                    httpCode: response.statusCode,
-                });
+            .setPartRanges(dataLocations, range) : dataLocations.slice();
+        response.on('finish', () => {
+            log.end().info('responded with streamed content', {
+                httpCode: response.statusCode,
             });
-        }
-
-        function getPart(array, partNumber) {
-            if (partNumber >= array.length) {
-                return finish('responded with multi-part streamed content');
-            }
-            const dataLocator = array[partNumber];
-            data.get(dataLocator, log, (err, readStream) => {
-                const info = { partNumber, dataLocator };
-                if (err) {
-                    info.errorMessage = err.message;
-                    log.error('unable to get object part', info);
-                    return finish('unable to get object part');
-                }
-
-                readStream.on('end', () => {
-                    log.debug('finished forwarding part', info);
-                    process.nextTick(getPart, array, partNumber + 1);
-                });
-
-                readStream.on('data', (chunk) => {
-                    info.chunkSize = chunk.length;
-                    log.trace('forwarding chunk', info);
-                    response.write(chunk);
-                });
-            });
-        }
-
-        getPart(array, 0);
+        });
+        return readySetStream(parsedLocations, data.get, response, log);
     },
 };
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "level-sublevel": "^6.5.4",
     "multilevel": "^7.3.0",
     "node-uuid": "^1.4.3",
+    "ready-set-stream": "^1.0.0",
     "sproxydclient": "scality/sproxydclient",
     "utf8": "~2.1.1",
     "vaultclient": "scality/vaultclient",

--- a/tests/functional/s3cmd/tests.js
+++ b/tests/functional/s3cmd/tests.js
@@ -12,11 +12,11 @@ const upload = 'test1MB';
 const emptyUpload = 'Utest0B';
 const emptyDownload = 'Dtest0B';
 const download = 'tmpfile';
-const MPUpload = 'test16MB';
+const MPUpload = 'test60MB';
 const MPUploadSplitter = [
-    'test16..|..MB',
-    '..|..test16MB',
-    'test16MB..|..',
+    'test60..|..MB',
+    '..|..test60MB',
+    'test60MB..|..',
 ];
 const MPDownload = 'MPtmpfile';
 const bucket = 'universe';
@@ -383,7 +383,7 @@ describe('s3cmd multipart upload', function titi() {
     this.timeout(0);
     before('create the multipart file', done => {
         this.timeout(60000);
-        createFile(MPUpload, 16777216, done);
+        createFile(MPUpload, 62914560, done);
     });
 
     after('delete the multipart and the downloaded file', done => {


### PR DESCRIPTION
Uses double buffering to increase the speed of gets of objects put by MPU.

Perf testing with 1GB object:

205 parts with specified part size of 5MB
-with rel/1.1:  about 13-14 seconds
-with double buffer: about 7-8 seconds

103 parts with specified part size of 10 MB
-with rel/1.1: about 15-16 seconds
-with double buffer: about 7-8 seconds

52 parts with specified part size of 20 MB
-with rel/1.1: about 12-13 seconds
-with double buffer: about 5-6 seconds

