### PR TITLE
FT: Add push metrics for more routes

### DIFF
--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -8,6 +8,8 @@ function _pushMetrics(err, utapi, action, resource) {
             utapi.pushMetricDeleteBucket(resource, timestamp);
         } else if (action === 'objectDelete') {
             utapi.pushMetricDeleteObject(resource, timestamp);
+        } else if (action === 'multipartDelete') {
+            utapi.pushMetricAbortMultipartUpload(resource, timestamp);
         }
     }
 }
@@ -24,10 +26,12 @@ export default function routeDELETE(request, response, log, utapi) {
     } else {
         if (request.query.uploadId) {
             api.callApiMethod('multipartDelete', request, log,
-                (err, resHeaders) =>
-                    routesUtils.responseNoBody(err, resHeaders, response, 204,
-                        log)
-            );
+                (err, resHeaders) => {
+                    _pushMetrics(err, utapi, 'multipartDelete',
+                        request.bucketName);
+                    return routesUtils.responseNoBody(err, resHeaders, response,
+                        204, log);
+                });
         } else {
             api.callApiMethod('objectDelete', request, log,
               (err, resHeaders) => {

--- a/lib/routes/routeHEAD.js
+++ b/lib/routes/routeHEAD.js
@@ -1,16 +1,31 @@
 import api from '../api/api';
 import routesUtils from './routesUtils';
 
-export default function routeHEAD(request, response, log) {
+function _pushMetrics(err, utapi, action, resource) {
+    if (!err) {
+        const timestamp = Date.now();
+        if (action === 'bucketHead') {
+            utapi.pushMetricHeadBucket(resource, timestamp);
+        } else if (action === 'objectHead') {
+            utapi.pushMetricHeadObject(resource, timestamp);
+        }
+    }
+}
+
+export default function routeHEAD(request, response, log, utapi) {
     log.debug('routing request', { method: 'routeHEAD' });
     // HEAD bucket
     if (request.objectKey === undefined) {
-        api.callApiMethod('bucketHead', request, log, (err, resHeaders) =>
-            routesUtils.responseNoBody(err, resHeaders, response, 200, log));
+        api.callApiMethod('bucketHead', request, log, (err, resHeaders) => {
+            _pushMetrics(err, utapi, 'bucketHead', request.bucketName);
+            return routesUtils.responseNoBody(err, resHeaders, response, 200,
+                log);
+        });
     } else {
         // HEAD object
         api.callApiMethod('objectHead', request, log, (err, resHeaders) => {
-            routesUtils.responseContentHeaders(err, {}, resHeaders,
+            _pushMetrics(err, utapi, 'objectHead', request.bucketName);
+            return routesUtils.responseContentHeaders(err, {}, resHeaders,
                                                response, log);
         });
     }

--- a/lib/routes/routePOST.js
+++ b/lib/routes/routePOST.js
@@ -3,7 +3,18 @@ import { errors } from 'arsenal';
 import api from '../api/api';
 import routesUtils from './routesUtils';
 
-export default function routePOST(request, response, log) {
+function _pushMetrics(err, utapi, action, resource) {
+    if (!err) {
+        const timestamp = Date.now();
+        if (action === 'initiateMultipartUpload') {
+            utapi.pushMetricInitiateMultipartUpload(resource, timestamp);
+        } else if (action === 'completeMultipartUpload') {
+            utapi.pushMetricCompleteMultipartUpload(resource, timestamp);
+        }
+    }
+}
+
+export default function routePOST(request, response, log, utapi) {
     log.debug('routing request', { method: 'routePOST' });
     request.post = '';
 
@@ -17,13 +28,19 @@ export default function routePOST(request, response, log) {
             // POST multipart upload
             api.callApiMethod('initiateMultipartUpload', request, log,
                 (err, result) => {
-                    routesUtils.responseXMLBody(err, result, response, log);
+                    _pushMetrics(err, utapi, 'initiateMultipartUpload',
+                        request.bucketName);
+                    return routesUtils.responseXMLBody(err, result, response,
+                        log);
                 });
         } else if (request.query.uploadId !== undefined) {
             // POST complete multipart upload
             api.callApiMethod('completeMultipartUpload', request, log,
                 (err, result) => {
-                    routesUtils.responseXMLBody(err, result, response, log);
+                    _pushMetrics(err, utapi, 'completeMultipartUpload',
+                        request.bucketName);
+                    return routesUtils.responseXMLBody(err, result, response,
+                        log);
                 });
         } else {
             routesUtils.responseNoBody(errors.InternalError, null, response,


### PR DESCRIPTION
This commit adds push metrics support on bucket level for
 - Initiate Multipart Upload
 - Complete Multipart Upload
 - Abort Multipart Upload
 - Head Bucket
 - Head Object