### PR TITLE
Cleanup/remove utapi timestamp

### DIFF
--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -1,27 +1,13 @@
 import api from '../api/api';
 import routesUtils from './routesUtils';
-
-function _pushMetrics(err, log, utapi, action, resource, contentLength) {
-    if (!err) {
-        const timestamp = Date.now();
-        const reqUid = log.getSerializedUids();
-        if (action === 'bucketDelete') {
-            utapi.pushMetricDeleteBucket(reqUid, resource, timestamp);
-        } else if (action === 'objectDelete') {
-            utapi.pushMetricDeleteObject(reqUid, resource, timestamp,
-                contentLength);
-        } else if (action === 'multipartDelete') {
-            utapi.pushMetricAbortMultipartUpload(reqUid, resource, timestamp);
-        }
-    }
-}
+import pushMetrics from '../utilities/pushMetrics';
 
 export default function routeDELETE(request, response, log, utapi) {
     log.debug('routing request', { method: 'routeDELETE' });
 
     if (request.objectKey === undefined) {
         api.callApiMethod('bucketDelete', request, log, (err, resHeaders) => {
-            _pushMetrics(err, log, utapi, 'bucketDelete', request.bucketName);
+            pushMetrics(err, log, utapi, 'bucketDelete', request.bucketName);
             return routesUtils.responseNoBody(err, resHeaders, response, 204,
                 log);
         });
@@ -29,7 +15,7 @@ export default function routeDELETE(request, response, log, utapi) {
         if (request.query.uploadId) {
             api.callApiMethod('multipartDelete', request, log,
                 (err, resHeaders) => {
-                    _pushMetrics(err, log, utapi, 'multipartDelete',
+                    pushMetrics(err, log, utapi, 'multipartDelete',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, resHeaders, response,
                         204, log);
@@ -46,7 +32,7 @@ export default function routeDELETE(request, response, log, utapi) {
                       return routesUtils.responseNoBody(err, null,
                         response, null, log);
                   }
-                  _pushMetrics(err, log, utapi, 'objectDelete',
+                  pushMetrics(err, log, utapi, 'objectDelete',
                     request.bucketName, contentLength);
                   return routesUtils.responseNoBody(null, null, response,
                     204, log);

--- a/lib/routes/routeGET.js
+++ b/lib/routes/routeGET.js
@@ -1,29 +1,7 @@
 import api from '../api/api';
 import { errors } from 'arsenal';
 import routesUtils from './routesUtils';
-
-function _pushMetrics(err, log, utapi, action, resource, contentLength) {
-    if (!err) {
-        const timestamp = Date.now();
-        const reqUid = log.getSerializedUids();
-        if (action === 'bucketGetACL') {
-            utapi.pushMetricGetBucketAcl(reqUid, resource, timestamp);
-        } else if (action === 'listMultipartUploads') {
-            utapi.pushMetricListBucketMultipartUploads(reqUid, resource,
-                timestamp);
-        } else if (action === 'bucketGet') {
-            utapi.pushMetricListBucket(reqUid, resource, timestamp);
-        } else if (action === 'objectGetACL') {
-            utapi.pushMetricGetObjectAcl(reqUid, resource, timestamp);
-        } else if (action === 'listParts') {
-            utapi.pushMetricListMultipartUploadParts(reqUid, resource,
-                timestamp);
-        } else if (action === 'objectGet') {
-            utapi.pushMetricGetObject(reqUid, resource, timestamp,
-                contentLength);
-        }
-    }
-}
+import pushMetrics from '../utilities/pushMetrics';
 
 export default function routerGET(request, response, log, utapi) {
     log.debug('routing request', { method: 'routerGET' });
@@ -38,7 +16,7 @@ export default function routerGET(request, response, log, utapi) {
         // GET bucket ACL
         if (request.query.acl !== undefined) {
             api.callApiMethod('bucketGetACL', request, log, (err, xml) => {
-                _pushMetrics(err, log, utapi, 'bucketGetACL',
+                pushMetrics(err, log, utapi, 'bucketGetACL',
                     request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
@@ -46,14 +24,14 @@ export default function routerGET(request, response, log, utapi) {
             // List MultipartUploads
             api.callApiMethod('listMultipartUploads', request, log,
                 (err, xml) => {
-                    _pushMetrics(err, log, utapi, 'listMultipartUploads',
+                    pushMetrics(err, log, utapi, 'listMultipartUploads',
                         request.bucketName);
                     return routesUtils.responseXMLBody(err, xml, response, log);
                 });
         } else {
             // GET bucket
             api.callApiMethod('bucketGet', request, log, (err, xml) => {
-                _pushMetrics(err, log, utapi, 'bucketGet', request.bucketName);
+                pushMetrics(err, log, utapi, 'bucketGet', request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
         }
@@ -61,14 +39,14 @@ export default function routerGET(request, response, log, utapi) {
         if (request.query.acl !== undefined) {
             // GET object ACL
             api.callApiMethod('objectGetACL', request, log, (err, xml) => {
-                _pushMetrics(err, log, utapi, 'objectGetACL',
+                pushMetrics(err, log, utapi, 'objectGetACL',
                     request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
             // List parts of an open multipart upload
         } else if (request.query.uploadId !== undefined) {
             api.callApiMethod('listParts', request, log, (err, xml) => {
-                _pushMetrics(err, log, utapi, 'listParts', request.bucketName);
+                pushMetrics(err, log, utapi, 'listParts', request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
         } else {
@@ -80,7 +58,7 @@ export default function routerGET(request, response, log, utapi) {
                     contentLength = resMetaHeaders['Content-Length'];
                 }
                 log.end().addDefaultFields({ contentLength });
-                _pushMetrics(err, log, utapi, 'objectGet', request.bucketName,
+                pushMetrics(err, log, utapi, 'objectGet', request.bucketName,
                     contentLength);
                 return routesUtils.responseStreamData(err, request.headers,
                     resMetaHeaders, dataGetInfo, response, range, log);

--- a/lib/routes/routeHEAD.js
+++ b/lib/routes/routeHEAD.js
@@ -1,18 +1,7 @@
 import api from '../api/api';
 import { errors } from 'arsenal';
 import routesUtils from './routesUtils';
-
-function _pushMetrics(err, log, utapi, action, resource) {
-    if (!err) {
-        const timestamp = Date.now();
-        const reqUid = log.getSerializedUids();
-        if (action === 'bucketHead') {
-            utapi.pushMetricHeadBucket(reqUid, resource, timestamp);
-        } else if (action === 'objectHead') {
-            utapi.pushMetricHeadObject(reqUid, resource, timestamp);
-        }
-    }
-}
+import pushMetrics from '../utilities/pushMetrics';
 
 export default function routeHEAD(request, response, log, utapi) {
     log.debug('routing request', { method: 'routeHEAD' });
@@ -23,14 +12,14 @@ export default function routeHEAD(request, response, log, utapi) {
     } else if (request.objectKey === undefined) {
         // HEAD bucket
         api.callApiMethod('bucketHead', request, log, (err, resHeaders) => {
-            _pushMetrics(err, log, utapi, 'bucketHead', request.bucketName);
+            pushMetrics(err, log, utapi, 'bucketHead', request.bucketName);
             return routesUtils.responseNoBody(err, resHeaders, response, 200,
                 log);
         });
     } else {
         // HEAD object
         api.callApiMethod('objectHead', request, log, (err, resHeaders) => {
-            _pushMetrics(err, log, utapi, 'objectHead', request.bucketName);
+            pushMetrics(err, log, utapi, 'objectHead', request.bucketName);
             return routesUtils.responseContentHeaders(err, {}, resHeaders,
                                                response, log);
         });

--- a/lib/routes/routePOST.js
+++ b/lib/routes/routePOST.js
@@ -2,20 +2,7 @@ import { errors } from 'arsenal';
 
 import api from '../api/api';
 import routesUtils from './routesUtils';
-
-function _pushMetrics(err, log, utapi, action, resource) {
-    if (!err) {
-        const timestamp = Date.now();
-        const reqUid = log.getSerializedUids();
-        if (action === 'initiateMultipartUpload') {
-            utapi.pushMetricInitiateMultipartUpload(reqUid, resource,
-                timestamp);
-        } else if (action === 'completeMultipartUpload') {
-            utapi.pushMetricCompleteMultipartUpload(reqUid, resource,
-                timestamp);
-        }
-    }
-}
+import pushMetrics from '../utilities/pushMetrics';
 
 export default function routePOST(request, response, log, utapi) {
     log.debug('routing request', { method: 'routePOST' });
@@ -31,7 +18,7 @@ export default function routePOST(request, response, log, utapi) {
             // POST multipart upload
             api.callApiMethod('initiateMultipartUpload', request, log,
                 (err, result) => {
-                    _pushMetrics(err, log, utapi, 'initiateMultipartUpload',
+                    pushMetrics(err, log, utapi, 'initiateMultipartUpload',
                         request.bucketName);
                     return routesUtils.responseXMLBody(err, result, response,
                         log);
@@ -40,7 +27,7 @@ export default function routePOST(request, response, log, utapi) {
             // POST complete multipart upload
             api.callApiMethod('completeMultipartUpload', request, log,
                 (err, result) => {
-                    _pushMetrics(err, log, utapi, 'completeMultipartUpload',
+                    pushMetrics(err, log, utapi, 'completeMultipartUpload',
                         request.bucketName);
                     return routesUtils.responseXMLBody(err, result, response,
                         log);

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -4,28 +4,8 @@ import { parseString } from 'xml2js';
 import api from '../api/api';
 import routesUtils from './routesUtils';
 import utils from '../utils';
+import pushMetrics from '../utilities/pushMetrics';
 import constants from '../../constants';
-
-function _pushMetrics(err, log, utapi, action, resource, contentLength,
-    prevContentLen) {
-    if (!err) {
-        const timestamp = Date.now();
-        const reqUid = log.getSerializedUids();
-        if (action === 'bucketPutACL') {
-            utapi.pushMetricPutBucketAcl(reqUid, resource, timestamp);
-        } else if (action === 'bucketPut') {
-            utapi.pushMetricCreateBucket(reqUid, resource, timestamp);
-        } else if (action === 'objectPutPart') {
-            utapi.pushMetricUploadPart(reqUid, resource, timestamp,
-                contentLength);
-        } else if (action === 'objectPutACL') {
-            utapi.pushMetricPutObjectAcl(reqUid, resource, timestamp);
-        } else if (action === 'objectPut') {
-            utapi.pushMetricPutObject(reqUid, resource, timestamp,
-                contentLength, prevContentLen);
-        }
-    }
-}
 
 export default function routePUT(request, response, log, utapi) {
     log.debug('routing request', { method: 'routePUT' });
@@ -38,7 +18,7 @@ export default function routePUT(request, response, log, utapi) {
             // PUT bucket ACL
             if (request.query.acl !== undefined) {
                 api.callApiMethod('bucketPutACL', request, log, err => {
-                    _pushMetrics(err, log, utapi, 'bucketPutACL',
+                    pushMetrics(err, log, utapi, 'bucketPutACL',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
                         log);
@@ -65,7 +45,7 @@ export default function routePUT(request, response, log, utapi) {
                             { locationConstraint });
                         return api.callApiMethod('bucketPut', request, log,
                         err => {
-                            _pushMetrics(err, log, utapi, 'bucketPut',
+                            pushMetrics(err, log, utapi, 'bucketPut',
                                 request.bucketName);
                             return routesUtils.responseNoBody(err, null,
                               response, 200, log);
@@ -73,7 +53,7 @@ export default function routePUT(request, response, log, utapi) {
                     });
                 }
                 return api.callApiMethod('bucketPut', request, log, err => {
-                    _pushMetrics(err, log, utapi, 'bucketPut',
+                    pushMetrics(err, log, utapi, 'bucketPut',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
                         log);
@@ -106,7 +86,7 @@ export default function routePUT(request, response, log, utapi) {
             api.callApiMethod('objectPutPart', request, log, err => {
                 // ETag's hex should always be enclosed in quotes
                 const resMetaHeaders = { ETag: `"${request.calculatedHash}"` };
-                _pushMetrics(err, log, utapi, 'objectPutPart',
+                pushMetrics(err, log, utapi, 'objectPutPart',
                     request.bucketName, request.headers['content-length']);
                 routesUtils.responseNoBody(err, resMetaHeaders, response,
                     200, log);
@@ -116,7 +96,7 @@ export default function routePUT(request, response, log, utapi) {
             request.on('data', chunk => request.post += chunk.toString());
             request.on('end', () => {
                 api.callApiMethod('objectPutACL', request, log, err => {
-                    _pushMetrics(err, log, utapi, 'objectPutACL',
+                    pushMetrics(err, log, utapi, 'objectPutACL',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
                         log);
@@ -152,7 +132,7 @@ export default function routePUT(request, response, log, utapi) {
                     const resMetaHeaders = {
                         ETag: `"${request.calculatedHash}"`,
                     };
-                    _pushMetrics(err, log, utapi, 'objectPut',
+                    pushMetrics(err, log, utapi, 'objectPut',
                         request.bucketName, request.headers['content-length'],
                         prevContentLen);
                     return routesUtils.responseNoBody(err, resMetaHeaders,

--- a/lib/utilities/pushMetrics.js
+++ b/lib/utilities/pushMetrics.js
@@ -1,0 +1,64 @@
+export default function pushMetrics(err, log, utapi, action, resource,
+    contentLength, prevContentLen) {
+    if (!err) {
+        const reqUid = log.getSerializedUids();
+        switch (action) {
+        case 'bucketPutACL':
+            utapi.pushMetricPutBucketAcl(reqUid, resource);
+            break;
+        case 'bucketPut':
+            utapi.pushMetricCreateBucket(reqUid, resource);
+            break;
+        case 'objectPutPart':
+            utapi.pushMetricUploadPart(reqUid, resource, contentLength);
+            break;
+        case 'objectPutACL':
+            utapi.pushMetricPutObjectAcl(reqUid, resource);
+            break;
+        case 'objectPut':
+            utapi.pushMetricPutObject(reqUid, resource, contentLength,
+                prevContentLen);
+            break;
+        case 'bucketGetACL':
+            utapi.pushMetricGetBucketAcl(reqUid, resource);
+            break;
+        case 'listMultipartUploads':
+            utapi.pushMetricListBucketMultipartUploads(reqUid, resource);
+            break;
+        case 'bucketGet':
+            utapi.pushMetricListBucket(reqUid, resource);
+            break;
+        case 'objectGetACL':
+            utapi.pushMetricGetObjectAcl(reqUid, resource);
+            break;
+        case 'listParts':
+            utapi.pushMetricListMultipartUploadParts(reqUid, resource);
+            break;
+        case 'objectGet':
+            utapi.pushMetricGetObject(reqUid, resource, contentLength);
+            break;
+        case 'bucketHead':
+            utapi.pushMetricHeadBucket(reqUid, resource);
+            break;
+        case 'objectHead':
+            utapi.pushMetricHeadObject(reqUid, resource);
+            break;
+        case 'bucketDelete':
+            utapi.pushMetricDeleteBucket(reqUid, resource);
+            break;
+        case 'objectDelete':
+            utapi.pushMetricDeleteObject(reqUid, resource, contentLength);
+            break;
+        case 'multipartDelete':
+            utapi.pushMetricAbortMultipartUpload(reqUid, resource);
+            break;
+        case 'initiateMultipartUpload':
+            utapi.pushMetricInitiateMultipartUpload(reqUid, resource);
+            break;
+        case 'completeMultipartUpload':
+            utapi.pushMetricCompleteMultipartUpload(reqUid, resource);
+            break;
+        default: throw new Error('Unkown action for push metrics');
+        }
+    }
+}


### PR DESCRIPTION
Removes timestamp generation for push metrics as it will be managed by the UtapiClient itself. Additionally, the code for push metrics has been cleanup as a utility instead.
