### PR TITLE
FT: add CMDI data backend

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,6 +23,11 @@
                         "s3-website-sa-east-1.amazonaws.com",
                         "s3-website.localhost",
                         "s3-website.scality.test"],
+    "cdmi": {
+        "host": "localhost",
+        "port": 81,
+        "path": "/dewpoint"
+    },
     "bucketd": {
         "bootstrap": ["localhost"]
     },

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -302,6 +302,29 @@ class Config {
                 'Please use restEndpoints and locationConfig');
         }
 
+        this.cdmi = {};
+        if (config.cdmi !== undefined) {
+            if (config.cdmi.host !== undefined) {
+                assert.strictEqual(typeof config.cdmi.host, 'string',
+                                   'bad config: cdmi host must be a string');
+                this.cdmi.host = config.cdmi.host;
+            }
+            if (config.cdmi.port !== undefined) {
+                assert(Number.isInteger(config.cdmi.port)
+                       && config.cdmi.port > 0,
+                       'bad config: cdmi port must be a positive integer');
+                this.cdmi.port = config.cdmi.port;
+            }
+            if (config.cdmi.path !== undefined) {
+                assert(typeof config.cdmi.path === 'string',
+                       'bad config: cdmi.path must be a string');
+                assert(config.cdmi.path.length > 0,
+                       'bad config: cdmi.path is empty');
+                assert(config.cdmi.path.charAt(0) === '/',
+                       'bad config: cdmi.path should start with a "/"');
+            }
+        }
+
         this.bucketd = { bootstrap: [] };
         if (config.bucketd !== undefined
                 && config.bucketd.bootstrap !== undefined) {
@@ -601,10 +624,10 @@ class Config {
         let metadata = 'file';
         let kms = 'file';
         if (process.env.S3BACKEND) {
-            const validBackends = ['mem', 'file', 'scality'];
+            const validBackends = ['mem', 'file', 'scality', 'cdmi'];
             assert(validBackends.indexOf(process.env.S3BACKEND) > -1,
                 'bad environment variable: S3BACKEND environment variable ' +
-                'should be one of mem/file/scality'
+                'should be one of mem/file/scality/cdmi'
             );
             auth = process.env.S3BACKEND;
             data = process.env.S3BACKEND;
@@ -614,7 +637,7 @@ class Config {
         if (process.env.S3VAULT) {
             auth = process.env.S3VAULT;
         }
-        if (auth === 'file' || auth === 'mem') {
+        if (auth === 'file' || auth === 'mem' || auth === 'cdmi') {
             // Auth only checks for 'mem' since mem === file
             auth = 'mem';
             let authfile = `${__dirname}/../conf/authdata.json`;

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -4,12 +4,18 @@ const { errors } = require('arsenal');
 const DataFileInterface = require('./file/backend');
 const inMemory = require('./in_memory/backend').backend;
 const multipleBackendGateway = require('./multipleBackendGateway');
-const CdmiData = require('cdmiclient').CdmiData;
 const { config } = require('../Config');
 const MD5Sum = require('../utilities/MD5Sum');
 const assert = require('assert');
 const kms = require('../kms/wrapper');
 const externalBackends = require('../../constants').externalBackends;
+
+let CdmiData;
+try {
+    CdmiData = require('cdmiclient').CdmiData;
+} catch (err) {
+    CdmiData = null;
+}
 
 let client;
 let implName;
@@ -24,6 +30,10 @@ if (config.backends.data === 'mem') {
     client = multipleBackendGateway;
     implName = 'multipleBackends';
 } else if (config.backends.data === 'cdmi') {
+    if (!CdmiData) {
+        throw new Error('Unauthorized backend');
+    }
+
     client = new CdmiData({
         path: config.cdmi.path,
         host: config.cdmi.host,

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -4,6 +4,7 @@ const { errors } = require('arsenal');
 const DataFileInterface = require('./file/backend');
 const inMemory = require('./in_memory/backend').backend;
 const multipleBackendGateway = require('./multipleBackendGateway');
+const CdmiData = require('cdmiclient').CdmiData;
 const { config } = require('../Config');
 const MD5Sum = require('../utilities/MD5Sum');
 const assert = require('assert');
@@ -22,6 +23,14 @@ if (config.backends.data === 'mem') {
 } else if (config.backends.data === 'multiple') {
     client = multipleBackendGateway;
     implName = 'multipleBackends';
+} else if (config.backends.data === 'cdmi') {
+    client = new CdmiData({
+        path: config.cdmi.path,
+        host: config.cdmi.host,
+        port: config.cdmi.port,
+        log: config.log,
+    });
+    implName = 'cdmi';
 }
 
 /**
@@ -103,7 +112,7 @@ const data = {
     get: (objectGetInfo, response, log, cb) => {
         // If objectGetInfo.key exists the md-model-version is 2 or greater.
         // Otherwise, the objectGetInfo is just the key string.
-        const objGetInfo = (implName === 'sproxyd') ?
+        const objGetInfo = (implName === 'sproxyd' || implName === 'cdmi') ?
             objectGetInfo.key : objectGetInfo;
         const range = objectGetInfo.range;
         log.debug('sending get to datastore', { implName,
@@ -150,7 +159,7 @@ const data = {
         const callback = cb || log.end;
         // If objectGetInfo.key exists the md-model-version is 2 or greater.
         // Otherwise, the objectGetInfo is just the key string.
-        const objGetInfo = (implName === 'sproxyd') ?
+        const objGetInfo = (implName === 'sproxyd' || implName === 'cdmi') ?
             objectGetInfo.key : objectGetInfo;
         log.trace('sending delete to datastore', {
             implName,

--- a/lib/kms/wrapper.js
+++ b/lib/kms/wrapper.js
@@ -26,7 +26,7 @@ let implName;
 if (config.backends.kms === 'mem') {
     client = inMemory;
     implName = 'memoryKms';
-} else if (config.backends.kms === 'file') {
+} else if (config.backends.kms === 'file' || config.backends.kms === 'cdmi') {
     client = file;
     implName = 'fileKms';
 } else if (config.backends.kms === 'scality') {

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -4,6 +4,7 @@ const BucketClientInterface = require('./bucketclient/backend');
 const BucketFileInterface = require('./bucketfile/backend');
 const BucketInfo = require('arsenal').models.BucketInfo;
 const inMemory = require('./in_memory/backend');
+const CdmiMetadata = require('cdmiclient').CdmiMetadata;
 const { config } = require('../Config');
 
 let client;
@@ -18,6 +19,14 @@ if (config.backends.metadata === 'mem') {
 } else if (config.backends.metadata === 'scality') {
     client = new BucketClientInterface();
     implName = 'bucketclient';
+} else if (config.backends.metadata === 'cdmi') {
+    client = new CdmiMetadata({
+        path: config.cdmi.path,
+        host: config.cdmi.host,
+        port: config.cdmi.port,
+        log: config.log,
+    });
+    implName = 'cdmi';
 }
 
 const metadata = {

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -4,8 +4,14 @@ const BucketClientInterface = require('./bucketclient/backend');
 const BucketFileInterface = require('./bucketfile/backend');
 const BucketInfo = require('arsenal').models.BucketInfo;
 const inMemory = require('./in_memory/backend');
-const CdmiMetadata = require('cdmiclient').CdmiMetadata;
 const { config } = require('../Config');
+
+let CdmiMetadata;
+try {
+    CdmiMetadata = require('cdmiclient').CdmiMetadata;
+} catch (err) {
+    CdmiMetadata = null;
+}
 
 let client;
 let implName;
@@ -20,6 +26,10 @@ if (config.backends.metadata === 'mem') {
     client = new BucketClientInterface();
     implName = 'bucketclient';
 } else if (config.backends.metadata === 'cdmi') {
+    if (!CdmiMetadata) {
+        throw new Error('Unauthorized backend');
+    }
+
     client = new CdmiMetadata({
         path: config.cdmi.path,
         host: config.cdmi.host,

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "utf8": "~2.1.1",
     "vaultclient": "scality/vaultclient",
     "werelogs": "scality/werelogs",
-    "xml2js": "~0.4.16",
-    "cdmiclient": "scality/cdmiclient"
+    "xml2js": "~0.4.16"
   },
   "devDependencies": {
     "bluebird": "^3.3.1",
@@ -49,6 +48,9 @@
     "node-mocks-http": "^1.5.2",
     "s3blaster": "scality/s3blaster",
     "tv4": "^1.2.7"
+  },
+  "optionalDependencies": {
+    "cdmiclient": "scality/cdmiclient"
   },
   "scripts": {
     "ft_awssdk": "cd tests/functional/aws-node-sdk && mocha test/",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "utf8": "~2.1.1",
     "vaultclient": "scality/vaultclient",
     "werelogs": "scality/werelogs",
-    "xml2js": "~0.4.16"
+    "xml2js": "~0.4.16",
+    "cdmiclient": "scality/cdmiclient"
   },
   "devDependencies": {
     "bluebird": "^3.3.1",


### PR DESCRIPTION
This commit introduces the CDMI client data backend. A CDMI client
metadata backend will be added but for now, for testing purpose, when
the CDMI data backend is used, the metadata one is forced to be the file
one.
