### PR TITLE
Cleanup/remove babel ignores

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,4 @@
 'use strict'; // eslint-disable-line strict
 
-require('babel-core/register')({
-    ignore: filename =>
-        !(filename.startsWith(`${__dirname}/constants.js`) ||
-        filename.startsWith(`${__dirname}/lib/`) ||
-        filename.startsWith(`${__dirname}/tests/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/lib/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/utils/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/router/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/responses/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/validators/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/handlers/`)),
-});
+require('babel-core/register')();
 require('./lib/server.js').default();

--- a/utapiServer.js
+++ b/utapiServer.js
@@ -1,16 +1,4 @@
 'use strict'; // eslint-disable-line strict
 
-require('babel-core/register')({
-    ignore: filename =>
-        !(filename.startsWith(`${__dirname}/constants.js`) ||
-        filename.startsWith(`${__dirname}/lib/`) ||
-        filename.startsWith(`${__dirname}/tests/`) ||
-        filename.startsWith(`${__dirname}/utapi/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/lib/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/utils/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/router/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/responses/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/validators/`) ||
-        filename.startsWith(`${__dirname}/node_modules/utapi/handlers/`)),
-});
+require('babel-core/register')();
 require('./lib/utapi/utapi.js').default();


### PR DESCRIPTION
As utapi is being compiled on post install, it doesn't require babel
transpiling.

Fix #155
