### PR TITLE
BF: optionally install ioctl dependency

### DIFF
--- a/init.js
+++ b/init.js
@@ -6,10 +6,16 @@ const fs = require('fs');
 const os = require('os');
 
 const async = require('async');
-const ioctl = require('ioctl');
 const constants = require('./constants').default;
 const config = require('./lib/Config.js').default;
 const logger = require('./lib/utilities/logger.js').logger;
+
+let ioctl;
+try {
+    ioctl = require('ioctl');
+} catch (err) {
+    logger.warn('ioctl dependency is unavailable. skipping...');
+}
 
 function _setDirSyncFlag(path) {
     const GETFLAGS = 2148034049;
@@ -45,7 +51,7 @@ const metadataPath = config.filePaths.metadataPath;
 fs.accessSync(dataPath, fs.F_OK | fs.R_OK | fs.W_OK);
 fs.accessSync(metadataPath, fs.F_OK | fs.R_OK | fs.W_OK);
 
-if (os.type() === 'Linux' && os.endianness() === 'LE') {
+if (os.type() === 'Linux' && os.endianness() === 'LE' && ioctl) {
     _setDirSyncFlag(dataPath);
     _setDirSyncFlag(metadataPath);
 } else {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "bucketclient": "scality/bucketclient#rel/1.1",
-    "ioctl": "^2.0.0",
     "level": "^1.4.0",
     "level-sublevel": "^6.5.4",
     "multilevel": "^7.3.0",
@@ -37,6 +36,9 @@
     "werelogs": "scality/werelogs#rel/1.1",
     "xml": "~1.0.0",
     "xml2js": "~0.4.12"
+  },
+  "optionalDependencies": {
+      "ioctl": "2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",


### PR DESCRIPTION
ioctl install fails on CentOS 7 aborting the whole npm install
process. Adding it as an optional depedency allow npm to continue
if the dependency install fails.

Fix #61