### PR TITLE
deleteObject's compat. w/ versioning

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -333,8 +333,8 @@ export default {
             });
         } else {
             // versioning
-            log.warn('deleteObject: versioning not implemented');
-            cb(errors.NotImplemented);
+            log.warn('deleteObject: versioning not fully implemented');
+            return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
         }
     },
 


### PR DESCRIPTION
Tests are not handling the case when S3 returns an [error](https://github.com/scality/S3/blob/master/lib/services.js#L337) if users delete an object with a versioning-enabled metadata backend.
This PR fixes the behavior of S3 instead of changing the tests; S3 will not return the error and will continue to delete the object in metadata in such case. This ensures the same metadata behavior though with different backends (versioning and non-versioning).
This fix is also inline with how S3 should handled versioning in future versions.