### PR TITLE
Centralize model version tracking for BucketInfo

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -42,7 +42,8 @@ function addToUsersBucket(canonicalID, bucketName, log, cb) {
                         `${bucketName}`;
                     const creationDate = new Date().toJSON();
                     const freshBucket = new BucketInfo(usersBucket,
-                        userBucketOwner, userBucketOwner, creationDate, 2);
+                        userBucketOwner, userBucketOwner, creationDate,
+                        BucketInfo.currentModelVersion());
                     return metadata.createBucket(usersBucket,
                         freshBucket, log, err => {
                             // Note: In the event that two
@@ -140,7 +141,8 @@ export function createBucket(authInfo, bucketName, headers,
         authInfo.getAccountDisplayName();
     const creationDate = new Date().toJSON();
     const bucket = new BucketInfo(bucketName,
-        canonicalID, ownerDisplayName, creationDate, 2);
+        canonicalID, ownerDisplayName, creationDate,
+        BucketInfo.currentModelVersion());
 
     if (locationConstraint !== undefined) {
         bucket.setLocationConstraint(locationConstraint);

--- a/lib/metadata/BucketInfo.js
+++ b/lib/metadata/BucketInfo.js
@@ -1,5 +1,8 @@
 import assert from 'assert';
 
+// WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
+const modelVersion = 2;
+
 export default class BucketInfo {
     /**
     * Represents all bucket information.
@@ -42,6 +45,8 @@ export default class BucketInfo {
             READ: [],
             READ_ACP: [],
         };
+
+        // IF UPDATING PROPERTIES, INCREMENT MODELVERSION NUMBER ABOVE
         this._acl = aclInstance;
         this._name = name;
         this._owner = owner;
@@ -81,6 +86,13 @@ export default class BucketInfo {
             obj.transient, obj.deleted);
     }
 
+    /**
+     * Returns the current model version for the data structure
+     * @return {number} - the current model version set above in the file
+     */
+    static currentModelVersion() {
+        return modelVersion;
+    }
 
     /**
      * Create a BucketInfo from an object

--- a/lib/metadata/ModelVersion.md
+++ b/lib/metadata/ModelVersion.md
@@ -1,0 +1,32 @@
+# BucketInfo Model Version History
+
+## Model Version 0/1
+
+### Properties
+
+``` javascript
+this._acl = aclInstance;
+this._name = name;
+this._owner = owner;
+this._ownerDisplayName = ownerDisplayName;
+this._creationDate = creationDate;
+```
+
+### Usage
+
+No explicit references in the code since mdBucketModelVersion
+property not added until Model Version 2
+
+## Model Version 2
+
+### Properties Added
+
+``` javascript
+this._mdBucketModelVersion = mdBucketModelVersion || 0
+this._transient = transient || false;
+this._deleted = deleted || false;
+```
+
+### Usage
+
+Used to determine which splitter to use ( < 2 means old splitter)

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -66,8 +66,8 @@ class BucketFileInterface {
            usersBucket here */
         sub.sublevel(constants.usersBucket);
         const usersBucketAttr = new BucketInfo(constants.usersBucket,
-                                               'admin', 'admin',
-                                               new Date().toJSON(), 2);
+            'admin', 'admin', new Date().toJSON(),
+            BucketInfo.currentModelVersion());
         metastore.put(constants.usersBucket, usersBucketAttr.serialize());
         const stream = metastore.createKeyStream();
         stream

--- a/lib/services.js
+++ b/lib/services.js
@@ -738,7 +738,8 @@ export default {
                 const creationDate = new Date().toJSON();
                 const mpuBucket = new BucketInfo(MPUBucketName,
                     destinationBucket.getOwner(),
-                    destinationBucket.getOwnerDisplayName(), creationDate, 2);
+                    destinationBucket.getOwnerDisplayName(), creationDate,
+                    BucketInfo.currentModelVersion());
                 // Note that unlike during the creation of a normal bucket,
                 // we do NOT add this bucket to the lists of a user's buckets.
                 // By not adding this bucket to the lists of a user's buckets,

--- a/tests/unit/api/listParts.js
+++ b/tests/unit/api/listParts.js
@@ -38,9 +38,10 @@ describe('List Parts API', () => {
         cleanup();
         const creationDate = new Date().toJSON();
         const sampleNormalBucketInstance = new BucketInfo(bucketName,
-            canonicalID, authInfo.getAccountDisplayName(), creationDate, 2);
+            canonicalID, authInfo.getAccountDisplayName(), creationDate,
+            BucketInfo.currentModelVersion());
         const sampleMPUInstance = new BucketInfo(mpuBucket,
-            'admin', 'admin', creationDate, 2);
+            'admin', 'admin', creationDate, BucketInfo.currentModelVersion());
         metadata.createBucket(bucketName, sampleNormalBucketInstance, log,
             () => {
                 metadata.createBucket(mpuBucket, sampleMPUInstance, log, () => {

--- a/tests/unit/bucket/BucketInfo.js
+++ b/tests/unit/bucket/BucketInfo.js
@@ -30,7 +30,8 @@ const testDate = new Date().toJSON();
 Object.keys(acl).forEach(
     aclObj => describe(`different acl configurations : ${aclObj}`, () => {
         const dummyBucket = new BucketInfo(
-            bucketName, owner, ownerDisplayName, testDate, 2, acl[aclObj],
+            bucketName, owner, ownerDisplayName, testDate,
+            BucketInfo.currentModelVersion(), acl[aclObj],
             false, false);
 
         describe('serialize/deSerialize on BucketInfo class', () => {


### PR DESCRIPTION
We are manually updating the BucketInfo model version a number of places in the code where BucketInfo is instantiated.  This is likely to be forgotten when changes are made to the BucketInfo model.  So, I have created a static function on the BucketInfo class which pulls the current model version.  I also added a changelog to keep track of the versions.