### PR TITLE
BF: Store / return AWS compatible headers

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -67,6 +67,18 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
         overrideMetadata,
         lastModifiedDate: new Date().toJSON(),
     };
+
+    // If COPY, make sure metadata stores original headers for following
+    if (whichMetadata === 'COPY') {
+        storeMetadataParams.headers['cache-control'] =
+          sourceObjMD['cache-control'];
+        storeMetadataParams.headers['content-disposition'] =
+          sourceObjMD['content-disposition'];
+        storeMetadataParams.headers['content-encoding'] =
+          sourceObjMD['content-encoding'];
+        storeMetadataParams.headers.expires = sourceObjMD.expires;
+    }
+
     return storeMetadataParams;
 }
 

--- a/lib/services.js
+++ b/lib/services.js
@@ -218,6 +218,22 @@ export default {
             authInfo.getAccountDisplayName();
         // This should be object creator's canonical ID.
         omVal['owner-id'] = authInfo.getCanonicalID();
+        // TODO: Find a way to store these headers for multipart uploads.
+        // params.headers is undefined when called from
+        // completeMultipartUploads because the latter does not pass
+        // headers as part of the params object
+        if (params.headers) {
+            omVal['cache-control'] = params.headers['cache-control'];
+            omVal['content-disposition'] =
+                params.headers['content-disposition'];
+            if (params.headers['content-encoding']) {
+                omVal['content-encoding'] =
+                    params.headers['content-encoding']
+                    .replace(/aws-chunked,?/, '');
+            }
+            omVal.expires = params.headers.expires;
+        }
+
         omVal['content-length'] = size;
         omVal['content-type'] = contentType;
         // Sending in last modified date in object put copy since need

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -27,6 +27,19 @@ function collectResponseHeaders(objectMD) {
         responseMetaHeaders['x-amz-server-side-encryption-aws-kms-key-id']
             = objectMD['x-amz-server-side-encryption-aws-kms-key-id'];
     }
+    if (objectMD['cache-control']) {
+        responseMetaHeaders['Cache-Control'] = objectMD['cache-control'];
+    }
+    if (objectMD['content-disposition']) {
+        responseMetaHeaders['Content-Disposition']
+          = objectMD['content-disposition'];
+    }
+    if (objectMD['content-encoding']) {
+        responseMetaHeaders['Content-Encoding'] = objectMD['content-encoding'];
+    }
+    if (objectMD.expires) {
+        responseMetaHeaders.Expires = objectMD.expires;
+    }
     responseMetaHeaders['Content-Length'] = objectMD['content-length'];
     // Note: ETag must have a capital "E" and capital "T" for cosbench
     // to work.

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -3,15 +3,35 @@ import assert from 'assert';
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
 
+const bucketName = 'buckettestgetobject';
+const objectName = 'someObject';
+// Specify sample headers to check for in GET response
+const cacheControl = 'max-age=86400';
+const contentDisposition = 'attachment; filename="fname.ext";';
+const contentEncoding = 'aws-chunked,gzip';
+// AWS Node SDK requires Date object, ISO-8601 string, or
+// a UNIX timestamp for Expires header
+const expires = new Date();
 
 describe('GET object', () => {
     withV4(sigCfg => {
         let bucketUtil;
         let s3;
 
-        before(() => {
+        before(done => {
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
+            // Create a bucket to put object to get later
+            s3.createBucket({ Bucket: bucketName }, done);
+        });
+
+        after(done => {
+            s3.deleteObject({ Bucket: bucketName, Key: objectName }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return s3.deleteBucket({ Bucket: bucketName }, done);
+            });
         });
 
 
@@ -21,8 +41,43 @@ describe('GET object', () => {
                     assert.notEqual(err, null,
                         'Expected failure but got success');
                     assert.strictEqual(err.code, 'NoSuchBucket');
-                    done();
+                    return done();
                 });
             });
+
+        describe('Additional headers: [Cache-Control, Content-Disposition, ' +
+        'Content-Encoding, Expires]', () => {
+            before(done => {
+                const params = {
+                    Bucket: bucketName,
+                    Key: objectName,
+                    CacheControl: cacheControl,
+                    ContentDisposition: contentDisposition,
+                    ContentEncoding: contentEncoding,
+                    Expires: expires,
+                };
+                s3.putObject(params, err => done(err));
+            });
+            it('should return additional headers if specified in objectPUT ' +
+              'request', done => {
+                s3.getObject({ Bucket: bucketName, Key: objectName },
+                  (err, res) => {
+                      if (err) {
+                          return done(err);
+                      }
+                      assert.strictEqual(res.CacheControl,
+                        cacheControl);
+                      assert.strictEqual(res.ContentDisposition,
+                        contentDisposition);
+                      // Should remove V4 streaming value 'aws-chunked'
+                      // to be compatible with AWS behavior
+                      assert.strictEqual(res.ContentEncoding,
+                        'gzip');
+                      assert.strictEqual(res.Expires,
+                          expires.toGMTString());
+                      return done();
+                  });
+            });
+        });
     });
 });

--- a/tests/functional/aws-node-sdk/test/object/objectHead_compatibleHeaders.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead_compatibleHeaders.js
@@ -1,0 +1,78 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucketName = 'objectheadtestheaders';
+const objectName = 'someObject';
+
+describe('HEAD object, compatibility headers [Cache-Control, ' +
+  'Content-Disposition, Content-Encoding, Expires]', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+        const cacheControl = 'max-age=86400';
+        const contentDisposition = 'attachment; filename="fname.ext";';
+        const contentEncoding = 'gzip,aws-chunked';
+        // AWS Node SDK requires Date object, ISO-8601 string, or
+        // a UNIX timestamp for Expires header
+        const expires = new Date();
+
+        before(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return bucketUtil.empty(bucketName).then(() =>
+                bucketUtil.deleteOne(bucketName)
+            )
+            .catch(err => {
+                if (err.code !== 'NoSuchBucket') {
+                    process.stdout.write(`${err}\n`);
+                    throw err;
+                }
+            })
+            .then(() => bucketUtil.createOne(bucketName))
+            .then(() => {
+                const params = {
+                    Bucket: bucketName,
+                    Key: objectName,
+                    CacheControl: cacheControl,
+                    ContentDisposition: contentDisposition,
+                    ContentEncoding: contentEncoding,
+                    Expires: expires,
+                };
+                return s3.putObjectAsync(params);
+            })
+            .catch(err => {
+                process.stdout.write(`Error with putObject: ${err}\n`);
+                throw err;
+            });
+        });
+
+        after(() => {
+            process.stdout.write('deleting bucket');
+            return bucketUtil.empty(bucketName).then(() =>
+            bucketUtil.deleteOne(bucketName));
+        });
+
+        it('should return additional headers if specified in objectPUT ' +
+          'request', done => {
+            s3.headObject({ Bucket: bucketName, Key: objectName },
+              (err, res) => {
+                  if (err) {
+                      return done(err);
+                  }
+                  assert.strictEqual(res.CacheControl,
+                    cacheControl);
+                  assert.strictEqual(res.ContentDisposition,
+                    contentDisposition);
+                  // Should remove V4 streaming value 'aws-chunked'
+                  // to be compatible with AWS behavior
+                  assert.strictEqual(res.ContentEncoding,
+                    'gzip,');
+                  assert.strictEqual(res.Expires,
+                      expires.toUTCString());
+                  return done();
+              });
+        });
+    });
+});


### PR DESCRIPTION
Related to issue fix #282
Optional headers Cache-Control, Content-Disposition, Content-Encoding, and Expires are missing in objectGet and objectHead response.
* Stores header values if specified in objectPut or objectCopy request.
* Returns stored values in objectGet and objectHead responses.
* Will follow-up in separate PR to address storing header values for multipartUpload