### PR TITLE
FT: Fix crypto encoding

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -64,5 +64,6 @@ export default {
     minimumAllowedPartSize: 5242880,
 
     // hex digest of sha256 hash of empty string:
-    emptyStringHash: crypto.createHash('sha256').update('').digest('hex'),
+    emptyStringHash: crypto.createHash('sha256')
+        .update('', 'binary').digest('hex'),
 };

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -251,7 +251,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             const binaryString = bufferedHex.toString('binary');
             // Get the md5 of the binary string
             const md5Hash = crypto.createHash('md5');
-            md5Hash.update(binaryString);
+            md5Hash.update(binaryString, 'binary');
             // Get the hex digest of the md5
             let aggregateETag = md5Hash.digest('hex');
             // Add the number of parts at the end

--- a/lib/auth/in_memory/backend.js
+++ b/lib/auth/in_memory/backend.js
@@ -66,7 +66,7 @@ const backend = {
             .filter(kv => kv.access === accessKey)[0].secret;
         const signingKey = calculateSigningKey(secretKey, region, scopeDate);
         const reconstructedSig = crypto.createHmac('sha256', signingKey)
-            .update(stringToSign).digest('hex');
+            .update(stringToSign, 'binary').digest('hex');
         if (signatureFromRequest !== reconstructedSig) {
             return callback(errors.SignatureDoesNotMatch);
         }

--- a/lib/auth/in_memory/vaultUtilities.js
+++ b/lib/auth/in_memory/vaultUtilities.js
@@ -8,7 +8,7 @@ import crypto from 'crypto';
  */
 export function hashSignature(stringToSign, secretKey, algorithm) {
     const hmacObject = crypto.createHmac(algorithm, secretKey);
-    return hmacObject.update(stringToSign).digest('base64');
+    return hmacObject.update(stringToSign, 'binary').digest('base64');
 }
 
 /** calculateSigningKey for v4 Auth
@@ -19,12 +19,12 @@ export function hashSignature(stringToSign, secretKey, algorithm) {
  */
 export function calculateSigningKey(secretKey, region, scopeDate) {
     const dateKey = crypto.createHmac('sha256', `AWS4${secretKey}`)
-        .update(scopeDate).digest('binary');
+        .update(scopeDate, 'binary').digest();
     const dateRegionKey = crypto.createHmac('sha256', dateKey)
-        .update(region).digest('binary');
+        .update(region, 'binary').digest();
     const dateRegionServiceKey = crypto.createHmac('sha256', dateRegionKey)
-        .update('s3').digest('binary');
+        .update('s3', 'binary').digest();
     const signingKey = crypto.createHmac('sha256', dateRegionServiceKey)
-        .update('aws4_request').digest('binary');
+        .update('aws4_request', 'binary').digest('binary');
     return signingKey;
 }

--- a/lib/auth/streamingV4/constructChunkStringToSign.js
+++ b/lib/auth/streamingV4/constructChunkStringToSign.js
@@ -21,7 +21,8 @@ export default function constructChunkStringToSign(timestamp,
         currentChunkHash = constants.emptyStringHash;
     } else {
         currentChunkHash = crypto.createHash('sha256');
-        currentChunkHash = currentChunkHash.update(justDataChunk).digest('hex');
+        currentChunkHash = currentChunkHash
+            .update(justDataChunk, 'binary').digest('hex');
     }
     return `AWS4-HMAC-SHA256-PAYLOAD\n${timestamp}\n` +
         `${credentialScope}\n${lastSignature}\n` +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -159,7 +159,8 @@ utils.isValidBucketName = function isValidBucketName(bucketname) {
 };
 
 utils.getContentMD5 = function getContentMD5(requestBody) {
-    return crypto.createHash('md5').update(requestBody).digest('base64');
+    return crypto.createHash('md5')
+        .update(requestBody, 'binary').digest('base64');
 };
 
 /**
@@ -201,7 +202,8 @@ utils.getMetaHeaders = function getMetaHeaders(headers) {
  * @return {string} hash to use as bucket key or object key
  */
 utils.getResourceUID = function getResourceUID(namespace, resource) {
-    return crypto.createHash('md5').update(namespace + resource).digest('hex');
+    return crypto.createHash('md5')
+        .update(namespace + resource, 'binary').digest('hex');
 };
 
 


### PR DESCRIPTION
in Node v4, default crypto encoding is binary, this
PR specify this encoding to avoid any change in the future
(node v6 in mind)