### PR TITLE
Use refactored Arsenal's Auth API - Step 1

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -26,7 +26,7 @@ import prepareRequestContexts from
 import serviceGet from './serviceGet';
 import vault from '../auth/vault';
 
-auth.setAuthHandler(vault);
+auth.setHandler(vault);
 
 const api = {
     callApiMethod(apiMethod, request, log, callback, locationConstraint) {
@@ -50,7 +50,7 @@ const api = {
         }
         const requestContexts = prepareRequestContexts(apiMethod,
             request, locationConstraint, sourceBucket, sourceObject);
-        return auth.doAuth(request, log, (err, userInfo,
+        return auth.server.doAuth(request, log, (err, userInfo,
             authorizationResults) => {
             if (err) {
                 log.trace('authentication error', { error: err });

--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -53,52 +53,84 @@ function vaultSignatureCb(err, authInfo, log, callback) {
     return callback(null, userInfo, authorizationResults);
 }
 
-const vault = {};
-
 /**
  * authenticateV2Request
  *
- * @param {string} accessKey - user's accessKey
- * @param {string} signatureFromRequest - signature sent with request
- * @param {string} stringToSign - string to sign built per AWS rules
- * @param {string} algo - either SHA256 or SHA1
+ * @param {string} params - the authentication parameters as returned by
+ *                          auth.extractParams
+ * @param {number} params.version - shall equal 2
+ * @param {string} params.data.accessKey - the user's accessKey
+ * @param {string} params.data.signatureFromRequest - the signature read from
+ *                                                    the request
+ * @param {string} params.data.stringToSign - the stringToSign
+ * @param {string} params.data.algo - the hashing algorithm used for the
+ *                                    signature
+ * @param {string} params.data.authType - the type of authentication (query or
+ *                                        header)
+ * @param {string} params.data.signatureVersion - the version of the signature
+ *                                                (AWS or AWS4)
+ * @param {number} [params.data.signatureAge] - the age of the signature in ms
+ * @param {string} params.data.log - the logger object
  * @param {RequestContext []} requestContexts - an array of RequestContext
  * instances which contain information for policy authorization check
- * @param {object} log - Werelogs logger
- * @param {function} callback - callback with either error or authInfo
- * @return {undefined}
+ * @param {function} callback - callback with either error or user info
+ * @returns {undefined}
  */
-vault.authenticateV2Request = (accessKey, signatureFromRequest,
-    stringToSign, algo, requestContexts, log, callback) => {
-    log.debug('authenticating V2 request');
+function authenticateV2Request(params, requestContexts, callback) {
+    params.log.debug('authenticating V2 request');
     const serializedRCs = requestContexts.map(rc => rc.serialize());
-    client.verifySignatureV2(stringToSign, signatureFromRequest, accessKey,
-        { algo, reqUid: log.getSerializedUids(),
-            requestContext: serializedRCs },
-    (err, authInfo) =>
-        vaultSignatureCb(err, authInfo, log, callback));
-};
+    client.verifySignatureV2(
+        params.data.stringToSign,
+        params.data.signatureFromRequest,
+        params.data.accessKey,
+        {
+            algo: params.data.algo,
+            reqUid: params.log.getSerializedUids(),
+            requestContext: serializedRCs,
+        },
+        (err, userInfo) => vaultSignatureCb(err, userInfo,
+                                            params.log, callback)
+    );
+}
 
 /** authenticateV4Request
- * @param {object} params - contains accessKey (string),
- * signatureFromRequest (string), region (string),
- * stringToSign (string) and log (object)
+ * @param {object} params - the authentication parameters as returned by
+ *                          auth.extractParams
+ * @param {number} params.version - shall equal 4
+ * @param {string} params.data.accessKey - the user's accessKey
+ * @param {string} params.data.signatureFromRequest - the signature read from
+ *                                                    the request
+ * @param {string} params.data.region - the AWS region
+ * @param {string} params.data.stringToSign - the stringToSign
+ * @param {string} params.data.scopeDate - the timespan to allow the request
+ * @param {string} params.data.authType - the type of authentication (query or
+ *                                        header)
+ * @param {string} params.data.signatureVersion - the version of the signature
+ *                                                (AWS or AWS4)
+ * @param {number} params.data.signatureAge - the age of the signature in ms
+ * @param {string} params.data.log - the logger object
  * @param {RequestContext []} requestContexts - an array of RequestContext
  * instances which contain information for policy authorization check
- * @param {function} callback - callback with either error or authInfo
+ * @param {function} callback - callback with either error or user info
  * @return {undefined}
 */
-vault.authenticateV4Request = (params, requestContexts, callback) => {
-    const { accessKey, signatureFromRequest, region, scopeDate,
-        stringToSign, log }
-        = params;
-    log.debug('authenticating V4 request');
+function authenticateV4Request(params, requestContexts, callback) {
+    params.log.debug('authenticating V4 request');
     const serializedRCs = requestContexts.map(rc => rc.serialize());
-    client.verifySignatureV4(stringToSign, signatureFromRequest,
-        accessKey, region, scopeDate, { reqUid: log.getSerializedUids(),
-            requestContext: serializedRCs },
-    (err, authInfo) => vaultSignatureCb(err, authInfo, log, callback));
-};
+    client.verifySignatureV4(
+        params.data.stringToSign,
+        params.data.signatureFromRequest,
+        params.data.accessKey,
+        params.data.region,
+        params.data.scopeDate,
+        {
+            reqUid: params.log.getSerializedUids(),
+            requestContext: serializedRCs,
+        },
+        (err, userInfo) => vaultSignatureCb(err, userInfo,
+                                            params.log, callback)
+    );
+}
 
 /** getCanonicalIds -- call Vault to get canonicalIDs based on email addresses
  * @param {array} emailAddresses - list of emailAddresses
@@ -108,7 +140,7 @@ vault.authenticateV4Request = (params, requestContexts, callback) => {
  * of an account as properties
  * @return {undefined}
 */
-vault.getCanonicalIds = (emailAddresses, log, callback) => {
+function getCanonicalIds(emailAddresses, log, callback) {
     log.trace('getting canonicalIDs from Vault based on emailAddresses',
         { emailAddresses });
     client.getCanonicalIds(emailAddresses, { reqUid: log.getSerializedUids() },
@@ -134,7 +166,7 @@ vault.getCanonicalIds = (emailAddresses, log, callback) => {
             }
             return callback(null, foundIds);
         });
-};
+}
 
 /** getEmailAddresses -- call Vault to get email addresses based on canonicalIDs
  * @param {array} canonicalIDs - list of canonicalIDs
@@ -143,7 +175,7 @@ vault.getCanonicalIds = (emailAddresses, log, callback) => {
  * with canonicalID keys and email address values
  * @return {undefined}
 */
-vault.getEmailAddresses = (canonicalIDs, log, callback) => {
+function getEmailAddresses(canonicalIDs, log, callback) {
     log.trace('getting emailAddresses from Vault based on canonicalIDs',
         { canonicalIDs });
     client.getEmailAddresses(canonicalIDs, { reqUid: log.getSerializedUids() },
@@ -166,6 +198,11 @@ vault.getEmailAddresses = (canonicalIDs, log, callback) => {
             });
             return callback(null, result);
         });
-};
+}
 
-export default vault;
+module.exports = {
+    getEmailAddresses,
+    getCanonicalIds,
+    authenticateV2Request,
+    authenticateV4Request,
+};

--- a/lib/kms/utilities.js
+++ b/lib/kms/utilities.js
@@ -48,7 +48,7 @@ function _createEncryptedBucket(host,
         });
     });
 
-    auth.generateV4Headers(request, '', accessKey, secretKey, 's3');
+    auth.client.generateV4Headers(request, '', accessKey, secretKey, 's3');
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }


### PR DESCRIPTION
This is the first step towards using the cleaned-up Auth API from arsenal.
The work is still ongoing, but this will allow us to avoid falling out-of-sync.

Depends on: https://github.com/scality/Arsenal/pull/119 then https://github.com/scality/vaultclient/pull/94