### PR TITLE
FIX: getObject works with ACL header: public-read

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -8,8 +8,7 @@ export function isBucketAuthorized(bucket, requestType, canonicalID) {
         return true;
     }
     const bucketAcl = bucket.getAcl();
-    if (requestType === 'bucketGet' || requestType === 'bucketHead'
-            || requestType === 'objectGet' || requestType === 'objectHead') {
+    if (requestType === 'bucketGet' || requestType === 'bucketHead') {
         if (bucketAcl.Canned === 'public-read'
             || bucketAcl.Canned === 'public-read-write'
             || (bucketAcl.Canned === 'authenticated-read'
@@ -48,12 +47,15 @@ export function isBucketAuthorized(bucket, requestType, canonicalID) {
             return true;
         }
     }
-    // Note that an account can have the ability to do objectPutACL
-    // or objectGetACL even if the account has no rights to the bucket
-    // holding the object.  So, if the requst type is objectPutACL
-    // or objectGetACL, the bucket authorization check should just
-    // return true so can move on to check rights at the object level.
-    return (requestType === 'objectPutACL' || requestType === 'objectGetACL');
+    // Note that an account can have the ability to do objectPutACL,
+    // objectGetACL, objectHead or objectGet even if the account has no rights
+    // to the bucket holding the object.  So, if the request type is
+    // objectPutACL, objectGetACL, objectHead or objectGet, the bucket
+    // authorization check should just return true so can move on to check
+    // rights at the object level.
+
+    return (requestType === 'objectPutACL' || requestType === 'objectGetACL' ||
+    requestType === 'objectGet' || requestType === 'objectHead');
 }
 
 export function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {

--- a/tests/unit/api/bucketACLauth.js
+++ b/tests/unit/api/bucketACLauth.js
@@ -26,7 +26,11 @@ describe('bucket authorization for bucketGet, bucketHead, ' +
     const requestTypes = ['bucketGet', 'bucketHead', 'objectGet', 'objectHead'];
 
     const trueArray = [true, true, true, true];
-    const falseArray = [false, false, false, false];
+    // An account can have the ability to do objectHead or objectGet even
+    // if the account has no rights to the bucket holding the object.
+    // So isBucketAuthorized should return true for 'objectGet' and 'objectHead'
+    // requests but false for 'bucketGet' and 'bucketHead'
+    const falseArrayBucketTrueArrayObject = [false, false, true, true];
 
     const orders = [
         { it: 'should allow access to bucket owner', canned: '',
@@ -35,16 +39,24 @@ describe('bucket authorization for bucketGet, bucketHead, ' +
           canned: 'public-read', id: accountToVet, response: trueArray },
         { it: 'should allow access to anyone if canned public-read-write ACL',
           canned: 'public-read-write', id: accountToVet, response: trueArray },
-        { it: 'should not allow access to public user if authenticated-read ' +
-          'ACL', canned: 'authenticated-read', id: constants.publicId,
-          response: falseArray },
+        { it: 'should not allow request on the bucket (bucketGet, bucketHead) '
+        + ' but should allow request on the object (objectGet, objectHead)'
+        + ' to public user if authenticated-read  ACL',
+          canned: 'authenticated-read', id: constants.publicId,
+          response: falseArrayBucketTrueArrayObject },
         { it: 'should allow access to any authenticated user if authenticated' +
           '-read ACL', canned: 'authenticated-read', id: accountToVet,
           response: trueArray },
-        { it: 'should not allow access to public user if private canned ACL',
-          canned: '', id: accountToVet, response: falseArray },
-        { it: 'should not allow access to just any user if private canned ACL',
-          canned: '', id: accountToVet, response: falseArray },
+        { it: 'should not allow request on the bucket (bucketGet, bucketHead) '
+        + ' but should allow request on the object (objectGet, objectHead)'
+        + ' to public user if private canned ACL',
+          canned: '', id: accountToVet,
+          response: falseArrayBucketTrueArrayObject },
+        { it: 'should not allow request on the bucket (bucketGet, bucketHead) '
+        + ' but should allow request on the object (objectGet, objectHead)'
+        + ' to just any user if private canned ACL',
+          canned: '', id: accountToVet,
+          response: falseArrayBucketTrueArrayObject },
         { it: 'should allow access to user if account was granted FULL_CONTROL',
           canned: '', id: accountToVet, response: trueArray,
           aclParam: ['FULL_CONTROL', accountToVet] },


### PR DESCRIPTION
When setting the 'public-read' ACL permission of the object, any account can get an object (objectGet) / get its metadata (objectHead) even if the account has no right to the bucket