### PR TITLE
fix: remove redundant ioctl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "bucketclient": "scality/bucketclient",
     "commander": "^2.9.0",
-    "ioctl": "^2.0.0",
     "level": "^1.4.0",
     "level-sublevel": "^6.5.4",
     "multilevel": "^7.3.0",


### PR DESCRIPTION
ioctl is already being installed as an optional dependency.
