### PR TITLE
Removed jets3t from pom.xml

### DIFF
--- a/tests/functional/jaws/pom.xml
+++ b/tests/functional/jaws/pom.xml
@@ -15,13 +15,6 @@
                 <project.build.outputEncoding>${project.custom.encoding}</project.build.outputEncoding>
                 <project.reporting.outputEncoding>${project.custom.encoding}</project.reporting.outputEncoding>
         </properties>
-        <repositories>
-                <repository>
-                        <name>jets3t</name>
-                        <id>jets3t</id>
-                        <url>http://repo1.maven.org/maven2/net/java/dev/jets3t/jets3t/</url>
-                </repository>
-        </repositories>
         <dependencies>
 		<dependency>
     			<groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
Removed jets3t from pom.xml.
the java test are using the java amazon sdk now (and not jets3t)
Fix https://github.com/scality/S3/issues/255
Sorry for that.