### PR TITLE
Data file backend: fix bug for put operation

### DIFF
--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -37,40 +37,39 @@ export const backend = {
         // Consider making async
         const key = crypto.randomBytes(20).toString('hex');
         const filePath = getFilePath(key);
-
         request.pause();
-
         fs.open(filePath, 'wx', (err, fd) => {
             if (err) {
                 log.error('error opening filePath', { error: err });
                 return callback(errors.InternalError);
             }
+            const fileStream = fs.createWriteStream(filePath, { fd });
+
             request.resume();
-            return request.on('data', data => {
-                // Disable data events as we need to wait for fs.write callback
-                request.pause();
-                return fs.write(fd, data, 0, data.length,
-                    err => {
-                        if (err) {
-                            log.error('error writing data', { error: err });
-                            fs.close(fd);
-                            return callback(errors.InternalError);
-                        }
-                        return request.resume(); // Allow data events again
-                    });
-            })
-            .on('error', err => {
-                log.error('error streaming data from request', { error: err });
-                fs.close(fd);
+            request.pipe(fileStream, { end: false }).on('error', err => {
+                log.error('error streaming data from request on write',
+                    { error: err });
                 return callback(errors.InternalError);
-            })
-            .on('end', () => {
-                log.debug('finished writing data', { key });
-                fs.fsync(fd, () => {
-                    fs.close(fd);
+            });
+            request.on('error', err => {
+                log.error('error streaming data from request on read',
+                    { error: err });
+                // close fileStream
+                return fs.close(fd, () => callback(errors.InternalError));
+            }).on('end', () => {
+                fs.fsync(fd, err => {
+                    fileStream.end();
+                    if (err) {
+                        log.error('error streaming data from request on fsync',
+                            { error: err });
+                        return callback(errors.InternalError);
+                    }
+                    log.debug('finished writing data', { key });
                     return callback(null, key);
                 });
+                return undefined;
             });
+            return undefined;
         });
     },
 


### PR DESCRIPTION
Fix #206 
It's possible that stream ends before the `fs.write` operation finishes.
Double checks to make sure that only one callback returns.