### PR TITLE
BF: optionally install ioctl dependency

### DIFF
--- a/init.js
+++ b/init.js
@@ -6,10 +6,16 @@ const fs = require('fs');
 const os = require('os');
 
 const async = require('async');
-const ioctl = require('ioctl');
 const constants = require('./constants').default;
 const config = require('./lib/Config.js').default;
 const logger = require('./lib/utilities/logger.js').logger;
+
+let ioctl;
+try {
+    ioctl = require('ioctl');
+} catch (err) {
+    logger.warn('ioctl dependency is unavailable. skipping...');
+}
 
 function _setDirSyncFlag(path) {
     const GETFLAGS = 2148034049;
@@ -48,7 +54,7 @@ const warning = 'WARNING: Synchronization directory updates are not ' +
     'supported on this platform. Newly written data could be lost ' +
     'if your system crashes before the operating system is able to ' +
     'write directory updates.';
-if (os.type() === 'Linux' && os.endianness() === 'LE') {
+if (os.type() === 'Linux' && os.endianness() === 'LE' && ioctl) {
     try {
         _setDirSyncFlag(dataPath);
         _setDirSyncFlag(metadataPath);

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "xml": "~1.0.0",
     "xml2js": "~0.4.12"
   },
+  "optionalDependencies": {
+      "ioctl": "2.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
ioctl install fails on CentOS7 aborting the whole npm install
process. Adding it as an optional depedency allow npm to continue
if the dependency install fails.

Fix #61