### PR TITLE
Fix Dockerfile, provide absolute paths for volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 
 CMD [ "npm", "start" ]
 
-VOLUME ["usr/src/app/localData","usr/src/app/localMetadata"]
+VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
 EXPOSE 8000
 


### PR DESCRIPTION
![1470345945-1d1859b3c12536481c1c570200dcbd43](https://cloud.githubusercontent.com/assets/36123/17418841/ec41e98a-5a70-11e6-938e-ca75109b8b84.jpg)

Otherwise you get stuff like this from `docker-compose`

`ERROR: Invalid bind mount spec "14d5d3123351185f9c57a61ad832da24218ab445655b545665556f883bb2ba35:usr/src/app/localMetadata:rw": Invalid volume destination path: 'usr/src/app/localMetadata' mount path must be absolute.`