### PR TITLE
COMPAT: set ACLs with an empty AccessControlList

### DIFF
--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -103,8 +103,10 @@ aclUtils.parseAclXml = function parseAclXml(toBeParsed, log, next) {
         }
         if (!result.AccessControlPolicy
                 || !result.AccessControlPolicy.AccessControlList
-                || !result.AccessControlPolicy
-                .AccessControlList[0].Grant) {
+                || result.AccessControlPolicy.AccessControlList.length !== 1
+                || (result.AccessControlPolicy.AccessControlList[0] !== '' &&
+                  Object.keys(result.AccessControlPolicy.AccessControlList[0])
+                    .some(listKey => listKey !== 'Grant'))) {
             log.warn('invalid acl', { acl: result });
             return next(errors.MalformedACLError);
         }


### PR DESCRIPTION
FIXES #304
I checked against AWS S3 and when:

- adding multiple AccessControlList section

OR

- AccessControlList section is not empty and there is no Grant section
it returns a MalformedACLError.

If AccessControlList section is empty `<AccessControlList></AccessControlList>`, AWS does not throw any error.