### PR TITLE
FIX: Ensure bucket is empty at end of test.

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/objectOverwrite.js
+++ b/tests/functional/aws-node-sdk/test/object/objectOverwrite.js
@@ -43,7 +43,9 @@ describe('Put object with same key as prior object', () => {
             assert.deepStrictEqual(res.Metadata, firstPutMetadata);
         }));
 
-        afterEach(() => bucketUtil.empty(bucketName));
+        afterEach(done => {
+            bucketUtil.empty(bucketName).then(() => done());
+        });
 
         after(() => bucketUtil.deleteOne(bucketName));
 


### PR DESCRIPTION
Without this change, the after all delete was being
attempted before the bucket was empty.

This closes https://github.com/scality/S3/issues/160
