### PR TITLE
Compat: header validation refactor and tests

### DIFF
--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -1,6 +1,8 @@
 import { errors } from 'arsenal';
 
 import services from '../services';
+import validateHeaders from '../utilities/validateHeaders';
+
 
 /**
  * objectDelete - DELETE an object from a bucket
@@ -27,7 +29,6 @@ export default function objectDelete(authInfo, request, log, cb) {
         requestType: 'objectDelete',
         log,
     };
-    const validateHeadersParams = { headers: request.headers };
     return services.metadataValidateAuthorization(valParams,
         (err, bucket, objMD) => {
             if (err) {
@@ -37,22 +38,19 @@ export default function objectDelete(authInfo, request, log, cb) {
                 });
                 return cb(err);
             }
-            return services.validateHeaders(objMD, validateHeadersParams,
-                (err, objMD, metaHeaders) => {
-                    if (err) {
-                        log.debug('error from headers validation', {
-                            error: err,
-                            method: 'validateHeaders',
-                        });
-                        return cb(err);
-                    }
-                    if (metaHeaders['Content-Length']) {
-                        log.end().addDefaultFields({
-                            contentLength: metaHeaders['Content-Length'],
-                        });
-                    }
-                    return services.deleteObject(bucketName, objMD, metaHeaders,
-                        objectKey, log, cb);
+            if (!objMD) {
+                return cb(errors.NoSuchKey);
+            }
+            const headerValResult = validateHeaders(objMD, request.headers);
+            if (headerValResult.error) {
+                return cb(headerValResult.error);
+            }
+            if (objMD['content-length']) {
+                log.end().addDefaultFields({
+                    contentLength: objMD['content-length'],
                 });
+            }
+            return services.deleteObject(bucketName, objMD,
+                objectKey, log, cb);
         });
 }

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -1,7 +1,9 @@
-import services from '../services';
 import { errors } from 'arsenal';
-import { parseRange } from './apiUtils/object/parseRange';
 
+import { parseRange } from './apiUtils/object/parseRange';
+import collectResponseHeaders from '../utilities/collectResponseHeaders';
+import services from '../services';
+import validateHeaders from '../utilities/validateHeaders';
 
 /**
  * GET Object - Get an object
@@ -30,53 +32,53 @@ function objectGet(authInfo, request, log, callback) {
             log.debug('error processing request', { error: err });
             return callback(err);
         }
-        services.validateHeaders(objMD, request, (error, objMD,
-            responseMetaHeaders) => {
-            if (error) {
-                log.debug('error processing request', { error });
-                return callback(error);
+        if (!objMD) {
+            return callback(errors.NoSuchKey);
+        }
+        const headerValResult = validateHeaders(objMD, request.headers);
+        if (headerValResult.error) {
+            return callback(headerValResult.error);
+        }
+        const responseMetaHeaders = collectResponseHeaders(objMD);
+        // 0 bytes file
+        if (objMD.location === null) {
+            return callback(null, null, responseMetaHeaders);
+        }
+        let range;
+        let maxContentLength;
+        if (request.headers.range) {
+            maxContentLength =
+                parseInt(responseMetaHeaders['Content-Length'], 10);
+            range = parseRange(request.headers.range, maxContentLength);
+            if (range) {
+                // End of range should be included so + 1
+                responseMetaHeaders['Content-Length'] =
+                    Math.min(maxContentLength - range[0],
+                    range[1] - range[0] + 1);
+                responseMetaHeaders['Accept-Ranges'] = 'bytes';
+                responseMetaHeaders['Content-Range'] = `bytes ${range[0]}-`
+                    + `${Math.min(maxContentLength - 1, range[1])}` +
+                    `/${maxContentLength}`;
             }
-            // 0 bytes file
-            if (objMD.location === null) {
-                return callback(null, null, responseMetaHeaders);
+        }
+        // To provide for backwards compatibility before md-model-version 2,
+        // need to handle cases where objMD.location is just a string
+        const dataLocator = Array.isArray(objMD.location) ?
+            objMD.location : [{ key: objMD.location }];
+        // If have a data model before version 2, cannot support get range
+        // for objects with multiple parts
+        if (range && dataLocator.length > 1 &&
+            dataLocator[0].start === undefined) {
+            return callback(errors.NotImplemented);
+        }
+        if (objMD['x-amz-server-side-encryption']) {
+            for (let i = 0; i < dataLocator.length; i++) {
+                dataLocator[i].masterKeyId =
+                    objMD['x-amz-server-side-encryption-aws-kms-key-id'];
+                dataLocator[i].algorithm =
+                    objMD['x-amz-server-side-encryption'];
             }
-            let range;
-            let maxContentLength;
-            if (request.headers.range) {
-                maxContentLength =
-                    parseInt(responseMetaHeaders['Content-Length'], 10);
-                range = parseRange(request.headers.range, maxContentLength);
-                if (range) {
-                    // End of range should be included so + 1
-                    responseMetaHeaders['Content-Length'] =
-                        Math.min(maxContentLength - range[0],
-                        range[1] - range[0] + 1);
-                    responseMetaHeaders['Accept-Ranges'] = 'bytes';
-                    responseMetaHeaders['Content-Range'] = `bytes ${range[0]}-`
-                        + `${Math.min(maxContentLength - 1, range[1])}` +
-                        `/${maxContentLength}`;
-                }
-            }
-            // To provide for backwards compatibility before md-model-version 2,
-            // need to handle cases where objMD.location is just a string
-            const dataLocator = Array.isArray(objMD.location) ?
-                objMD.location : [{ key: objMD.location }];
-            // If have a data model before version 2, cannot support get range
-            // for objects with multiple parts
-            if (range && dataLocator.length > 1 &&
-                dataLocator[0].start === undefined) {
-                return callback(errors.NotImplemented);
-            }
-            if (objMD['x-amz-server-side-encryption']) {
-                for (let i = 0; i < dataLocator.length; i++) {
-                    dataLocator[i].masterKeyId =
-                        objMD['x-amz-server-side-encryption-aws-kms-key-id'];
-                    dataLocator[i].algorithm =
-                        objMD['x-amz-server-side-encryption'];
-                }
-            }
-            return callback(null, dataLocator, responseMetaHeaders, range);
-        });
-        return undefined;
+        }
+        return callback(null, dataLocator, responseMetaHeaders, range);
     });
 }

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,6 +1,8 @@
-import async from 'async';
+import errors from 'arsenal';
 
+import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import services from '../services';
+import validateHeaders from '../utilities/validateHeaders';
 
 /**
  * HEAD Object - Same as Get Object but only respond with headers
@@ -23,12 +25,24 @@ export default function objectHead(authInfo, request, log, callback) {
         requestType: 'objectHead',
         log,
     };
-    const validateHeadersParams = { headers: request.headers };
 
-    async.waterfall([
-        next => services.metadataValidateAuthorization(metadataValParams, next),
-        (bucket, objectMetadata, next) => services.validateHeaders(
-                                objectMetadata, validateHeadersParams, next),
-    ], (err, objectMetadata, responseMetaHeaders) =>
-        callback(err, responseMetaHeaders));
+    return services.metadataValidateAuthorization(metadataValParams,
+        (err, bucket, objMD) => {
+            if (err) {
+                log.debug('error processing request', {
+                    error: err,
+                    method: 'metadataValidateAuthorization',
+                });
+                return callback(err);
+            }
+            if (!objMD) {
+                return callback(errors.NoSuchKey);
+            }
+            const headerValResult = validateHeaders(objMD, request.headers);
+            if (headerValResult.error) {
+                return callback(headerValResult.error);
+            }
+            const responseMetaHeaders = collectResponseHeaders(objMD);
+            return callback(err, responseMetaHeaders);
+        });
 }

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,4 +1,4 @@
-import errors from 'arsenal';
+import { errors } from 'arsenal';
 
 import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import services from '../services';

--- a/lib/services.js
+++ b/lib/services.js
@@ -305,14 +305,12 @@ export default {
      * Deletes objects from a bucket
      * @param {string} bucketName - bucket in which objectMD is stored
      * @param {object} objectMD - object's metadata
-     * @param {object} responseMDHeaders - contains user meta headers
-     *                                     to be passed to response
      * @param {string} objectKey - object key name
      * @param {Log} log - logger instance
      * @param {function} cb - callback from async.waterfall in objectGet
      * @return {undefined}
      */
-    deleteObject(bucketName, objectMD, responseMDHeaders, objectKey, log, cb) {
+    deleteObject(bucketName, objectMD, objectKey, log, cb) {
         log.trace('deleting object from bucket');
         assert.strictEqual(typeof bucketName, 'string');
         assert.strictEqual(typeof objectMD, 'object');
@@ -358,82 +356,6 @@ export default {
             log.warn('deleteObject: versioning not fully implemented');
             return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
         }
-    },
-
-    /**
-     * Validates request headers included 'if-modified-since',
-     * 'if-unmodified-since', 'if-match' or 'if-none-match'
-     * headers.  If so, return appropriate response based
-     * on last-modified date of object or ETag.
-     * Also pulls user's meta headers from metadata and
-     * passes them along to be added to response.
-     * @param {object} objectMD - object's metadata
-     * @param {object} metadataCheckParams - contains lowercased
-     * headers from request object
-     * @param {function} cb - callback from async.waterfall in objectGet
-     * @return {function} executes cb error, bucket, objectMetada
-     * and responseMetaHeaders as arguments
-     */
-    validateHeaders(objectMD, metadataCheckParams, cb) {
-        assert.strictEqual(arguments.length, 3);
-        if (!objectMD) {
-            return cb(errors.NoSuchKey);
-        }
-
-        const headers = metadataCheckParams.headers;
-        const lastModified = new Date(objectMD['last-modified']).getTime();
-        const contentMD5 = objectMD['content-md5'];
-        let ifModifiedSinceTime = headers['if-modified-since'];
-        let ifUnmodifiedSinceTime = headers['if-unmodified-since'];
-        const ifETagMatch = headers['if-match'];
-        const ifETagNoneMatch = headers['if-none-match'];
-        if (ifModifiedSinceTime) {
-            ifModifiedSinceTime = new Date(ifModifiedSinceTime);
-            ifModifiedSinceTime = ifModifiedSinceTime.getTime();
-            if (isNaN(ifModifiedSinceTime)) {
-                return cb(errors.InvalidArgument);
-            }
-            if (lastModified < ifModifiedSinceTime) {
-                return cb(errors.NotModified);
-            }
-        }
-        if (ifUnmodifiedSinceTime) {
-            ifUnmodifiedSinceTime = new Date(ifUnmodifiedSinceTime);
-            ifUnmodifiedSinceTime = ifUnmodifiedSinceTime.getTime();
-            if (isNaN(ifUnmodifiedSinceTime)) {
-                return cb(errors.InvalidArgument);
-            }
-            if (lastModified > ifUnmodifiedSinceTime) {
-                return cb(errors.PreconditionFailed);
-            }
-        }
-        if (ifETagMatch) {
-            if (ifETagMatch !== contentMD5) {
-                return cb(errors.PreconditionFailed);
-            }
-        }
-        if (ifETagNoneMatch) {
-            if (ifETagNoneMatch === contentMD5) {
-                return cb(errors.NotModified);
-            }
-        }
-        // Add user meta headers from objectMD
-        const responseMetaHeaders = {};
-        Object.keys(objectMD).filter(val => val.substr(0, 11) === 'x-amz-meta-')
-            .forEach(id => { responseMetaHeaders[id] = objectMD[id]; });
-
-        // TODO: Add additional response headers --
-        // i.e. x-amz-storage-class and x-amz-server-side-encryption
-        responseMetaHeaders['Content-Length'] = objectMD['content-length'];
-        // Note: ETag must have a capital "E" and capital "T" for cosbench
-        // to work.
-        responseMetaHeaders.ETag = `"${objectMD['content-md5']}"`;
-        responseMetaHeaders['Last-Modified'] =
-            new Date(objectMD['last-modified']).toUTCString();
-        if (objectMD['content-type']) {
-            responseMetaHeaders['Content-Type'] = objectMD['content-type'];
-        }
-        return cb(null, objectMD, responseMetaHeaders);
     },
 
     /**

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -1,0 +1,41 @@
+/**
+ * Pulls data from saved object metadata to send in response
+ * @param {object} objectMD - object's metadata
+ * @param {object} headers - contains headers from request object
+ * @return {object} responseMetaHeaders headers with object metadata to include
+ * in response to client
+ */
+function collectResponseHeaders(objectMD) {
+    // Add user meta headers from objectMD
+    const responseMetaHeaders = {};
+    Object.keys(objectMD).filter(val => val.substr(0, 11) === 'x-amz-meta-')
+        .forEach(id => { responseMetaHeaders[id] = objectMD[id]; });
+
+    // TODO: When implement versioning and lifecycle,
+    // add additional response headers
+    // http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
+    if (objectMD['x-amz-storage-class'] !== 'STANDARD') {
+        responseMetaHeaders['x-amz-storage-class'] =
+            objectMD['x-amz-storage-class'];
+    }
+    if (objectMD['x-amz-server-side-encryption']) {
+        responseMetaHeaders['x-amz-server-side-encryption']
+            = objectMD['x-amz-server-side-encryption'];
+    }
+    if (objectMD['x-amz-server-side-encryption-aws-kms-key-id']) {
+        responseMetaHeaders['x-amz-server-side-encryption-aws-kms-key-id']
+            = objectMD['x-amz-server-side-encryption-aws-kms-key-id'];
+    }
+    responseMetaHeaders['Content-Length'] = objectMD['content-length'];
+    // Note: ETag must have a capital "E" and capital "T" for cosbench
+    // to work.
+    responseMetaHeaders.ETag = `"${objectMD['content-md5']}"`;
+    responseMetaHeaders['Last-Modified'] =
+        new Date(objectMD['last-modified']).toUTCString();
+    if (objectMD['content-type']) {
+        responseMetaHeaders['Content-Type'] = objectMD['content-type'];
+    }
+    return responseMetaHeaders;
+}
+
+export default collectResponseHeaders;

--- a/lib/utilities/validateHeaders.js
+++ b/lib/utilities/validateHeaders.js
@@ -1,5 +1,73 @@
 import { errors } from 'arsenal';
 
+function checkEtagMatch(ifETagMatch, contentMD5) {
+    const res = { present: false, error: null };
+    if (ifETagMatch) {
+        res.present = true;
+        if (ifETagMatch.indexOf(',')) {
+            const items = ifETagMatch.split(',');
+            const anyMatch = items.some(item =>
+                item === contentMD5 || item === '*' ||
+                item === `"${contentMD5}"`
+            );
+            if (!anyMatch) {
+                res.error = errors.PreconditionFailed;
+            }
+        } else if (ifETagMatch !== contentMD5) {
+            res.error = errors.PreconditionFailed;
+        }
+    }
+    return res;
+}
+
+function checkEtagNoneMatch(ifETagNoneMatch, contentMD5) {
+    const res = { present: false, error: null };
+    if (ifETagNoneMatch) {
+        res.present = true;
+        if (ifETagNoneMatch.indexOf(',')) {
+            const items = ifETagNoneMatch.split(',');
+            const anyMatch = items.some(item =>
+                item === contentMD5 || item === '*' ||
+                item === `"${contentMD5}"`
+            );
+            if (anyMatch) {
+                res.error = errors.NotModified;
+            }
+        } else if (ifETagNoneMatch === contentMD5) {
+            res.error = errors.NotModified;
+        }
+    }
+    return res;
+}
+
+function checkModifiedSince(ifModifiedSinceTime, lastModified) {
+    const res = { present: false, error: null };
+    if (ifModifiedSinceTime) {
+        res.present = true;
+        const checkWith = (new Date(ifModifiedSinceTime)).getTime();
+        if (isNaN(checkWith)) {
+            res.error = errors.InvalidArgument;
+        } else if (lastModified <= checkWith) {
+            res.error = errors.NotModified;
+        }
+    }
+    return res;
+}
+
+function checkUnmodifiedSince(ifUnmodifiedSinceTime, lastModified) {
+    const res = { present: false, error: null };
+    if (ifUnmodifiedSinceTime) {
+        res.present = true;
+        const checkWith = (new Date(ifUnmodifiedSinceTime)).getTime();
+        if (isNaN(checkWith)) {
+            res.error = errors.InvalidArgument;
+        } else if (lastModified > checkWith) {
+            res.error = errors.PreconditionFailed;
+        }
+    }
+    return res;
+}
+
 /**
  * Checks 'if-modified-since', 'if-unmodified-since', 'if-match' or
  * 'if-none-match' headers if included in request against last-modified
@@ -10,62 +78,32 @@ import { errors } from 'arsenal';
  * empty object if no error
  */
 export default function validateHeaders(objectMD, headers) {
-    const lastModified = new Date(objectMD['last-modified']).getTime();
+    let lastModified = new Date(objectMD['last-modified']);
+    lastModified.setMilliseconds(0);
+    lastModified = lastModified.getTime();
     const contentMD5 = objectMD['content-md5'];
-    let ifModifiedSinceTime = headers['if-modified-since'];
-    let ifUnmodifiedSinceTime = headers['if-unmodified-since'];
-    let ifETagMatch = headers['if-match'];
-    let ifETagNoneMatch = headers['if-none-match'];
-    if (ifETagMatch) {
-        if (ifETagMatch.indexOf(',')) {
-            ifETagMatch = ifETagMatch.split(',');
-            const anyMatch = ifETagMatch.some(item =>
-                item === contentMD5 || item === '*'
-            );
-            if (!anyMatch) {
-                return { error: errors.PreconditionFailed };
-            }
-        } else if (ifETagMatch !== contentMD5) {
-            return { error: errors.PreconditionFailed };
-        }
+    const etagMatchRes = checkEtagMatch(headers['if-match'], contentMD5);
+    const etagNoneMatchRes = checkEtagNoneMatch(headers['if-none-match'],
+        contentMD5);
+    const modifiedSinceRes = checkModifiedSince(headers['if-modified-since'],
+        lastModified);
+    const unmodifiedSinceRes = checkUnmodifiedSince(
+        headers['if-unmodified-since'], lastModified);
+    // If-Unmodified-Since condition evaluates to false and If-Match
+    // is not present, then return the error. Otherwise, If-Unmodified-Since is
+    // silent when If-Match match, and when If-Match does not match, it's the
+    // same error, so each case are covered.
+    if (!etagMatchRes.present && unmodifiedSinceRes.error) {
+        return unmodifiedSinceRes;
     }
-    if (ifETagNoneMatch) {
-        if (ifETagNoneMatch.indexOf(',')) {
-            ifETagNoneMatch = ifETagNoneMatch.split(',');
-            const anyMatch = ifETagNoneMatch.some(item =>
-                item === contentMD5 || item === '*'
-            );
-            // If both of the If-None-Match and If-Modified-Since headers
-            // are present in the request and If-None-Match fails,
-            // return 304 Not Modified regardless of If-Modified-Since
-            if (anyMatch) {
-                return { error: errors.NotModified };
-            }
-        } else if (ifETagNoneMatch === contentMD5) {
-            return { error: errors.NotModified };
-        }
+    if (etagMatchRes.present && etagMatchRes.error) {
+        return etagMatchRes;
     }
-    if (ifModifiedSinceTime) {
-        ifModifiedSinceTime = new Date(ifModifiedSinceTime);
-        ifModifiedSinceTime = ifModifiedSinceTime.getTime();
-        if (isNaN(ifModifiedSinceTime)) {
-            return { error: errors.InvalidArgument };
-        }
-        if (lastModified < ifModifiedSinceTime) {
-            return { error: errors.NotModified };
-        }
+    if (etagNoneMatchRes.present && etagNoneMatchRes.error) {
+        return etagNoneMatchRes;
     }
-    if (ifUnmodifiedSinceTime) {
-        ifUnmodifiedSinceTime = new Date(ifUnmodifiedSinceTime);
-        ifUnmodifiedSinceTime = ifUnmodifiedSinceTime.getTime();
-        if (isNaN(ifUnmodifiedSinceTime)) {
-            return { error: errors.InvalidArgument };
-        }
-        // If-Unmodified-Since condition evaluates to false but If-Match
-        // evaluated to true, then no error.
-        if (lastModified > ifUnmodifiedSinceTime && !ifETagMatch) {
-            return { error: errors.PreconditionFailed };
-        }
+    if (modifiedSinceRes.present && modifiedSinceRes.error) {
+        return modifiedSinceRes;
     }
     return {};
 }

--- a/lib/utilities/validateHeaders.js
+++ b/lib/utilities/validateHeaders.js
@@ -9,13 +9,42 @@ import { errors } from 'arsenal';
  * @return {object} object with error as key and arsenal error as value or
  * empty object if no error
  */
-function validateHeaders(objectMD, headers) {
+export default function validateHeaders(objectMD, headers) {
     const lastModified = new Date(objectMD['last-modified']).getTime();
     const contentMD5 = objectMD['content-md5'];
     let ifModifiedSinceTime = headers['if-modified-since'];
     let ifUnmodifiedSinceTime = headers['if-unmodified-since'];
-    const ifETagMatch = headers['if-match'];
-    const ifETagNoneMatch = headers['if-none-match'];
+    let ifETagMatch = headers['if-match'];
+    let ifETagNoneMatch = headers['if-none-match'];
+    if (ifETagMatch) {
+        if (ifETagMatch.indexOf(',')) {
+            ifETagMatch = ifETagMatch.split(',');
+            const anyMatch = ifETagMatch.some(item =>
+                item === contentMD5 || item === '*'
+            );
+            if (!anyMatch) {
+                return { error: errors.PreconditionFailed };
+            }
+        } else if (ifETagMatch !== contentMD5) {
+            return { error: errors.PreconditionFailed };
+        }
+    }
+    if (ifETagNoneMatch) {
+        if (ifETagNoneMatch.indexOf(',')) {
+            ifETagNoneMatch = ifETagNoneMatch.split(',');
+            const anyMatch = ifETagNoneMatch.some(item =>
+                item === contentMD5 || item === '*'
+            );
+            // If both of the If-None-Match and If-Modified-Since headers
+            // are present in the request and If-None-Match fails,
+            // return 304 Not Modified regardless of If-Modified-Since
+            if (anyMatch) {
+                return { error: errors.NotModified };
+            }
+        } else if (ifETagNoneMatch === contentMD5) {
+            return { error: errors.NotModified };
+        }
+    }
     if (ifModifiedSinceTime) {
         ifModifiedSinceTime = new Date(ifModifiedSinceTime);
         ifModifiedSinceTime = ifModifiedSinceTime.getTime();
@@ -32,21 +61,11 @@ function validateHeaders(objectMD, headers) {
         if (isNaN(ifUnmodifiedSinceTime)) {
             return { error: errors.InvalidArgument };
         }
-        if (lastModified > ifUnmodifiedSinceTime) {
+        // If-Unmodified-Since condition evaluates to false but If-Match
+        // evaluated to true, then no error.
+        if (lastModified > ifUnmodifiedSinceTime && !ifETagMatch) {
             return { error: errors.PreconditionFailed };
-        }
-    }
-    if (ifETagMatch) {
-        if (ifETagMatch !== contentMD5) {
-            return { error: errors.PreconditionFailed };
-        }
-    }
-    if (ifETagNoneMatch) {
-        if (ifETagNoneMatch === contentMD5) {
-            return { error: errors.NotModified };
         }
     }
     return {};
 }
-
-export default validateHeaders;

--- a/lib/utilities/validateHeaders.js
+++ b/lib/utilities/validateHeaders.js
@@ -1,0 +1,52 @@
+import { errors } from 'arsenal';
+
+/**
+ * Checks 'if-modified-since', 'if-unmodified-since', 'if-match' or
+ * 'if-none-match' headers if included in request against last-modified
+ * date of object and/or ETag.
+ * @param {object} objectMD - object's metadata
+ * @param {object} headers - contains headers from request object
+ * @return {object} object with error as key and arsenal error as value or
+ * empty object if no error
+ */
+function validateHeaders(objectMD, headers) {
+    const lastModified = new Date(objectMD['last-modified']).getTime();
+    const contentMD5 = objectMD['content-md5'];
+    let ifModifiedSinceTime = headers['if-modified-since'];
+    let ifUnmodifiedSinceTime = headers['if-unmodified-since'];
+    const ifETagMatch = headers['if-match'];
+    const ifETagNoneMatch = headers['if-none-match'];
+    if (ifModifiedSinceTime) {
+        ifModifiedSinceTime = new Date(ifModifiedSinceTime);
+        ifModifiedSinceTime = ifModifiedSinceTime.getTime();
+        if (isNaN(ifModifiedSinceTime)) {
+            return { error: errors.InvalidArgument };
+        }
+        if (lastModified < ifModifiedSinceTime) {
+            return { error: errors.NotModified };
+        }
+    }
+    if (ifUnmodifiedSinceTime) {
+        ifUnmodifiedSinceTime = new Date(ifUnmodifiedSinceTime);
+        ifUnmodifiedSinceTime = ifUnmodifiedSinceTime.getTime();
+        if (isNaN(ifUnmodifiedSinceTime)) {
+            return { error: errors.InvalidArgument };
+        }
+        if (lastModified > ifUnmodifiedSinceTime) {
+            return { error: errors.PreconditionFailed };
+        }
+    }
+    if (ifETagMatch) {
+        if (ifETagMatch !== contentMD5) {
+            return { error: errors.PreconditionFailed };
+        }
+    }
+    if (ifETagNoneMatch) {
+        if (ifETagNoneMatch === contentMD5) {
+            return { error: errors.NotModified };
+        }
+    }
+    return {};
+}
+
+export default validateHeaders;

--- a/tests/functional/aws-node-sdk/test/object/objectHead.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead.js
@@ -1,0 +1,412 @@
+import assert from 'assert';
+import { errors } from 'arsenal';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucketName = 'alexbucketnottaken';
+const objectName = 'someObject';
+
+function checkNoError(err) {
+    assert.equal(err, null,
+        `Expected success, got error ${JSON.stringify(err)}`);
+}
+
+function checkError(err, code) {
+    assert.notEqual(err, null, 'Expected failure but got success');
+    assert.strictEqual(err.code, code);
+}
+
+function dateFromNow(diff) {
+    const d = new Date();
+    d.setHours(d.getHours() + diff);
+    return d.toISOString();
+}
+
+function dateConvert(d) {
+    return (new Date(d)).toISOString();
+}
+
+describe('HEAD object, conditions', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+        let etag;
+        let etagTrim;
+        let lastModified;
+
+        before(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return bucketUtil.empty(bucketName).then(() =>
+                bucketUtil.deleteOne(bucketName)
+            )
+            .catch(err => {
+                if (err.code !== 'NoSuchBucket') {
+                    process.stdout.write(`${err}\n`);
+                    throw err;
+                }
+            })
+            .then(() => bucketUtil.createOne(bucketName));
+        });
+
+        function requestHead(fields, cb) {
+            s3.headObject(Object.assign({
+                Bucket: bucketName,
+                Key: objectName,
+            }, fields), cb);
+        }
+
+        beforeEach(() => s3.putObjectAsync({
+            Bucket: bucketName,
+            Key: objectName,
+            Body: 'I am the best content ever',
+        }).then(res => {
+            etag = res.ETag;
+            etagTrim = etag.substring(1, etag.length - 1);
+            return s3.headObjectAsync({ Bucket: bucketName, Key: objectName });
+        }).then(res => {
+            lastModified = res.LastModified;
+        }));
+
+        afterEach(() => bucketUtil.empty(bucketName));
+
+        after(() => bucketUtil.deleteOne(bucketName));
+
+        it('If-Match: returns no error when ETag match, with double quotes ' +
+            'around ETag',
+            done => {
+                requestHead({ IfMatch: etag }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Match: returns no error when one of ETags match, with double ' +
+            'quotes around ETag',
+            done => {
+                requestHead({ IfMatch: `non-matching,${etag}` }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Match: returns no error when ETag match, without double ' +
+            'quotes around ETag',
+            done => {
+                requestHead({ IfMatch: etagTrim }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Match: returns no error when one of ETags match, without ' +
+            'double quotes around ETag',
+            done => {
+                requestHead({ IfMatch: `non-matching,${etagTrim}` }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Match: returns no error when ETag match with *', done => {
+            requestHead({ IfMatch: '*' }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Match: returns PreconditionFailed when ETag does not match',
+            done => {
+                requestHead({ IfMatch: 'non-matching ETag' }, err => {
+                    checkError(err, errors.PreconditionFailed.code);
+                    done();
+                });
+            });
+
+        it('If-None-Match: returns no error when ETag does not match', done => {
+            requestHead({ IfNoneMatch: 'non-matching' }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-None-Match: returns no error when all ETags do not match',
+            done => {
+                requestHead({
+                    IfNoneMatch: 'non-matching,non-matching-either',
+                }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-None-Match: returns NotModified when ETag match, with double ' +
+            'quotes around ETag',
+            done => {
+                requestHead({ IfNoneMatch: etag }, err => {
+                    checkError(err, 'NotModified');
+                    done();
+                });
+            });
+
+        it('If-None-Match: returns NotModified when one of ETags match, with ' +
+            'double quotes around ETag',
+            done => {
+                requestHead({
+                    IfNoneMatch: `non-matching,${etag}`,
+                }, err => {
+                    checkError(err, 'NotModified');
+                    done();
+                });
+            });
+
+        it('If-None-Match: returns NotModified when ETag match, without ' +
+            'double quotes around ETag',
+            done => {
+                requestHead({ IfNoneMatch: etagTrim }, err => {
+                    checkError(err, 'NotModified');
+                    done();
+                });
+            });
+
+        it('If-None-Match: returns NotModified when one of ETags match, ' +
+            'without double quotes around ETag',
+            done => {
+                requestHead({
+                    IfNoneMatch: `non-matching,${etagTrim}`,
+                }, err => {
+                    checkError(err, 'NotModified');
+                    done();
+                });
+            });
+
+        it('If-Modified-Since: returns no error if Last modified date is ' +
+            'greater',
+            done => {
+                requestHead({ IfModifiedSince: dateFromNow(-1) },
+                    err => {
+                        checkNoError(err);
+                        done();
+                    });
+            });
+
+        // Skipping this test, because real AWS does not provide error as
+        // expected
+        it.skip('If-Modified-Since: returns NotModified if Last modified ' +
+            'date is lesser',
+            done => {
+                requestHead({ IfModifiedSince: dateFromNow(1) },
+                    err => {
+                        checkError(err, 'NotModified');
+                        done();
+                    });
+            });
+
+        it('If-Modified-Since: returns NotModified if Last modified ' +
+            'date is equal',
+            done => {
+                requestHead({ IfModifiedSince: dateConvert(lastModified) },
+                    err => {
+                        checkError(err, 'NotModified');
+                        done();
+                    });
+            });
+
+        it('If-Unmodified-Since: returns no error when lastModified date is ' +
+            'greater',
+            done => {
+                requestHead({ IfUnmodifiedSince: dateFromNow(1) }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Unmodified-Since: returns no error when lastModified ' +
+            'date is equal',
+            done => {
+                requestHead({ IfUnmodifiedSince: dateConvert(lastModified) },
+                    err => {
+                        checkNoError(err);
+                        done();
+                    });
+            });
+
+        it('If-Unmodified-Since: returns PreconditionFailed when ' +
+            'lastModified date is lesser',
+            done => {
+                requestHead({ IfUnmodifiedSince: dateFromNow(-1) }, err => {
+                    checkError(err, errors.PreconditionFailed.code);
+                    done();
+                });
+            });
+
+        it('If-Match & If-Unmodified-Since: returns no error when match Etag ' +
+            'and lastModified is greater',
+            done => {
+                requestHead({
+                    IfMatch: etagTrim,
+                    IfUnmodifiedSince: dateFromNow(-1),
+                }, err => {
+                    checkNoError(err);
+                    done();
+                });
+            });
+
+        it('If-Match match & If-Unmodified-Since match', done => {
+            requestHead({
+                IfMatch: etagTrim,
+                IfUnmodifiedSince: dateFromNow(1),
+            }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Match not match & If-Unmodified-Since not match', done => {
+            requestHead({
+                IfMatch: 'non-matching',
+                IfUnmodifiedSince: dateFromNow(-1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+
+        it('If-Match not match & If-Unmodified-Since match', done => {
+            requestHead({
+                IfMatch: 'non-matching',
+                IfUnmodifiedSince: dateFromNow(1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+
+        // Skipping this test, because real AWS does not provide error as
+        // expected
+        it.skip('If-Match match & If-Modified-Since not match', done => {
+            requestHead({
+                IfMatch: etagTrim,
+                IfModifiedSince: dateFromNow(1),
+            }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Match match & If-Modified-Since match', done => {
+            requestHead({
+                IfMatch: etagTrim,
+                IfModifiedSince: dateFromNow(-1),
+            }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-Match not match & If-Modified-Since not match', done => {
+            requestHead({
+                IfMatch: 'non-matching',
+                IfModifiedSince: dateFromNow(1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+
+        it('If-Match not match & If-Modified-Since match', done => {
+            requestHead({
+                IfMatch: 'non-matching',
+                IfModifiedSince: dateFromNow(-1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+
+        it('If-None-Match & If-Modified-Since: returns NotModified when Etag ' +
+            'does not match and lastModified is greater',
+            done => {
+                requestHead({
+                    IfNoneMatch: etagTrim,
+                    IfModifiedSince: dateFromNow(-1),
+                }, err => {
+                    checkError(err, 'NotModified');
+                    done();
+                });
+            });
+
+        it('If-None-Match not match & If-Modified-Since not match', done => {
+            requestHead({
+                IfNoneMatch: etagTrim,
+                IfModifiedSince: dateFromNow(1),
+            }, err => {
+                checkError(err, 'NotModified');
+                done();
+            });
+        });
+
+        it('If-None-Match match & If-Modified-Since match', done => {
+            requestHead({
+                IfNoneMatch: 'non-matching',
+                IfModifiedSince: dateFromNow(-1),
+            }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        // Skipping this test, because real AWS does not provide error as
+        // expected
+        it.skip('If-None-Match match & If-Modified-Since not match', done => {
+            requestHead({
+                IfNoneMatch: 'non-matching',
+                IfModifiedSince: dateFromNow(1),
+            }, err => {
+                checkError(err, 'NotModified');
+                done();
+            });
+        });
+
+        it('If-None-Match match & If-Unmodified-Since match', done => {
+            requestHead({
+                IfNoneMatch: 'non-matching',
+                IfUnmodifiedSince: dateFromNow(1),
+            }, err => {
+                checkNoError(err);
+                done();
+            });
+        });
+
+        it('If-None-Match match & If-Unmodified-Since not match', done => {
+            requestHead({
+                IfNoneMatch: 'non-matching',
+                IfUnmodifiedSince: dateFromNow(-1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+
+        it('If-None-Match not match & If-Unmodified-Since match', done => {
+            requestHead({
+                IfNoneMatch: etagTrim,
+                IfUnmodifiedSince: dateFromNow(1),
+            }, err => {
+                checkError(err, 'NotModified');
+                done();
+            });
+        });
+
+        it('If-None-Match not match & If-Unmodified-Since not match', done => {
+            requestHead({
+                IfNoneMatch: etagTrim,
+                IfUnmodifiedSince: dateFromNow(-1),
+            }, err => {
+                checkError(err, errors.PreconditionFailed.code);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Refactor and tests the header validation to ensure compatibility against real AWS S3 api

1) Modularizes the validateHeaders function so that 3 functions that were combined are separated: (a) checking whether the object exists, (b) checking the if-match and if-modified headers against the object metadata, (c) pulling the metadata for the response.  This impacts objectHead, deleteObject and getObject API's.

2) Fixes the if-match and if-modified header checks to deal with multiple etags provided in one request and for AWS compatibility with mixed headers (e.g., if-match and if-modified-since together in the same request).  This closes https://github.com/scality/S3/issues/125
