### PR TITLE
Testing with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:4
+MAINTAINER Giorgio Regni <gr@scality.com>
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+RUN npm install
+
+CMD [ "npm", "start" ]
+
+VOLUME ["usr/src/app/localData","usr/src/app/localMetadata"]
+
+EXPOSE 8000
+


### PR DESCRIPTION
Build :
-> `docker build -t 'test:1.0' ./`
Run with volumes :
-> `docker run -d -P -v /tmp/localData:/usr/src/app/localData -v /tmp/localMetadata:/usr/src/app/localMetadata test:1.0`
->  When running Dockerfile on macOS, there is an issue with the function : **_setDirSyncFlag** on init.js and the levelup and leveldown with levelDB.
Working fine when running directly on linux / linux VM.