### PR TITLE
BF: Log errors or return errors from MD

### DIFF
--- a/lib/services.js
+++ b/lib/services.js
@@ -450,6 +450,7 @@ export default {
             metadata.putObjectMD(bucketName, longMPUIdentifier,
                 multipartObjectMD, log, (err) => {
                     if (err) {
+                        log.error('error from metadata', { error: err });
                         return cb(err);
                     }
                     return cb();
@@ -478,6 +479,7 @@ export default {
         const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
         metadata.getBucket(mpuBucketName, log, (err, mpuBucket) => {
             if (err) {
+                log.error('error from metadata', { error: err });
                 return cb(errors.NoSuchUpload);
             }
             let splitter = constants.splitter;
@@ -496,6 +498,7 @@ export default {
                 searchArgs.marker, searchArgs.delimiter, searchArgs.maxKeys,
                 log, (err, response) => {
                     if (err) {
+                        log.error('error from metadata', { error: err });
                         return cb(err);
                     }
                     if (response.Contents.length !== 1) {
@@ -629,6 +632,7 @@ export default {
         }
         metadata.putObjectMD(mpuBucketName, partKey, omVal, log, err => {
             if (err) {
+                log.error('error from metadata', { error: err });
                 return cb(err);
             }
             return cb(null);
@@ -649,6 +653,10 @@ export default {
         assert.strictEqual(typeof listingParams.splitter, 'string');
 
         metadata.getBucket(MPUbucketName, log, (err, bucket) => {
+            if (err) {
+                log.error('error from metadata', { error: err });
+                return cb(err);
+            }
             if (bucket === undefined) {
                 return cb(null, {
                     IsTruncated: false,
@@ -686,6 +694,7 @@ export default {
         const MPUBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
         metadata.getBucket(MPUBucketName, log, (err, bucket) => {
             if (err && err.NoSuchBucket) {
+                log.trace('no buckets found');
                 const creationDate = new Date().toJSON();
                 const mpuBucket = new BucketInfo(MPUBucketName,
                     destinationBucket.getOwner(),
@@ -700,6 +709,7 @@ export default {
                 return metadata.createBucket(MPUBucketName, mpuBucket, log,
                     err => {
                         if (err) {
+                            log.error('error from metadata', { error: err });
                             return cb(err);
                         }
                         return cb(null, mpuBucket);


### PR DESCRIPTION
Fix #252
* If a method is not logging an error from metadata, then log it
* If an error object is not being handled, then log it and return
  the callback, passing the error object