### PR TITLE
CLEANUP: Remove xml module usage in objectGetAcl api

### DIFF
--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -3,7 +3,7 @@ import { errors } from 'arsenal';
 import aclUtils from '../utilities/aclUtils';
 import constants from '../../constants';
 import services from '../services';
-import utils from '../utils';
+import escapeForXML from '../utilities/escapeForXML';
 import vault from '../auth/vault';
 
 //	Sample XML response:
@@ -25,8 +25,75 @@ import vault from '../auth/vault';
     </Grant>
   </AccessControlList>
 </AccessControlPolicy>
- */
+*/
 
+/**
+ * convertToXml - Converts the `grantInfo` object (defined in `objectGetACL()`)
+ * to an XML DOM string
+ * @param {object} grantInfo - The `grantInfo` object defined in
+ * `objectGetACL()`
+ * @return {string} xml.join('') - The XML DOM string
+ */
+const convertToXml = grantInfo => {
+    const { grants, ownerInfo } = grantInfo;
+    const xml = [];
+
+    // Escape any special XML characters
+    for (const key in grants) {
+        if (grants.hasOwnProperty(key)) {
+            grants[key] = escapeForXML(grants[key]);
+        }
+    }
+    for (const key in ownerInfo) {
+        if (ownerInfo.hasOwnProperty(key)) {
+            ownerInfo[key] = escapeForXML(ownerInfo[key]);
+        }
+    }
+
+    // Begin pushing XML element strings to the `xml` to create the XML DOM
+    xml.push('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+             '<AccessControlPolicy>',
+             '<Owner>',
+             `<ID>${ownerInfo.ID}</ID>`,
+             `<DisplayName>${ownerInfo.displayName}</DisplayName>`,
+             '</Owner>',
+             '<AccessControlList>'
+    );
+
+    // For each object in `grants`, push the relevant XML elements to `xml`
+    grants.forEach(grant => {
+        xml.push('<Grant>');
+
+        // Push the `<Grantee>` tag with the correct attributes, then push
+        // either an `<ID>` tag or an `<URI>` tag
+        if (grant.ID) {
+            xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
+                        'XMLSchema-instance" xsi:type="CanonicalUser">',
+                     `<ID>${grant.ID}</ID>`
+            );
+        } else if (grant.URI) {
+            xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
+                        'XMLSchema-instance" xsi:type="Group">',
+                     `<URI>${grant.URI}</URI>`
+            );
+        }
+
+        if (grant.displayName) {
+            xml.push(`<DisplayName>${grant.displayName}</DisplayName>`);
+        }
+
+        xml.push('</Grantee>',
+                 `<Permission>${grant.permission}</Permission>`,
+                 '</Grant>'
+        );
+    });
+
+    xml.push('</AccessControlList>',
+             '</AccessControlPolicy>'
+    );
+
+    return xml.join('');
+};
 
 /**
  * objectGetACL - Return ACL for object
@@ -101,8 +168,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                     objectACL.Canned, ownerGrant);
                 }
                 grantInfo.grants = grantInfo.grants.concat(cannedGrants);
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = convertToXml(grantInfo);
                 return callback(null, xml);
             }
             /**
@@ -132,8 +198,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                 * grants (if any) and return
                 */
                 grantInfo.grants = grantInfo.grants.concat(uriGrantInfo);
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = convertToXml(grantInfo);
                 return callback(null, xml);
             }
             /**
@@ -170,8 +235,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                 grantInfo.grants = grantInfo.grants
                     .concat(individualGrants).concat(uriGrantInfo);
                 // parse info about accounts and owner info to convert to xml
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = convertToXml(grantInfo);
                 return callback(null, xml);
             });
         });


### PR DESCRIPTION
Fix #285
* Generate the XML DOM with a function instead of constructing
  a JSON object with `aclUtils.constructGetACLsJson` and then
  using the xml module