### PR TITLE
Move config parsing to encrypt bucket function.

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/copyPart.js
+++ b/tests/functional/aws-node-sdk/test/object/copyPart.js
@@ -8,10 +8,6 @@ import getConfig from '../support/config';
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
 
-const config = getConfig();
-const endpointWithoutHttp = config.endpoint.split('//')[1];
-const host = endpointWithoutHttp.split(':')[0];
-const port = endpointWithoutHttp.split(':')[1];
 
 const sourceBucketName = 'supersourcebucket81033016532';
 const sourceObjName = 'supersourceobject';
@@ -35,6 +31,10 @@ function checkError(err, code) {
 function createEncryptedBucket(bucketParams, cb) {
     process.stdout.write('Creating encrypted bucket' +
     `${bucketParams.Bucket}`);
+    const config = getConfig();
+    const endpointWithoutHttp = config.endpoint.split('//')[1];
+    const host = endpointWithoutHttp.split(':')[0];
+    const port = endpointWithoutHttp.split(':')[1];
 
     const prog = `${__dirname}/../../../../../bin/create_encrypted_bucket.js`;
     let args = [


### PR DESCRIPTION
If do not move this parsing, cannot run AWS_ON_AIR tests.

The encrypted bucket function is only meant for the S3 server.
However, by having the parsing done outside of the createEncryptedBucket function,
the process will crash before running tests with AWS_ON_AIR=true.
