### PR TITLE
FT: disable utapi by default

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,14 +27,6 @@
         "host": "localhost",
         "port": 8500
     },
-    "utapi": {
-        "port": 8100,
-        "workers": 5,
-        "redis": {
-            "host": "localhost",
-            "port": 6379
-        }
-    },
     "clusters": 10,
     "log": {
         "logLevel": "info",


### PR DESCRIPTION
Currently it is filling up logs with push metrics errors on a default
install. Changing this to be enabled on-demand.