### PR TITLE
fix: pass null for push metrics on object put

### DIFF
--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -54,8 +54,11 @@ function _storeIt(bucketName, objectKey, objMD, authInfo, canonicalID,
         dataToDelete = Array.isArray(objMD.location) ?
             objMD.location : [objMD.location];
     }
+
+    // null - new object
+    // 0 or > 0 - existing object with content-length 0 or greater than 0
     const prevContentLen = objMD && objMD['content-length'] ?
-        objMD['content-length'] : 0;
+        objMD['content-length'] : null;
     if (size !== 0) {
         log.trace('storing object in data', {
             method: 'services.metadataValidateAuthorization',


### PR DESCRIPTION
pushMetrics call for object PUT uses the content-length to calculate
incoming bytes, number of object counters. A null would indicate that
the object is created new and any number 0 or greater than 0 indicates
an existing object which would not alter the count of number of objects
in the bucket.

fixes #198