### PR TITLE
Convert in memory bucket key to string to store.

### DIFF
--- a/lib/kms/in_memory/backend.js
+++ b/lib/kms/in_memory/backend.js
@@ -20,8 +20,10 @@ export const backend = {
         process.nextTick(() => {
             // Using createDataKey here for purposes of createBucketKeyMem
             // so that we do not need a separate function.
-            kms[count] = Common.createDataKey();
-            cb(null, count++);
+            const key = count.toString();
+            kms[key] = Common.createDataKey();
+            count++
+            cb(null, key);
         });
     },
 


### PR DESCRIPTION
The in memory implementation is using a counter so the id was being stored as a number.  This was causing the assertion in BucketInfo.js (checks for string) to fail.