### PR TITLE
Specify backend variable for one worker.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -100,7 +100,7 @@ class S3Server {
 
 export default function main() {
     let clusters = _config.clusters || 1;
-    if (process.env.S3BACKEND) {
+    if (process.env.S3BACKEND === 'mem') {
         clusters = 1;
     }
     if (cluster.isMaster) {


### PR DESCRIPTION
If the backend is anything other than 'mem', the number of workers should be set by the config.