### PR TITLE
Dockerfile for mem backend

### DIFF
--- a/DockerfileMem
+++ b/DockerfileMem
@@ -1,0 +1,11 @@
+FROM node:4
+MAINTAINER Giorgio Regni <gr@scality.com>
+
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+RUN npm install
+ENV S3BACKEND mem
+CMD [ "npm", "start" ]
+
+EXPOSE 8000


### PR DESCRIPTION
We are starting adding some kind of versioning for our S3 Docker image.

On Docker, we are now pushing four tags every time we generate a new S3 image:

- **file backend** : `latest` and `HASHCOMMIT`
- **in-memory backend**: `mem-latest` and `mem-HASHCOMMIT`

I started doing it here: https://hub.docker.com/r/scality/s3server/tags/
I will add a _Supported tags and respective Dockerfile links_ inside our [scality/s3server Docker repo](https://hub.docker.com/r/scality/s3server/)

We will use [DockerfileMem](https://github.com/scality/S3/blob/dev/Dockerfile-mem/DockerfileMem) for our in-memory backend S3 image.
`docker build -t 's3mem' -f 'DockerfileMem' ./`