### PR TITLE
should not return sse key id unless sse is aws:kms

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -22,7 +22,8 @@ function collectResponseHeaders(objectMD) {
         responseMetaHeaders['x-amz-server-side-encryption']
             = objectMD['x-amz-server-side-encryption'];
     }
-    if (objectMD['x-amz-server-side-encryption-aws-kms-key-id']) {
+    if (objectMD['x-amz-server-side-encryption-aws-kms-key-id'] &&
+        objectMD['x-amz-server-side-encryption'] === 'aws:kms') {
         responseMetaHeaders['x-amz-server-side-encryption-aws-kms-key-id']
             = objectMD['x-amz-server-side-encryption-aws-kms-key-id'];
     }


### PR DESCRIPTION
by return, I mean in the response header