### PR TITLE
CLEAN UP: second "if" never been accessed

### DIFF
--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -139,12 +139,14 @@ export default function routePUT(request, response, log, utapi) {
                     additionalHeaders);
             });
         } else {
-            if (Number.isNaN(request.parsedContentLength)) {
+            if (request.headers['content-length'] === undefined &&
+            request.headers['x-amz-decoded-content-length'] === undefined) {
                 return routesUtils.responseNoBody(errors.MissingContentLength,
                     null, response, 411, log);
             }
-            if (Number.isNaN(request.parsedContentLength)) {
-                return routesUtils.responseNoBody(errors.InvalidArgument,
+            if (Number.isNaN(request.parsedContentLength) ||
+            request.parsedContentLength < 0) {
+                return routesUtils.responseNoBody(errors.BadRequest,
                     null, response, 400, log);
             }
             log.end().addDefaultFields({


### PR DESCRIPTION
The second `if`has never been accessed.

_CASES:_ 
- `content-length`  undefined  && `x-amz-decoded-content-length` undefined  : **errors.MissingContentLength**(411)
- `content-length` is not an integer or is negatif: node `http` module filter the request (ie: request never reach our S3 server)
- `x-amz-decoded-content-length` is not an integer or is negatif **errors.BadRequest** (400)