### PR TITLE
Prevent overriding of file if hash collision.

### DIFF
--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -41,7 +41,7 @@ export const backend = {
 
         request.pause();
 
-        fs.open(filePath, 'w', (err, fd) => {
+        fs.open(filePath, 'wx', (err, fd) => {
             if (err) {
                 log.error('error opening filePath', { error: err });
                 return callback(errors.InternalError);


### PR DESCRIPTION
See https://nodejs.org/api/fs.html#fs_fs_open_path_flags_mode_callback

'w' - Open file for writing. The file is created (if it does not exist) or truncated (if it exists).

'wx' - Like 'w' but fails if path exists.