### PR TITLE
BF: Limiting maxKeys/maxUploads/maxParts

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -3,6 +3,7 @@ import constants from '../../constants';
 
 import services from '../services';
 import escapeForXML from '../utilities/escapeForXML';
+import { errors } from 'arsenal';
 
 //	Sample XML response:
 /*	<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -45,6 +46,9 @@ export default function bucketGet(authInfo, request, log, callback) {
     const encoding = params['encoding-type'];
     let maxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
+    if (maxKeys < 0) {
+        return callback(errors.InvalidArgument);
+    }
     if (maxKeys > constants.listingHardLimit) {
         maxKeys = constants.listingHardLimit;
     }

--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -4,6 +4,7 @@ import querystring from 'querystring';
 
 import constants from '../../constants';
 import services from '../services';
+import { errors } from 'arsenal';
 
 //	Sample XML response:
 /*
@@ -181,11 +182,19 @@ export default function listMultipartUploads(authInfo,
             if (mpuBucket.getMdBucketModelVersion() < 2) {
                 splitter = constants.oldSplitter;
             }
+            let maxUploads = Number.parseInt(query['max-uploads'], 10) ?
+                Number.parseInt(query['max-uploads'], 10) : 1000;
+            if (maxUploads < 0) {
+                return callback(errors.InvalidArgument);
+            }
+            if (maxUploads > constants.listingHardLimit) {
+                maxUploads = constants.listingHardLimit;
+            }
             const listingParams = {
                 delimiter: query.delimiter,
                 keyMarker: query['key-marker'],
                 uploadIdMarker: query['upload-id-marker'],
-                maxKeys: query['max-uploads'],
+                maxKeys: maxUploads,
                 prefix: `overview${splitter}${prefix}`,
                 queryPrefixLength: prefix.length,
                 listingType: 'multipartuploads',

--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -4,6 +4,7 @@ import querystring from 'querystring';
 import constants from '../../constants';
 import services from '../services';
 import escapeForXML from '../utilities/escapeForXML';
+import { errors } from 'arsenal';
 
   /*
   Format of xml response:
@@ -71,8 +72,14 @@ export default function listParts(authInfo, request, log, callback) {
     let objectKey = request.objectKey;
     const uploadId = request.query.uploadId;
     const encoding = request.query['encoding-type'];
-    const maxParts = Number.parseInt(request.query['max-parts'], 10) ?
+    let maxParts = Number.parseInt(request.query['max-parts'], 10) ?
         Number.parseInt(request.query['max-parts'], 10) : 1000;
+    if (maxParts < 0) {
+        return callback(errors.InvalidArgument);
+    }
+    if (maxParts > constants.listingHardLimit) {
+        maxParts = constants.listingHardLimit;
+    }
     const partNumberMarker =
         Number.parseInt(request.query['part-number-marker'], 10) ?
         Number.parseInt(request.query['part-number-marker'], 10) : 0;


### PR DESCRIPTION
**bucketGet.js** : 
    -  max-keys can not be negative,
     if the value is negative we return an error message to the user " errors.InvalidArgument".
**listParts.js** : 
    - Making 1000 uploads, the maximum number of uploads a response can include.
    - Making 1000 the default value.
    - The response can not include negative value,
     if the value is negative we return an error message to the user " errors.InvalidArgument".
    [http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListParts.html)
**listMultipartUploads.js** :
    - Making 1000 multipart uploads, the maximum number of uploads a response can include.
    - Making 1000 the default value.
    - The response can not include negative value,
     if the value is negative we return an error message to the user " errors.InvalidArgument".
  [http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html]( http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadListMPUpload.html)
