### PR TITLE
Ft/policy auth

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1,4 +1,5 @@
 import { auth } from 'arsenal';
+import { policies } from 'arsenal';
 
 import bucketDelete from './bucketDelete';
 import bucketGet from './bucketGet';
@@ -21,17 +22,19 @@ import objectPutPart from './objectPutPart';
 import serviceGet from './serviceGet';
 import vault from '../auth/vault';
 
+const RequestContext = policies.RequestContext;
 auth.setAuthHandler(vault);
 
 const api = {
     callApiMethod(apiMethod, request, log, callback) {
+        const requestContext = new RequestContext(request, apiMethod, 's3', 1);
         auth.doAuth(request, log, (err, authInfo) => {
             if (err) {
                 log.trace('authentication error', { error: err });
                 return callback(err);
             }
             return this[apiMethod](authInfo, request, log, callback);
-        }, 's3', request.query);
+        }, 's3', requestContext);
     },
     bucketDelete,
     bucketGet,

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -26,12 +26,19 @@ const RequestContext = policies.RequestContext;
 auth.setAuthHandler(vault);
 
 const api = {
-    callApiMethod(apiMethod, request, log, callback) {
-        const requestContext = new RequestContext(request, apiMethod, 's3', 1);
+    callApiMethod(apiMethod, request, log, callback, locationConstraint) {
+        const requestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            request.socket.remoteAddress, request.connection.encrypted,
+            apiMethod, 's3', locationConstraint);
         auth.doAuth(request, log, (err, authInfo) => {
             if (err) {
                 log.trace('authentication error', { error: err });
                 return callback(err);
+            }
+            if (apiMethod === 'bucketPut') {
+                return bucketPut(authInfo, request, locationConstraint,
+                    log, callback);
             }
             return this[apiMethod](authInfo, request, log, callback);
         }, 's3', requestContext);

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -1,5 +1,4 @@
 import { errors } from 'arsenal';
-import { parseString } from 'xml2js';
 
 import { createBucket } from './apiUtils/bucket/bucketCreation';
 
@@ -16,11 +15,14 @@ import { createBucket } from './apiUtils/bucket/bucketCreation';
  * PUT Service - Create bucket for the user
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - http request object
+ * @param {string | undefined} locationConstraint - locationConstraint for
+ * bucket (if any)
  * @param {object} log - Werelogs logger
  * @param {function} callback - callback to server
  * @return {undefined}
  */
-export default function bucketPut(authInfo, request, log, callback) {
+export default function bucketPut(authInfo, request, locationConstraint, log,
+    callback) {
     log.debug('processing request', { method: 'bucketPut' });
 
     if (authInfo.isRequesterPublicUser()) {
@@ -29,24 +31,6 @@ export default function bucketPut(authInfo, request, log, callback) {
     }
     const bucketName = request.bucketName;
 
-    if (request.post) {
-        const xmlToParse = request.post;
-        return parseString(xmlToParse, (err, result) => {
-            if (err || !result.CreateBucketConfiguration
-                || !result.CreateBucketConfiguration.LocationConstraint
-                || !result.CreateBucketConfiguration.LocationConstraint[0]) {
-                log.debug('request xml is malformed');
-                return callback(errors.MalformedXML);
-            }
-            const locationConstraint =
-                result.CreateBucketConfiguration.LocationConstraint[0];
-            log.trace('location constraint', { locationConstraint });
-            return createBucket(authInfo, bucketName, request.headers,
-                                         locationConstraint, log, callback);
-        });
-    }
-    // TODO Check user policies to see if user is authorized
-    // to create a bucket
     return createBucket(authInfo, bucketName, request.headers,
-                                 null, log, callback);
+                                 locationConstraint, log, callback);
 }

--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -60,15 +60,18 @@ const vault = {};
  * @param {string} signatureFromRequest - signature sent with request
  * @param {string} stringToSign - string to sign built per AWS rules
  * @param {string} algo - either SHA256 or SHA1
+ * @param {RequestContext} requestContext - an instance of a RequestContext
+ * object containing information for policy authorization check
  * @param {object} log - Werelogs logger
  * @param {function} callback - callback with either error or user info
  * @return {undefined}
  */
 vault.authenticateV2Request = (accessKey, signatureFromRequest,
-    stringToSign, algo, log, callback) => {
+    stringToSign, algo, requestContext, log, callback) => {
     log.debug('authenticating V2 request');
     client.verifySignatureV2(stringToSign, signatureFromRequest, accessKey,
-        { algo, reqUid: log.getSerializedUids() },
+        { algo, reqUid: log.getSerializedUids(),
+            requestContext: requestContext.serialize() },
     (err, userInfo) => vaultSignatureCb(err, userInfo, log, callback));
 };
 
@@ -76,16 +79,18 @@ vault.authenticateV2Request = (accessKey, signatureFromRequest,
  * @param {object} params - contains accessKey (string),
  * signatureFromRequest (string), region (string),
  * stringToSign (string) and log (object)
+ * @param {object} requestContext - info for policy auth check
  * @param {function} callback - callback with either error or user info
  * @return {undefined}
 */
-vault.authenticateV4Request = (params, callback) => {
+vault.authenticateV4Request = (params, requestContext, callback) => {
     const { accessKey, signatureFromRequest, region, scopeDate,
         stringToSign, log }
         = params;
     log.debug('authenticating V4 request');
     client.verifySignatureV4(stringToSign, signatureFromRequest,
-        accessKey, region, scopeDate, { reqUid: log.getSerializedUids() },
+        accessKey, region, scopeDate, { reqUid: log.getSerializedUids(),
+            requestContext: requestContext.serialize() },
     (err, userInfo) => vaultSignatureCb(err, userInfo, log, callback));
 };
 

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -1,4 +1,5 @@
 import { errors } from 'arsenal';
+import { parseString } from 'xml2js';
 
 import api from '../api/api';
 import routesUtils from './routesUtils';
@@ -19,7 +20,31 @@ export default function routePUT(request, response, log) {
                     routesUtils.responseNoBody(err, null, response, 200, log));
             } else if (request.query.acl === undefined) {
                 // PUT bucket
-                api.callApiMethod('bucketPut', request, log, (err) =>
+                if (request.post) {
+                    const xmlToParse = request.post;
+                    return parseString(xmlToParse, (err, result) => {
+                        if (err || !result.CreateBucketConfiguration
+                            || !result.CreateBucketConfiguration
+                                .LocationConstraint
+                            || !result.CreateBucketConfiguration
+                                .LocationConstraint[0]) {
+                            log.debug('request xml is malformed');
+                            return routesUtils.responseNoBody(errors
+                                .MalformedXML,
+                                null, response, null, log);
+                        }
+                        const locationConstraint =
+                            result.CreateBucketConfiguration
+                            .LocationConstraint[0];
+                        log.trace('location constraint',
+                            { locationConstraint });
+                        return api.callApiMethod('bucketPut', request, log,
+                        err =>
+                            routesUtils.responseNoBody(err, null,
+                                response, 200, log), locationConstraint);
+                    });
+                }
+                return api.callApiMethod('bucketPut', request, log, err =>
                     routesUtils.responseNoBody(err, null, response, 200, log));
             }
         });

--- a/tests/functional/s3cmd/tests.js
+++ b/tests/functional/s3cmd/tests.js
@@ -167,6 +167,14 @@ describe('s3cmd putBucket', () => {
     it('put an invalid bucket, should fail', done => {
         exec(['mb', `s3://${invalidName}`], done, 11);
     });
+
+    it('should put a valid bucket with region (regardless of region)', done => {
+        exec(['mb', `s3://regioned`, '--region=wherever'], done);
+    });
+
+    it('should delete bucket put with region', done => {
+        exec(['rb', `s3://regioned`, '--region=wherever'], done);
+    });
 });
 
 describe('s3cmd put and get bucket ACLs', function aclBuck() {

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -145,6 +145,28 @@ describe('s3curl put and delete buckets', () => {
             });
     });
 
+    it('should not be able to put a bucket with invalid xml' +
+        ' in the post body', done => {
+        provideRawOutput(['--createBucket', '--',
+            '--data', 'malformedxml', `${endpoint}/${bucket}`, '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '400 BAD REQUEST');
+                assertError(rawOutput.stdout, 'MalformedXML',
+                    done);
+            });
+    });
+
+    it('should not be able to put a bucket with xml that does' +
+        ' not conform to s3 docs for locationConstraint', done => {
+        provideRawOutput(['--createBucket', '--',
+            '--data', '<Hello>a</Hello>', `${endpoint}/${bucket}`, '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '400 BAD REQUEST');
+                assertError(rawOutput.stdout, 'MalformedXML',
+                    done);
+            });
+    });
+
     it('should not be able to put a bucket with an invalid name', done => {
         provideRawOutput(['--createBucket', '--',
             `${endpoint}/2`, '-v'],

--- a/tests/unit/api/bucketDelete.js
+++ b/tests/unit/api/bucketDelete.js
@@ -16,6 +16,7 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = new Buffer('I am a body');
 const usersBucket = constants.usersBucket;
+const locationConstraint = 'us-west-1';
 
 describe('bucketDelete API', () => {
     beforeEach(() => {
@@ -39,7 +40,7 @@ describe('bucketDelete API', () => {
             objectKey: objectName,
         }, postBody);
 
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.strictEqual(err, undefined);
             objectPut(authInfo, testPutObjectRequest, log, err => {
                 assert.strictEqual(err, null);
@@ -61,7 +62,7 @@ describe('bucketDelete API', () => {
     });
 
     it('should delete a bucket', done => {
-        bucketPut(authInfo, testRequest, log, () => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
             bucketDelete(authInfo, testRequest, log, () => {
                 metadata.getBucket(bucketName, log, (err, md) => {
                     assert.deepStrictEqual(err, errors.NoSuchBucket);

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -17,6 +17,7 @@ const log = new DummyRequestLogger();
 const namespace = 'default';
 const postBody = new Buffer('I am a body');
 const prefix = 'sub';
+const locationConstraint = 'us-west-1';
 
 let testPutBucketRequest;
 let testPutObjectRequest1;
@@ -71,7 +72,8 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest1, log, next),
             (result, next) => objectPut(authInfo, testPutObjectRequest2, log,
                                 next),
@@ -97,7 +99,8 @@ describe('bucketGet API', () => {
 
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest1, log, next),
             (result, next) => objectPut(authInfo, testPutObjectRequest2, log,
                                 next),
@@ -123,7 +126,8 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest1, log, next),
             (result, next) => objectPut(authInfo, testPutObjectRequest2, log,
                                 next),
@@ -148,7 +152,8 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest1, log, next),
             (result, next) => objectPut(authInfo, testPutObjectRequest2, log,
                                 next),
@@ -176,7 +181,8 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => bucketGet(authInfo, testGetRequest, log, next),
             (result, next) => parseString(result, next),
         ],

--- a/tests/unit/api/bucketGetACL.js
+++ b/tests/unit/api/bucketGetACL.js
@@ -14,6 +14,7 @@ const authInfo = makeAuthInfo(accessKey);
 const canonicalID = authInfo.getCanonicalID();
 const namespace = 'default';
 const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
 
 describe('bucketGetACL API', () => {
     beforeEach(() => {
@@ -47,7 +48,8 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),
@@ -79,7 +81,8 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),
@@ -122,7 +125,8 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),
@@ -159,7 +163,8 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),
@@ -197,7 +202,8 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),
@@ -255,7 +261,8 @@ describe('bucketGetACL API', () => {
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => bucketPutACL(authInfo, testPutACLRequest, log, next),
             (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
                                 next),

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -9,6 +9,7 @@ const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const namespace = 'default';
 const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
 const testRequest = {
     bucketName,
     namespace,
@@ -29,7 +30,7 @@ describe('bucketHead API', () => {
 
     it('should return an error if user is not authorized', done => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(otherAuthInfo, testRequest, log, () => {
+        bucketPut(otherAuthInfo, testRequest, locationConstraint, log, () => {
             bucketHead(authInfo, testRequest, log, err => {
                 assert.deepStrictEqual(err, errors.AccessDenied);
                 done();
@@ -39,7 +40,7 @@ describe('bucketHead API', () => {
 
     it('should return a success message if ' +
        'bucket exists and user is authorized', done => {
-        bucketPut(authInfo, testRequest, log, () => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
             bucketHead(authInfo, testRequest, log, (err, result) => {
                 assert.strictEqual(result,
                                    'Bucket exists and user authorized -- 200');

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -14,6 +14,7 @@ const namespace = 'default';
 const splitter = constants.splitter;
 const usersBucket = constants.usersBucket;
 const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
 const testRequest = {
     bucketName,
     namespace,
@@ -29,65 +30,17 @@ describe('bucketPut API', () => {
 
     it('should return an error if bucket already exists', done => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(authInfo, testRequest, log, () => {
-            bucketPut(otherAuthInfo, testRequest, log, err => {
-                assert.deepStrictEqual(err, errors.BucketAlreadyExists);
-                done();
-            });
-        });
-    });
-
-    it('should return an error if malformed xml ' +
-       'is provided in request.post', done => {
-        const testRequest = {
-            bucketName,
-            namespace,
-            headers: {},
-            url: `/${bucketName}`,
-            post: 'malformedxml',
-        };
-        bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedXML);
-            done();
-        });
-    });
-
-    it('should return an error if xml which does ' +
-       'not conform to s3 docs is provided in request.post', done => {
-        const testRequest = {
-            bucketName,
-            namespace,
-            headers: {},
-            url: `/${bucketName}`,
-            post: '<Hello></Hello>',
-        };
-        bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, errors.MalformedXML);
-            done();
-        });
-    });
-
-    it('should not return an error if LocationConstraint ' +
-       'specified is not valid', done => {
-        const testRequest = {
-            bucketName,
-            namespace,
-            headers: {},
-            url: `/${bucketName}`,
-            post:
-                '<CreateBucketConfiguration '
-                + 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
-                + '<LocationConstraint>invalidLocation</LocationConstraint>'
-                + '</CreateBucketConfiguration>',
-        };
-        bucketPut(authInfo, testRequest, log, err => {
-            assert.deepStrictEqual(err, undefined);
-            done();
+        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
+            bucketPut(otherAuthInfo, testRequest, locationConstraint,
+                log, err => {
+                    assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+                    done();
+                });
         });
     });
 
     it('should create a bucket', done => {
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             if (err) {
                 return done(new Error(err));
             }
@@ -119,7 +72,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.deepStrictEqual(err, errors.InvalidArgument);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -140,7 +93,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.deepStrictEqual(err, errors.InvalidArgument);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -162,7 +115,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.deepStrictEqual(err, errors.UnresolvableGrantByEmailAddress);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -184,7 +137,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.strictEqual(err, undefined);
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(err, null);
@@ -220,7 +173,7 @@ describe('bucketPut API', () => {
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
         const canonicalIDforSample2 =
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
-        bucketPut(authInfo, testRequest, log, err => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
             assert.strictEqual(err, undefined, 'Error creating bucket');
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(md.getAcl().READ[0], constants.logId);
@@ -240,7 +193,7 @@ describe('bucketPut API', () => {
 
     it('should prevent anonymous user from accessing putBucket API', done => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
-        bucketPut(publicAuthInfo, testRequest, log, err => {
+        bucketPut(publicAuthInfo, testRequest, locationConstraint, log, err => {
             assert.deepStrictEqual(err, errors.AccessDenied);
         });
         done();

--- a/tests/unit/api/bucketPutACL.js
+++ b/tests/unit/api/bucketPutACL.js
@@ -13,6 +13,7 @@ const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
 const testBucketPutRequest = {
     bucketName,
     namespace,
@@ -22,7 +23,8 @@ const testBucketPutRequest = {
 
 describe('putBucketACL API', () => {
     before(() => cleanup());
-    beforeEach(done => bucketPut(authInfo, testBucketPutRequest, log, done));
+    beforeEach(done => bucketPut(authInfo, testBucketPutRequest,
+        locationConstraint, log, done));
     afterEach(() => cleanup());
 
     it('should parse a grantheader', () => {

--- a/tests/unit/api/listMultipartUploads.js
+++ b/tests/unit/api/listMultipartUploads.js
@@ -14,6 +14,7 @@ const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
 
 describe('listMultipartUploads API', () => {
     beforeEach(() => {
@@ -67,7 +68,8 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
                         log, next),
             (result, next) => initiateMultipartUpload(authInfo,
@@ -96,7 +98,8 @@ describe('listMultipartUploads API', () => {
 
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
                         log, next),
             (result, next) => initiateMultipartUpload(authInfo,
@@ -127,7 +130,8 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
                         log, next),
             (result, next) => initiateMultipartUpload(authInfo,
@@ -162,7 +166,8 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
                         log, next),
             (result, next) => initiateMultipartUpload(authInfo,
@@ -193,7 +198,8 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
                         log, next),
             (result, next) => initiateMultipartUpload(authInfo,

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -32,6 +32,7 @@ const bucketPutRequest = {
     url: '/',
     post: '',
 };
+const locationConstraint = 'us-west-1';
 const objectKey = 'testObject';
 const initiateRequest = {
     bucketName,
@@ -49,7 +50,7 @@ describe('Multipart Upload API', () => {
 
 
     it('should initiate a multipart upload', done => {
-        bucketPut(authInfo, bucketPutRequest, log, () => {
+        bucketPut(authInfo, bucketPutRequest, locationConstraint, log, () => {
             initiateMultipartUpload(authInfo, initiateRequest,
                 log, (err, result) => {
                     assert.strictEqual(err, undefined);
@@ -71,7 +72,8 @@ describe('Multipart Upload API', () => {
 
     it('should upload a part', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => {
@@ -136,7 +138,8 @@ describe('Multipart Upload API', () => {
     it('should upload a part even if the client sent a base 64 ETag ' +
     '(and the stored ETag in metadata should be hex)', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -184,7 +187,8 @@ describe('Multipart Upload API', () => {
 
     it('should return an error if too many parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -219,7 +223,8 @@ describe('Multipart Upload API', () => {
 
     it('should return an error if part number is not an integer', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -257,7 +262,8 @@ describe('Multipart Upload API', () => {
         // by setting a large content-length.  It is not actually putting a
         // large file.  Functional tests will test actual large data.
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -296,7 +302,8 @@ describe('Multipart Upload API', () => {
 
     it('should upload two parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -378,7 +385,8 @@ describe('Multipart Upload API', () => {
         initiateRequest.headers['x-amz-meta-stuff'] =
             'I am some user metadata';
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -464,7 +472,8 @@ describe('Multipart Upload API', () => {
             'I am some user metadata';
         async.waterfall([
             function waterfall1(next) {
-                bucketPut(authInfo, bucketPutRequest, log, next);
+                bucketPut(authInfo, bucketPutRequest,
+                    locationConstraint, log, next);
             },
             function waterfall2(next) {
                 initiateMultipartUpload(
@@ -544,7 +553,8 @@ describe('Multipart Upload API', () => {
     it('should return an error if a complete multipart upload' +
     ' request contains malformed xml', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -596,7 +606,8 @@ describe('Multipart Upload API', () => {
     'multipart upload request contains xml that ' +
     'does not conform to the AWS spec', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -648,7 +659,8 @@ describe('Multipart Upload API', () => {
     'multipart upload request contains xml with ' +
     'a part list that is not in numerical order', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -724,7 +736,8 @@ describe('Multipart Upload API', () => {
     + 'contains xml with a part ETag that does not match the md5 for '
     + 'the part that was actually sent', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -799,7 +812,8 @@ describe('Multipart Upload API', () => {
     'other than the last part that is less than 5MB ' +
     'in size', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -880,7 +894,8 @@ describe('Multipart Upload API', () => {
 
     it('should aggregate the sizes of the parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -982,7 +997,8 @@ describe('Multipart Upload API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -1084,7 +1100,8 @@ describe('Multipart Upload API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -1170,7 +1187,8 @@ describe('Multipart Upload API', () => {
 
     it('should abort/delete a multipart upload', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -1215,7 +1233,8 @@ describe('Multipart Upload API', () => {
     it('should return an error if attempt to abort/delete ' +
         'a multipart upload that does not exist', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest,
+                locationConstraint, log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => {
@@ -1264,7 +1283,8 @@ describe('Multipart Upload API', () => {
     done => {
         const partBody = new Buffer('I am a part\n');
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, locationConstraint,
+                log, next),
             next => initiateMultipartUpload(authInfo, initiateRequest, log,
                         next),
             (result, next) => parseString(result, next),
@@ -1401,7 +1421,7 @@ describe('Multipart Upload API', () => {
             },
         }, postBody);
 
-        bucketPut(authInfo, bucketPutRequest, log, () =>
+        bucketPut(authInfo, bucketPutRequest, locationConstraint, log, () =>
           objectPutPart(authInfo, partRequest, log, err => {
               assert.strictEqual(err, errors.NoSuchUpload);
               done();

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -17,10 +17,11 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = new Buffer('I am a body');
 const objectKey = 'objectName';
+const locationConstraint = 'us-west-1';
 
 function testAuth(bucketOwner, authUser, bucketPutReq, objPutReq, objDelReq,
     log, cb) {
-    bucketPut(bucketOwner, bucketPutReq, log, () => {
+    bucketPut(bucketOwner, bucketPutReq, locationConstraint, log, () => {
         bucketPutACL(bucketOwner, bucketPutReq, log, err => {
             assert.strictEqual(err, undefined);
             objectPut(bucketOwner, objPutReq, log, err => {
@@ -74,17 +75,18 @@ describe('objectDelete API', () => {
     });
 
     it('should delete an object', done => {
-        bucketPut(authInfo, testBucketPutRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, () => {
-                objectDelete(authInfo, testDeleteRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    objectGet(authInfo, testGetObjectRequest, log, err => {
-                        assert.deepStrictEqual(err, errors.NoSuchKey);
-                        done();
+        bucketPut(authInfo, testBucketPutRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log, () => {
+                    objectDelete(authInfo, testDeleteRequest, log, err => {
+                        assert.strictEqual(err, undefined);
+                        objectGet(authInfo, testGetObjectRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.NoSuchKey);
+                            done();
+                        });
                     });
                 });
             });
-        });
     });
 
     it('should delete a 0 bytes object', done => {
@@ -95,19 +97,21 @@ describe('objectDelete API', () => {
             headers: {},
             url: `/${bucketName}/${objectKey}`,
         }, '');
-        bucketPut(authInfo, testBucketPutRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, () => {
-                objectDelete(authInfo, testDeleteRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    objectGet(authInfo, testGetObjectRequest, log, err => {
-                        const expected = Object.assign({}, errors.NoSuchKey);
-                        const received = Object.assign({}, err);
-                        assert.deepStrictEqual(received, expected);
-                        done();
+        bucketPut(authInfo, testBucketPutRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log, () => {
+                    objectDelete(authInfo, testDeleteRequest, log, err => {
+                        assert.strictEqual(err, undefined);
+                        objectGet(authInfo, testGetObjectRequest, log, err => {
+                            const expected =
+                                Object.assign({}, errors.NoSuchKey);
+                            const received = Object.assign({}, err);
+                            assert.deepStrictEqual(received, expected);
+                            done();
+                        });
                     });
                 });
             });
-        });
     });
 
     it('should prevent anonymous user deleteObject API access', done => {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -19,6 +19,7 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const objectName = 'objectName';
 const postBody = new Buffer('I am a body');
+const locationConstraint = 'us-west-1';
 
 describe('objectGet API', () => {
     let testPutObjectRequest;
@@ -56,37 +57,43 @@ describe('objectGet API', () => {
     };
 
     it('should get the object metadata', done => {
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectGet(authInfo, testGetRequest,
-                    log, (err, result, responseMetaHeaders) => {
-                        assert.strictEqual(responseMetaHeaders[userMetadataKey],
-                                           userMetadataValue);
-                        assert.strictEqual(responseMetaHeaders.ETag,
-                                           `"${correctMD5}"`);
-                        done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest,
+                    log, (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectGet(authInfo, testGetRequest,
+                            log, (err, result, responseMetaHeaders) => {
+                                assert.strictEqual(responseMetaHeaders
+                                    [userMetadataKey],
+                                    userMetadataValue);
+                                assert.strictEqual(responseMetaHeaders.ETag,
+                                    `"${correctMD5}"`);
+                                done();
+                            });
                     });
             });
-        });
     });
 
     it('should get the object data retrieval info', done => {
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectGet(authInfo, testGetRequest, log, (err, dataGetInfo) => {
-                    assert.deepStrictEqual(dataGetInfo,
-                        [{
-                            key: 1,
-                            start: 0,
-                            size: 12,
-                            dataStoreName: 'mem',
-                        }]);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectGet(authInfo, testGetRequest, log,
+                            (err, dataGetInfo) => {
+                                assert.deepStrictEqual(dataGetInfo,
+                            [{
+                                key: 1,
+                                start: 0,
+                                size: 12,
+                                dataStoreName: 'mem',
+                            }]);
+                                done();
+                            });
+                    });
             });
-        });
     });
 
     it('should get the object data retrieval info for an object put by MPU',
@@ -100,7 +107,8 @@ describe('objectGet API', () => {
                 url: `/${objectName}?uploads`,
             };
             async.waterfall([
-                next => bucketPut(authInfo, testPutBucketRequest, log, next),
+                next => bucketPut(authInfo, testPutBucketRequest,
+                    locationConstraint, log, next),
                 next => initiateMultipartUpload(authInfo, initiateRequest, log,
                             next),
                 (result, next) => parseString(result, next),
@@ -213,19 +221,21 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
             calculatedHash: 'd41d8cd98f00b204e9800998ecf8427e',
         }, postBody);
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectGet(authInfo, testGetRequest,
-                    log, (err, result, responseMetaHeaders) => {
-                        assert.strictEqual(result, null);
-                        assert.strictEqual(responseMetaHeaders
-                            [userMetadataKey], userMetadataValue);
-                        assert.strictEqual(responseMetaHeaders.ETag,
-                            `"${correctMD5}"`);
-                        done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectGet(authInfo, testGetRequest,
+                        log, (err, result, responseMetaHeaders) => {
+                            assert.strictEqual(result, null);
+                            assert.strictEqual(responseMetaHeaders
+                                [userMetadataKey], userMetadataValue);
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
                     });
             });
-        });
     });
 });

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -21,6 +21,7 @@ const otherAccountCanonicalID = otherAccountAuthInfo.getCanonicalID();
 const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = new Buffer('I am a body');
+const locationConstraint = 'us-west-1';
 
 describe('objectGetACL API', () => {
     beforeEach(() => {
@@ -56,7 +57,8 @@ describe('objectGetACL API', () => {
             post: postBody,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -77,12 +79,13 @@ describe('objectGetACL API', () => {
 
     it('should return an error if try to get an ACL ' +
         'for a nonexistent object', done => {
-        bucketPut(authInfo, testBucketPutRequest, log, () => {
-            objectGetACL(authInfo, testGetACLRequest, log, err => {
-                assert.deepStrictEqual(err, errors.NoSuchKey);
-                done();
+        bucketPut(authInfo, testBucketPutRequest,
+            locationConstraint, log, () => {
+                objectGetACL(authInfo, testGetACLRequest, log, err => {
+                    assert.deepStrictEqual(err, errors.NoSuchKey);
+                    done();
+                });
             });
-        });
     });
 
     it('should get a canned public-read ACL', done => {
@@ -94,7 +97,8 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -129,7 +133,8 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -171,7 +176,8 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -210,8 +216,8 @@ describe('objectGetACL API', () => {
         }, postBody);
         async.waterfall([
             next =>
-                bucketPut(otherAccountAuthInfo, testBucketPutRequest, log,
-                    next),
+                bucketPut(otherAccountAuthInfo, testBucketPutRequest,
+                    locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -249,8 +255,8 @@ describe('objectGetACL API', () => {
         }, postBody);
         async.waterfall([
             next =>
-                bucketPut(otherAccountAuthInfo, testBucketPutRequest, log,
-                    next),
+                bucketPut(otherAccountAuthInfo, testBucketPutRequest,
+                    locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);
@@ -298,7 +304,8 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest,
+                locationConstraint, log, next),
             next => objectPut(authInfo, testPutObjectRequest, log, next),
             (result, next) => {
                 assert.strictEqual(result, correctMD5);

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -27,6 +27,7 @@ const testPutBucketRequest = {
 };
 const userMetadataKey = 'x-amz-meta-test';
 const userMetadataValue = 'some metadata';
+const locationConstraint = 'us-west-1';
 
 let testPutObjectRequest;
 
@@ -54,15 +55,17 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.NotModified);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectHead(authInfo, testGetRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.NotModified);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return PreconditionFailed if request header ' +
@@ -75,15 +78,18 @@ describe('objectHead API', () => {
             headers: { 'if-unmodified-since': earlierDate },
             url: `/${bucketName}/${objectName}`,
         };
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.PreconditionFailed);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectHead(authInfo, testGetRequest, log, err => {
+                            assert.deepStrictEqual(err,
+                                errors.PreconditionFailed);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return PreconditionFailed if request header ' +
@@ -97,15 +103,18 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.PreconditionFailed);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectHead(authInfo, testGetRequest, log, err => {
+                            assert.deepStrictEqual(err,
+                                errors.PreconditionFailed);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return NotModified if request header ' +
@@ -119,15 +128,17 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectHead(authInfo, testGetRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.NotModified);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectHead(authInfo, testGetRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.NotModified);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should get the object metadata', done => {
@@ -139,16 +150,20 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectHead(authInfo, testGetRequest, log, (err, success) => {
-                    assert.strictEqual(success[userMetadataKey],
+        bucketPut(authInfo, testPutBucketRequest,
+            locationConstraint, log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectHead(authInfo, testGetRequest, log,
+                            (err, success) => {
+                                assert.strictEqual(success[userMetadataKey],
                         userMetadataValue);
-                    assert.strictEqual(success.ETag, `"${correctMD5}"`);
-                    done();
-                });
+                                assert
+                                .strictEqual(success.ETag, `"${correctMD5}"`);
+                                done();
+                            });
+                    });
             });
-        });
     });
 });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -22,13 +22,14 @@ const testPutBucketRequest = new DummyRequest({
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
 });
+const locationConstraint = 'us-west-1';
 
 const objectName = 'objectName';
 
 let testPutObjectRequest;
 
 function testAuth(bucketOwner, authUser, bucketPutReq, log, cb) {
-    bucketPut(bucketOwner, bucketPutReq, log, () => {
+    bucketPut(bucketOwner, bucketPutReq, locationConstraint, log, () => {
         bucketPutACL(bucketOwner, testPutBucketRequest, log, err => {
             assert.strictEqual(err, undefined);
             objectPut(authUser, testPutObjectRequest, log, (err, res) => {
@@ -61,12 +62,13 @@ describe('objectPut API', () => {
 
     it('should return an error if user is not authorized', done => {
         const putAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(putAuthInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, err => {
-                assert.deepStrictEqual(err, errors.AccessDenied);
-                done();
+        bucketPut(putAuthInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log, err => {
+                    assert.deepStrictEqual(err, errors.AccessDenied);
+                    done();
+                });
             });
-        });
     });
 
     it('should put object if user has FULL_CONTROL grant on bucket', done => {
@@ -104,16 +106,20 @@ describe('objectPut API', () => {
             calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                metadata.getObjectMD(bucketName, objectName, log, (err, md) => {
-                    assert(md);
-                    assert.strictEqual(md['content-md5'], correctMD5);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        metadata.getObjectMD(bucketName, objectName,
+                            log, (err, md) => {
+                                assert(md);
+                                assert
+                                .strictEqual(md['content-md5'], correctMD5);
+                                done();
+                            });
+                    });
             });
-        });
     });
 
     it('should successfully put an object with user metadata', done => {
@@ -135,20 +141,24 @@ describe('objectPut API', () => {
             calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                metadata.getObjectMD(bucketName, objectName, log, (err, md) => {
-                    assert(md);
-                    assert.strictEqual(md['x-amz-meta-test'], 'some metadata');
-                    assert.strictEqual(md['x-amz-meta-test2'],
-                                       'some more metadata');
-                    assert.strictEqual(md['x-amz-meta-test3'],
-                                       'even more metadata');
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert(md);
+                                assert.strictEqual(md['x-amz-meta-test'],
+                                'some metadata');
+                                assert.strictEqual(md['x-amz-meta-test2'],
+                                           'some more metadata');
+                                assert.strictEqual(md['x-amz-meta-test3'],
+                                           'even more metadata');
+                                done();
+                            });
+                    });
             });
-        });
     });
 
     it('should put an object with user metadata but no data', done => {
@@ -169,22 +179,26 @@ describe('objectPut API', () => {
             calculatedHash: 'd41d8cd98f00b204e9800998ecf8427e',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                assert.deepStrictEqual(ds, []);
-                metadata.getObjectMD(bucketName, objectName, log, (err, md) => {
-                    assert(md);
-                    assert.strictEqual(md.location, null);
-                    assert.strictEqual(md['x-amz-meta-test'], 'some metadata');
-                    assert.strictEqual(md['x-amz-meta-test2'],
-                                       'some more metadata');
-                    assert.strictEqual(md['x-amz-meta-test3'],
-                                       'even more metadata');
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        assert.deepStrictEqual(ds, []);
+                        metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert(md);
+                                assert.strictEqual(md.location, null);
+                                assert.strictEqual(md['x-amz-meta-test'],
+                                'some metadata');
+                                assert.strictEqual(md['x-amz-meta-test2'],
+                                           'some more metadata');
+                                assert.strictEqual(md['x-amz-meta-test3'],
+                                           'even more metadata');
+                                done();
+                            });
+                    });
             });
-        });
     });
 
     it('should not leave orphans in data when overwriting an object', done => {
@@ -196,22 +210,24 @@ describe('objectPut API', () => {
             url: `/${bucketName}/${objectName}`,
         }, new Buffer('I am another body'));
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, () => {
-                objectPut(authInfo, testPutObjectRequest2, log,
-                    () => {
-                        // orphan objects don't get deleted until the next tick
-                        // in memory
-                        process.nextTick(() => {
-                            // Data store starts at index 1
-                            assert.strictEqual(ds[0], undefined);
-                            assert.strictEqual(ds[1], undefined);
-                            assert.deepStrictEqual(ds[2].value,
-                                new Buffer('I am another body'));
-                            done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log, () => {
+                    objectPut(authInfo, testPutObjectRequest2, log,
+                        () => {
+                            // orphan objects don't get deleted
+                            // until the next tick
+                            // in memory
+                            process.nextTick(() => {
+                                // Data store starts at index 1
+                                assert.strictEqual(ds[0], undefined);
+                                assert.strictEqual(ds[1], undefined);
+                                assert.deepStrictEqual(ds[2].value,
+                                    new Buffer('I am another body'));
+                                done();
+                            });
                         });
-                    });
+                });
             });
-        });
     });
 });

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -23,7 +23,7 @@ const testPutBucketRequest = new DummyRequest({
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
 });
-
+const locationConstraint = 'us-west-1';
 let testPutObjectRequest;
 
 describe('putObjectACL API', () => {
@@ -48,15 +48,18 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.InvalidArgument);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert
+                                .deepStrictEqual(err, errors.InvalidArgument);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should set a canned public-read-write ACL', done => {
@@ -69,20 +72,22 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    metadata.getObjectMD(bucketName, objectName, log,
-                        (err, md) => {
-                            assert.strictEqual(md.acl.Canned,
-                            'public-read-write');
-                            done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err, undefined);
+                            metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert.strictEqual(md.acl.Canned,
+                                'public-read-write');
+                                done();
+                            });
                         });
-                });
+                    });
             });
-        });
     });
 
     it('should set a canned public-read ACL followed by'
@@ -105,30 +110,32 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest1, log, err => {
-                    assert.strictEqual(err, undefined);
-                    metadata.getObjectMD(bucketName, objectName, log,
-                        (err, md) => {
-                            assert.strictEqual(md.acl.Canned,
-                            'public-read');
-                            objectPutACL(authInfo, testObjACLRequest2, log,
-                                err => {
-                                    assert.strictEqual(err, undefined);
-                                    metadata.getObjectMD(bucketName,
-                                        objectName, log, (err, md) => {
-                                            assert.strictEqual(md
-                                                   .acl.Canned,
-                                                   'authenticated-read');
-                                            done();
-                                        });
-                                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest1, log, err => {
+                            assert.strictEqual(err, undefined);
+                            metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert.strictEqual(md.acl.Canned,
+                                'public-read');
+                                objectPutACL(authInfo, testObjACLRequest2, log,
+                                    err => {
+                                        assert.strictEqual(err, undefined);
+                                        metadata.getObjectMD(bucketName,
+                                            objectName, log, (err, md) => {
+                                                assert.strictEqual(md
+                                                       .acl.Canned,
+                                                       'authenticated-read');
+                                                done();
+                                            });
+                                    });
+                            });
                         });
-                });
+                    });
             });
-        });
     });
 
     it('should set ACLs provided in request headers', done => {
@@ -156,29 +163,32 @@ describe('putObjectACL API', () => {
             url: `/${bucketName}/${objectName}?acl`,
             query: { acl: '' },
         };
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    metadata.getObjectMD(bucketName, objectName, log,
-                        (err, md) => {
-                            assert.strictEqual(err, null);
-                            const acls = md.acl;
-                            assert.strictEqual(acls.READ[0], constants.logId);
-                            assert(acls.FULL_CONTROL[0]
-                               .indexOf(canonicalIDforSample1) > -1);
-                            assert(acls.FULL_CONTROL[1]
-                               .indexOf(canonicalIDforSample2) > -1);
-                            assert(acls.READ_ACP[0]
-                                .indexOf(canonicalIDforSample1) > -1);
-                            assert(acls.WRITE_ACP[0]
-                                .indexOf(canonicalIDforSample2) > -1);
-                            done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err, undefined);
+                            metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert.strictEqual(err, null);
+                                const acls = md.acl;
+                                assert.strictEqual(acls.READ[0],
+                                    constants.logId);
+                                assert(acls.FULL_CONTROL[0]
+                                   .indexOf(canonicalIDforSample1) > -1);
+                                assert(acls.FULL_CONTROL[1]
+                                   .indexOf(canonicalIDforSample2) > -1);
+                                assert(acls.READ_ACP[0]
+                                    .indexOf(canonicalIDforSample1) > -1);
+                                assert(acls.WRITE_ACP[0]
+                                    .indexOf(canonicalIDforSample2) > -1);
+                                done();
+                            });
                         });
-                });
+                    });
             });
-        });
     });
 
     it('should return an error if invalid email ' +
@@ -196,16 +206,18 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err,
-                                       errors.UnresolvableGrantByEmailAddress);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err,
+                                errors.UnresolvableGrantByEmailAddress);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should set ACLs provided in request body', done => {
@@ -256,28 +268,30 @@ describe('putObjectACL API', () => {
         const canonicalIDforSample1 =
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    metadata.getObjectMD(bucketName, objectName, log,
-                        (err, md) => {
-                            assert.strictEqual(md
-                                .acl.FULL_CONTROL[0],
-                                '852b113e7a2f25102679df27bb0ae12b3f85be6');
-                            assert.strictEqual(md
-                                .acl.READ[0], constants.publicId);
-                            assert.strictEqual(md
-                                .acl.WRITE_ACP[0], canonicalIDforSample1);
-                            assert.strictEqual(md
-                                .acl.READ_ACP[0],
-                                'f30716ab7115dcb44a5ef76e9d74b8e20567f63');
-                            done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest,
+                    log, (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err, undefined);
+                            metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert.strictEqual(md
+                                    .acl.FULL_CONTROL[0],
+                                    '852b113e7a2f25102679df27bb0ae12b3f85be6');
+                                assert.strictEqual(md
+                                    .acl.READ[0], constants.publicId);
+                                assert.strictEqual(md
+                                    .acl.WRITE_ACP[0], canonicalIDforSample1);
+                                assert.strictEqual(md
+                                    .acl.READ_ACP[0],
+                                    'f30716ab7115dcb44a5ef76e9d74b8e20567f63');
+                                done();
+                            });
                         });
-                });
+                    });
             });
-        });
     });
 
     it('should ignore if WRITE ACL permission is ' +
@@ -314,28 +328,30 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err, undefined);
-                    metadata.getObjectMD(bucketName, objectName, log,
-                        (err, md) => {
-                            assert.strictEqual(md.acl.Canned, '');
-                            assert.strictEqual(md.acl.FULL_CONTROL[0],
-                                '852b113e7a2f2510267' +
-                                '9df27bb0ae12b3f85be6');
-                            assert.strictEqual(md.acl.WRITE, undefined);
-                            assert.strictEqual(md.acl.READ[0], undefined);
-                            assert.strictEqual(md.acl.WRITE_ACP[0],
-                                undefined);
-                            assert.strictEqual(md.acl.READ_ACP[0],
-                                undefined);
-                            done();
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err, undefined);
+                            metadata.getObjectMD(bucketName, objectName, log,
+                            (err, md) => {
+                                assert.strictEqual(md.acl.Canned, '');
+                                assert.strictEqual(md.acl.FULL_CONTROL[0],
+                                    '852b113e7a2f2510267' +
+                                    '9df27bb0ae12b3f85be6');
+                                assert.strictEqual(md.acl.WRITE, undefined);
+                                assert.strictEqual(md.acl.READ[0], undefined);
+                                assert.strictEqual(md.acl.WRITE_ACP[0],
+                                    undefined);
+                                assert.strictEqual(md.acl.READ_ACP[0],
+                                    undefined);
+                                done();
+                            });
                         });
-                });
+                    });
             });
-        });
     });
 
     it('should return an error if invalid email ' +
@@ -367,16 +383,18 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.strictEqual(err,
-                                       errors.UnresolvableGrantByEmailAddress);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.strictEqual(err,
+                                errors.UnresolvableGrantByEmailAddress);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return an error if xml provided does not match s3 ' +
@@ -408,15 +426,18 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.MalformedACLError);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.deepStrictEqual(err,
+                                errors.MalformedACLError);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return an error if malformed xml provided', done => {
@@ -447,15 +468,17 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.MalformedXML);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.MalformedXML);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return an error if invalid group ' +
@@ -487,15 +510,17 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.MalformedXML);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.MalformedXML);
+                            done();
+                        });
+                    });
             });
-        });
     });
 
     it('should return an error if invalid group uri ' +
@@ -514,14 +539,16 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, log, () => {
-            objectPut(authInfo, testPutObjectRequest, log, (err, result) => {
-                assert.strictEqual(result, correctMD5);
-                objectPutACL(authInfo, testObjACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.InvalidArgument);
-                    done();
-                });
+        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
+            log, () => {
+                objectPut(authInfo, testPutObjectRequest, log,
+                    (err, result) => {
+                        assert.strictEqual(result, correctMD5);
+                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+                            assert.deepStrictEqual(err, errors.InvalidArgument);
+                            done();
+                        });
+                    });
             });
-        });
     });
 });

--- a/tests/unit/api/serviceGet.js
+++ b/tests/unit/api/serviceGet.js
@@ -14,6 +14,8 @@ const namespace = 'default';
 const bucketName1 = 'bucketname1';
 const bucketName2 = 'bucketname2';
 const bucketName3 = 'bucketname3';
+const locationConstraint = 'us-west-1';
+
 
 describe('serviceGet API', () => {
     beforeEach(() => {
@@ -47,13 +49,16 @@ describe('serviceGet API', () => {
         };
         async.waterfall([
             function waterfall1(next) {
-                bucketPut(authInfo, testbucketPutRequest1, log, next);
+                bucketPut(authInfo, testbucketPutRequest1, locationConstraint,
+                    log, next);
             },
             function waterfall2(next) {
-                bucketPut(authInfo, testbucketPutRequest2, log, next);
+                bucketPut(authInfo, testbucketPutRequest2, locationConstraint,
+                    log, next);
             },
             function waterfall3(next) {
-                bucketPut(authInfo, testbucketPutRequest3, log, next);
+                bucketPut(authInfo, testbucketPutRequest3, locationConstraint,
+                    log, next);
             },
             function waterfall4(next) {
                 serviceGet(authInfo, serviceGetRequest, log, next);

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -56,6 +56,8 @@ const userBucketOwner = 'admin';
 const creationDate = new Date().toJSON();
 const usersBucket = new BucketInfo(usersBucketName,
     userBucketOwner, userBucketOwner, creationDate);
+const locationConstraint = 'us-west-1';
+
 
 describe('transient bucket handling', () => {
     beforeEach(done => {
@@ -74,7 +76,7 @@ describe('transient bucket handling', () => {
 
     it('putBucket request should complete creation of transient bucket if ' +
         'request is from same account that originally put', done => {
-        bucketPut(authInfo, baseTestRequest, log, err => {
+        bucketPut(authInfo, baseTestRequest, locationConstraint, log, err => {
             assert.ifError(err);
             serviceGet(authInfo, serviceGetRequest, log, (err, data) => {
                 parseString(data, (err, result) => {
@@ -90,17 +92,18 @@ describe('transient bucket handling', () => {
 
     it('putBucket request should return error if ' +
         'transient bucket created by different account', done => {
-        bucketPut(otherAccountAuthInfo, baseTestRequest, log, err => {
-            assert.deepStrictEqual(err, errors.BucketAlreadyExists);
-            serviceGet(otherAccountAuthInfo, serviceGetRequest,
-                log, (err, data) => {
-                    parseString(data, (err, result) => {
-                        assert.strictEqual(result.ListAllMyBucketsResult
-                        .Buckets[0], '');
-                        done();
+        bucketPut(otherAccountAuthInfo, baseTestRequest, locationConstraint,
+            log, err => {
+                assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+                serviceGet(otherAccountAuthInfo, serviceGetRequest,
+                    log, (err, data) => {
+                        parseString(data, (err, result) => {
+                            assert.strictEqual(result.ListAllMyBucketsResult
+                            .Buckets[0], '');
+                            done();
+                        });
                     });
-                });
-        });
+            });
     });
 
     it('ACLs from clean up putBucket request should overwrite ACLs from ' +
@@ -108,7 +111,7 @@ describe('transient bucket handling', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-acl': 'public-read' }, 'headers',
             baseTestRequest, baseTestRequest.headers);
-        bucketPut(authInfo, alteredRequest, log, err => {
+        bucketPut(authInfo, alteredRequest, locationConstraint, log, err => {
             assert.ifError(err);
             metadata.getBucket(bucketName, log, (err, data) => {
                 assert.strictEqual(data._transient, false);


### PR DESCRIPTION
This sends a RequestContext to vault with an authentication request so that Vault can evaluate the request against any policies attached to a user (if the request is from a user).

The RequestContext requires information from the request (such as the locationConstraint on a create bucket request) so some refactoring was required to move the parsing of the locationConstraint to the routes.  Most of the changes are modifying the units tests to handle this.

This is dependent on:
1) Arsenal: https://github.com/scality/Arsenal/pull/109
2) VaultClient: https://github.com/scality/vaultclient/pull/91
3) Vault: https://github.com/scality/Vault/pull/415