### PR TITLE
Forward-port of rel/1.1-smartbulb into master

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -52,4 +52,8 @@ export default {
 
     // Number of sub-directories for file backend
     folderHash: 3511, // Prime number
+    // AWS sets a hard limit on the listing maxKeys
+    // http://docs.aws.amazon.com/AmazonS3/latest/API/
+    //      RESTBucketGET.html#RESTBucketGET-requests
+    listingHardLimit: 1000,
 };

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1,5 +1,4 @@
-import { auth } from 'arsenal';
-import { policies } from 'arsenal';
+import { auth, policies } from 'arsenal';
 
 import bucketDelete from './bucketDelete';
 import bucketGet from './bucketGet';

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -1,6 +1,9 @@
-import services from '../services';
-
 import querystring from 'querystring';
+import constants from '../../constants';
+
+import services from '../services';
+import escapeForXML from '../utilities/escapeForXML';
+import { errors } from 'arsenal';
 
 //	Sample XML response:
 /*	<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
@@ -41,8 +44,14 @@ export default function bucketGet(authInfo, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
     const encoding = params['encoding-type'];
-    const maxKeys = params['max-keys'] ?
+    let maxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
+    if (maxKeys < 0) {
+        return callback(errors.InvalidArgument);
+    }
+    if (maxKeys > constants.listingHardLimit) {
+        maxKeys = constants.listingHardLimit;
+    }
     const metadataValParams = {
         authInfo,
         bucketName,
@@ -95,7 +104,7 @@ export default function bucketGet(authInfo, request, log, callback) {
             list.Contents.forEach(item => {
                 const v = item.value;
                 const objectKey = encoding === 'url' ?
-                    querystring.escape(item.key) : item.key;
+                    querystring.escape(item.key) : escapeForXML(item.key);
 
                 xml.push(
                     '<Contents>',

--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -4,6 +4,7 @@ import querystring from 'querystring';
 
 import constants from '../../constants';
 import services from '../services';
+import { errors } from 'arsenal';
 
 //	Sample XML response:
 /*
@@ -181,11 +182,19 @@ export default function listMultipartUploads(authInfo,
             if (mpuBucket.getMdBucketModelVersion() < 2) {
                 splitter = constants.oldSplitter;
             }
+            let maxUploads = Number.parseInt(query['max-uploads'], 10) ?
+                Number.parseInt(query['max-uploads'], 10) : 1000;
+            if (maxUploads < 0) {
+                return callback(errors.InvalidArgument);
+            }
+            if (maxUploads > constants.listingHardLimit) {
+                maxUploads = constants.listingHardLimit;
+            }
             const listingParams = {
                 delimiter: query.delimiter,
                 keyMarker: query['key-marker'],
                 uploadIdMarker: query['upload-id-marker'],
-                maxKeys: query['max-uploads'],
+                maxKeys: maxUploads,
                 prefix: `overview${splitter}${prefix}`,
                 queryPrefixLength: prefix.length,
                 listingType: 'multipartuploads',

--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -3,6 +3,8 @@ import querystring from 'querystring';
 
 import constants from '../../constants';
 import services from '../services';
+import escapeForXML from '../utilities/escapeForXML';
+import { errors } from 'arsenal';
 
   /*
   Format of xml response:
@@ -70,8 +72,14 @@ export default function listParts(authInfo, request, log, callback) {
     let objectKey = request.objectKey;
     const uploadId = request.query.uploadId;
     const encoding = request.query['encoding-type'];
-    const maxParts = Number.parseInt(request.query['max-parts'], 10) ?
+    let maxParts = Number.parseInt(request.query['max-parts'], 10) ?
         Number.parseInt(request.query['max-parts'], 10) : 1000;
+    if (maxParts < 0) {
+        return callback(errors.InvalidArgument);
+    }
+    if (maxParts > constants.listingHardLimit) {
+        maxParts = constants.listingHardLimit;
+    }
     const partNumberMarker =
         Number.parseInt(request.query['part-number-marker'], 10) ?
         Number.parseInt(request.query['part-number-marker'], 10) : 0;
@@ -139,6 +147,8 @@ export default function listParts(authInfo, request, log, callback) {
         }, function waterfall4(mpuBucket, storedParts, mpuOverviewArray, next) {
             if (encoding === 'url') {
                 objectKey = querystring.escape(objectKey);
+            } else {
+                objectKey = escapeForXML(objectKey);
             }
             const isTruncated = storedParts.IsTruncated;
             const splitterLen = splitter.length;

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -31,7 +31,7 @@ export default function objectDelete(authInfo, request, log, cb) {
     return services.metadataValidateAuthorization(valParams,
         (err, bucket, objMD) => {
             if (err) {
-                log.warn('error processing request', {
+                log.debug('error processing request', {
                     error: err,
                     method: 'metadataValidateAuthorization',
                 });
@@ -40,7 +40,7 @@ export default function objectDelete(authInfo, request, log, cb) {
             return services.validateHeaders(objMD, validateHeadersParams,
                 (err, objMD, metaHeaders) => {
                     if (err) {
-                        log.warn('error from headers validation', {
+                        log.debug('error from headers validation', {
                             error: err,
                             method: 'validateHeaders',
                         });

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -47,7 +47,7 @@ const metadata = {
         log.debug('getting bucket from metadata');
         client.getBucketAttributes(bucketName, log, (err, data) => {
             if (err) {
-                log.warn('error from metadata', { implName, error: err });
+                log.debug('error from metadata', { implName, error: err });
                 return cb(err);
             }
             log.trace('bucket retrieved from metadata');
@@ -59,7 +59,7 @@ const metadata = {
         log.debug('deleting bucket from metadata');
         client.deleteBucket(bucketName, log, err => {
             if (err) {
-                log.warn('error from metadata', { implName, error: err });
+                log.debug('error from metadata', { implName, error: err });
                 return cb(err);
             }
             log.debug('Deleted bucket from Metadata');

--- a/lib/utilities/escapeForXML.js
+++ b/lib/utilities/escapeForXML.js
@@ -1,0 +1,19 @@
+/**
+* Project: node-xml https://github.com/dylang/node-xml
+* License: MIT https://github.com/dylang/node-xml/blob/master/LICENSE
+*/
+const XML_CHARACTER_MAP = {
+    '&': '&amp;',
+    '"': '&quot;',
+    "'": '&apos;',
+    '<': '&lt;',
+    '>': '&gt;',
+};
+
+function escapeForXML(string) {
+    return string && string.replace
+        ? string.replace(/([&"<>'])/g, (str, item) => XML_CHARACTER_MAP[item])
+        : string;
+}
+
+export default escapeForXML;

--- a/tests/functional/aws-node-sdk/test/bucket/get.js
+++ b/tests/functional/aws-node-sdk/test/bucket/get.js
@@ -169,10 +169,11 @@ describe('GET Bucket - AWS.S3.listObjects', () => {
                 .catch(done);
         });
 
-        it('should list object titles that begin with special chars', done => {
+        it('should list object titles that contain special chars', done => {
             const s3 = bucketUtil.s3;
             const Bucket = bucketName;
             const objects = [
+                { Bucket, Key: 'foo&<>\'"' },
                 { Bucket, Key: '*asterixObjTitle/' },
                 { Bucket, Key: '*asterixObjTitle/objTitleA', Body: '{}' },
                 { Bucket, Key: '*asterixObjTitle/*asterixObjTitle',
@@ -304,6 +305,7 @@ describe('GET Bucket - AWS.S3.listObjects', () => {
                         '_underscoreObjTitle/',
                         '_underscoreObjTitle/_underscoreObjTitle',
                         '_underscoreObjTitle/objTitleA',
+                        'foo&<>\'"',
                         'ÀaGraveUpperCaseObjTitle',
                         'ÀaGraveUpperCaseObjTitle/objTitleA',
                         'ÀaGraveUpperCaseObjTitle/ÀaGraveUpperCaseObjTitle',

--- a/tests/functional/aws-node-sdk/test/legacy/tests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/tests.js
@@ -20,6 +20,7 @@ md5HashSecondPart.update(secondBufferBody);
 const calculatedFirstPartHash = md5HashFirstPart.digest('hex');
 const calculatedSecondPartHash = md5HashSecondPart.digest('hex');
 const combinedETag = '0ea4f0f688a0be07ae1d92eb298d5218-2';
+const objectKey = 'toAbort&<>"\'';
 
 // Store uploadId's in memory so can do multiple tests with
 // same uploadId
@@ -61,14 +62,14 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
     });
 
     it('should create a multipart upload', function createMPU(done) {
-        s3.createMultipartUpload({ Bucket: bucket, Key: 'toAbort' },
+        s3.createMultipartUpload({ Bucket: bucket, Key: objectKey },
             (err, data) => {
                 if (err) {
                     return done(new Error(
                         `error initiating multipart upload: ${err}`));
                 }
                 assert.strictEqual(data.Bucket, bucket);
-                assert.strictEqual(data.Key, 'toAbort');
+                assert.strictEqual(data.Key, objectKey);
                 assert.ok(data.UploadId);
                 multipartUploadData.firstUploadId = data.UploadId;
                 done();
@@ -79,7 +80,7 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
         function uploadpart(done) {
             const params = {
                 Bucket: bucket,
-                Key: 'toAbort',
+                Key: objectKey,
                 PartNumber: 1,
                 UploadId: multipartUploadData.firstUploadId,
                 Body: firstBufferBody,
@@ -96,7 +97,7 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
     it('should abort a multipart upload', function abortMPU(done) {
         const params = {
             Bucket: bucket,
-            Key: 'toAbort',
+            Key: objectKey,
             UploadId: multipartUploadData.firstUploadId,
         };
         s3.abortMultipartUpload(params, (err, data) => {

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -10,6 +10,8 @@ import objectPut from '../../../lib/api/objectPut';
 import { cleanup, DummyRequestLogger, makeAuthInfo } from '../helpers';
 import DummyRequest from '../DummyRequest';
 
+import { errors } from 'arsenal';
+
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
 const delimiter = '/';
@@ -142,6 +144,44 @@ describe('bucketGet API', () => {
         });
     });
 
+    it('should return an InvalidArgument error if max-keys == -1', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            headers: { host: '/' },
+            url: `/${bucketName}`,
+            query: { 'max-keys': '-1' },
+        };
+        bucketGet(authInfo, testGetRequest, log, err => {
+            assert.deepStrictEqual(err, errors.InvalidArgument);
+            done();
+        });
+    });
+
+    it('should return max-keys: 1000 if max-keys > 1000', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            headers: { host: '/' },
+            url: `/${bucketName}`,
+            query: { 'max-keys': '9999' },
+        };
+        async.waterfall([
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
+            next => objectPut(authInfo, testPutObjectRequest1, log, next),
+            (result, next) => objectPut(authInfo, testPutObjectRequest2, log,
+                                next),
+            (result, next) => bucketGet(authInfo, testGetRequest, log, next),
+            (result, next) => parseString(result, next),
+        ],
+        (err, result) => {
+            assert.strictEqual(result.ListBucketResult.MaxKeys[0],
+                               '1000');
+            done();
+        });
+    });
+
     it('should url encode object key name if requested', done => {
         const testGetRequest = {
             bucketName,
@@ -167,6 +207,30 @@ describe('bucketGet API', () => {
                                querystring.escape(objectName3));
             assert.strictEqual(result.ListBucketResult.Contents[1].Key[0],
                                querystring.escape(objectName1));
+            done();
+        });
+    });
+
+    it('should escape invalid xml characters in object key names', done => {
+        const testGetRequest = {
+            bucketName,
+            namespace,
+            headers: { host: '/' },
+            url: `/${bucketName}`,
+            query: {},
+        };
+
+        testPutObjectRequest1.objectKey += '&><"\'';
+        async.waterfall([
+            next => bucketPut(authInfo, testPutBucketRequest,
+                locationConstraint, log, next),
+            next => objectPut(authInfo, testPutObjectRequest1, log, next),
+            (result, next) => bucketGet(authInfo, testGetRequest, log, next),
+            (result, next) => parseString(result, next),
+        ],
+        (err, result) => {
+            assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
+                              testPutObjectRequest1.objectKey);
             done();
         });
     });


### PR DESCRIPTION
The forward-port of rel/1.1 to rel/1.1-smartbulb was already done, so here is the step that will bring all the required changes to master.

As there were a few conflicts, @rahulreddy @LaurenSpiegel Could you please check this over, and validate that everything's good here ? We'll run the end-to-end CI anyways.

Once this is merged, people should automatically forward-port their changes from one branch to another (reminder, at the moment the order is:  rel/1.1 -> rel/1.1-smartbulb -> master)