### PR TITLE
CLEANUP: Remove xml module usage in objectGetAcl api

### DIFF
--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -3,7 +3,6 @@ import { errors } from 'arsenal';
 import aclUtils from '../utilities/aclUtils';
 import constants from '../../constants';
 import services from '../services';
-import utils from '../utils';
 import vault from '../auth/vault';
 
 //	Sample XML response:
@@ -101,8 +100,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                     objectACL.Canned, ownerGrant);
                 }
                 grantInfo.grants = grantInfo.grants.concat(cannedGrants);
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = aclUtils.convertToXml(grantInfo);
                 return callback(null, xml);
             }
             /**
@@ -132,8 +130,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                 * grants (if any) and return
                 */
                 grantInfo.grants = grantInfo.grants.concat(uriGrantInfo);
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = aclUtils.convertToXml(grantInfo);
                 return callback(null, xml);
             }
             /**
@@ -170,8 +167,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                 grantInfo.grants = grantInfo.grants
                     .concat(individualGrants).concat(uriGrantInfo);
                 // parse info about accounts and owner info to convert to xml
-                const xml = utils.convertToXml(grantInfo,
-                    aclUtils.constructGetACLsJson);
+                const xml = aclUtils.convertToXml(grantInfo);
                 return callback(null, xml);
             });
         });

--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -2,6 +2,7 @@ import { parseString } from 'xml2js';
 
 import { errors } from 'arsenal';
 import constants from '../../constants';
+import escapeForXML from '../utilities/escapeForXML';
 
 const aclUtils = {};
 
@@ -234,5 +235,62 @@ aclUtils.sortHeaderGrants =
         });
         return addACLParams;
     };
+
+/**
+ * convertToXml - Converts the `grantInfo` object (defined in `objectGetACL()`)
+ * to an XML DOM string
+ * @param {object} grantInfo - The `grantInfo` object defined in
+ * `objectGetACL()`
+ * @return {string} xml.join('') - The XML DOM string
+ */
+aclUtils.convertToXml = grantInfo => {
+    const { grants, ownerInfo } = grantInfo;
+    const xml = [];
+
+    xml.push('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+             '<AccessControlPolicy>',
+             '<Owner>',
+             `<ID>${ownerInfo.ID}</ID>`,
+             `<DisplayName>${escapeForXML(ownerInfo.displayName)}` +
+                '</DisplayName>',
+             '</Owner>',
+             '<AccessControlList>'
+    );
+
+    grants.forEach(grant => {
+        xml.push('<Grant>');
+
+        // The `<Grantee>` tag has different attributes depending on whether the
+        // grant has an ID or URI
+        if (grant.ID) {
+            xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
+                        'XMLSchema-instance" xsi:type="CanonicalUser">',
+                     `<ID>${grant.ID}</ID>`
+            );
+        } else if (grant.URI) {
+            xml.push('<Grantee xmlns:xsi="http://www.w3.org/2001/' +
+                        'XMLSchema-instance" xsi:type="Group">',
+                     `<URI>${escapeForXML(grant.URI)}</URI>`
+            );
+        }
+
+        if (grant.displayName) {
+            xml.push(`<DisplayName>${escapeForXML(grant.displayName)}` +
+                     '</DisplayName>'
+            );
+        }
+
+        xml.push('</Grantee>',
+                 `<Permission>${grant.permission}</Permission>`,
+                 '</Grant>'
+        );
+    });
+
+    xml.push('</AccessControlList>',
+             '</AccessControlPolicy>'
+    );
+
+    return xml.join('');
+};
 
 export default aclUtils;


### PR DESCRIPTION
Fix #285
* Generate the XML DOM with the function `convertToXml()` instead
  of constructing a JSON object with `aclUtils.constructGetACLsJson`
  and then using the xml module