### PR TITLE
COMPAT: check for empty content-md5 header

### DIFF
--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -120,6 +120,14 @@ export default function routePUT(request, response, log, utapi) {
         // PUT object copy
         // if content-md5 is not present in the headers, try to
         // parse content-md5 from meta headers
+
+        if (request.headers['content-md5'] === '') {
+            log.debug('empty content-md5 header', {
+                method: 'routePUT',
+            });
+            return routesUtils
+            .responseNoBody(errors.InvalidDigest, null, response, 200, log);
+        }
         if (request.headers['content-md5']) {
             request.contentMD5 = request.headers['content-md5'];
         } else {

--- a/lib/services.js
+++ b/lib/services.js
@@ -179,16 +179,49 @@ export default {
                              { dataRetrievalInfo });
                      hashedStream.on('hashed', () => {
                          log.trace('hashed event emitted');
+                         const checkHashMatchMD5Res = this.checkHashMatchMD5(
+                           request.contentMD5, hashedStream.completedHash, log);
+                         if (!checkHashMatchMD5Res) {
+                             log.trace('contentMD5 does not match, deleting' +
+                             ' data.');
+                             data.batchDelete(dataRetrievalInfo, log);
+                             return cb(errors.BadDigest);
+                         }
                          return cb(null, objectMetadata, dataRetrievalInfo,
                              hashedStream.completedHash);
                      });
                      if (hashedStream.completedHash) {
+                         const checkHashMatchMD5Res = this.checkHashMatchMD5(
+                           request.contentMD5, hashedStream.completedHash, log);
+                         if (!checkHashMatchMD5Res) {
+                             log.trace('contentMD5 does not match, deleting' +
+                             ' data.');
+                             data.batchDelete(dataRetrievalInfo, log);
+                             return cb(errors.BadDigest);
+                         }
                          hashedStream.removeAllListeners('hashed');
                          return cb(null, objectMetadata, dataRetrievalInfo,
                              hashedStream.completedHash);
                      }
                      return undefined;
                  });
+    },
+
+   /**
+    * Check that hashedStream.completedHash matches header contentMd5.
+    * @param {object} contentMD5 - content-md5 header
+    * @param {string} completedHash - hashed stream once completed
+    * @param {RequestLogger} log - the current request logger
+    * @return {boolean} - true if contentMD5 matches or is undefined,
+    * false otherwise
+    */
+    checkHashMatchMD5(contentMD5, completedHash, log) {
+        if (contentMD5 && completedHash && contentMD5 !== completedHash) {
+            log.debug('contentMD5 and completedHash does not match',
+            { method: 'checkHashMatchMD5', completedHash, contentMD5 });
+            return false;
+        }
+        return true;
     },
 
     /**

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -317,6 +317,32 @@ describe('s3curl putObject', () => {
                 });
         });
 
+    it('should not be able to put an object if content-md5 header is' +
+    'invalid',
+        done => {
+            provideRawOutput(['--debug', `--put=${upload}`,
+                '--contentMd5', 'toto', '--',
+                `${endpoint}/${bucket}/` +
+                `${prefix}${delimiter}${upload}1`, '-v'],
+                (httpCode, rawOutput) => {
+                    assert.strictEqual(httpCode, '400 BAD REQUEST');
+                    assertError(rawOutput.stdout, 'InvalidDigest', done);
+                });
+        });
+
+    it('should not be able to put an object if content-md5 header is' +
+    'mismatched MD5',
+        done => {
+            provideRawOutput(['--debug', `--put=${upload}`,
+                '--contentMd5', 'rL0Y20zC+Fzt72VPzMSk2A==', '--',
+                `${endpoint}/${bucket}/` +
+                `${prefix}${delimiter}${upload}1`, '-v'],
+                (httpCode, rawOutput) => {
+                    assert.strictEqual(httpCode, '400 BAD REQUEST');
+                    assertError(rawOutput.stdout, 'BadDigest', done);
+                });
+        });
+
     it('should not be able to put an object in a bucket with an invalid name',
         done => {
             provideRawOutput(['--debug', `--put=${upload}`, '--',


### PR DESCRIPTION
Fixes https://github.com/scality/S3/issues/281

When content-md5 header is empty: return InvalidDigest error
**On [ceph/s3-tests](https://github.com/ceph/s3-tests), these changes fix**:

- `FAIL: s3tests.functional.test_headers.test_object_create_bad_md5_empty` **should return InvalidDigest error**
- `FAIL: s3tests.functional.test_headers.test_object_create_bad_md5_bad`  **should return BadDigest error**
when `content-md5` header mismatches the hash which has been generated.