### PR TITLE
CLEANUP: Remove xml module usage in bucketGetAcl api

### DIFF
--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -1,7 +1,6 @@
 import aclUtils from '../utilities/aclUtils';
 import constants from '../../constants';
 import services from '../services';
-import utils from '../utils';
 import vault from '../auth/vault';
 
 //	Sample XML response:
@@ -85,8 +84,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
             const cannedGrants = aclUtils.handleCannedGrant(
                 bucketACL.Canned, ownerGrant);
             grantInfo.grants = grantInfo.grants.concat(cannedGrants);
-            const xml = utils.convertToXml(grantInfo,
-                aclUtils.constructGetACLsJson);
+            const xml = aclUtils.convertToXml(grantInfo);
             return callback(null, xml);
         }
         /**
@@ -116,8 +114,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
             * grants (if any) and return
             */
             grantInfo.grants = grantInfo.grants.concat(uriGrantInfo);
-            const xml = utils.convertToXml(grantInfo,
-                aclUtils.constructGetACLsJson);
+            const xml = aclUtils.convertToXml(grantInfo);
             return callback(null, xml);
         }
         /**
@@ -153,8 +150,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
             grantInfo.grants = grantInfo.grants
                 .concat(individualGrants).concat(uriGrantInfo);
             // parse info about accounts and owner info to convert to xml
-            const xml = utils.convertToXml(grantInfo,
-                aclUtils.constructGetACLsJson);
+            const xml = aclUtils.convertToXml(grantInfo);
             return callback(null, xml);
         });
     });

--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -118,47 +118,6 @@ aclUtils.parseAclXml = function parseAclXml(toBeParsed, log, next) {
     });
 };
 
-aclUtils.constructGetACLsJson = function constrctGetACLsJson(grantInfo) {
-    const { grants, ownerInfo } = grantInfo;
-    const accessControlList = grants.map(grant => {
-        let grantIdentifier;
-        let type;
-        if (grant.ID) {
-            grantIdentifier = { ID: grant.ID };
-            type = 'CanonicalUser';
-        }
-        if (grant.URI) {
-            grantIdentifier = { URI: grant.URI };
-            type = 'Group';
-        }
-        const grantItem = {
-            Grant: [
-                { Grantee: [{ _attr: { 'xmlns:xsi':
-                    'http://www.w3.org/2001/XMLSchema-instance',
-                    'xsi:type': type,
-                    },
-                },
-                    grantIdentifier] },
-                { Permission: grant.permission },
-            ],
-        };
-        if (grant.displayName) {
-            grantItem.Grant[0].Grantee.push({ DisplayName: grant.displayName });
-        }
-        return grantItem;
-    });
-
-    return {
-        AccessControlPolicy: [{
-            Owner: [
-                { ID: ownerInfo.ID },
-                { DisplayName: ownerInfo.displayName },
-            ],
-        },
-        { AccessControlList: accessControlList }],
-    };
-};
-
 aclUtils.getPermissionType = function getPermissionType(identifier, resourceACL,
         resourceType) {
     const fullControlIndex = resourceACL.FULL_CONTROL.indexOf(identifier);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 import url from 'url';
 import crypto from 'crypto';
-import xmlService from 'xml';
 
 import config from './Config';
 import constants from '../constants';
@@ -258,13 +257,6 @@ utils.mapHeaders = function mapHeaders(headers, addHeaders) {
     }
     /* eslint-enable no-param-reassign */
     return headers;
-};
-
-
-utils.convertToXml = function convertToXml(infoToConvert, jsonConstructer) {
-    const constructedJSON = jsonConstructer(infoToConvert);
-    return xmlService(constructedJSON,
-        { declaration: { standalone: 'yes', encoding: 'UTF-8' } });
 };
 
 export default utils;


### PR DESCRIPTION
Fix #269
- Use `aclUtils.convertToXml` function to generate the XML DOM
- Remove `aclUtils.constructGetACLsJson` function because XML
  is generated with the `grantInfo` object and does not need to
  be formatted for the XML module
- Remove `utils.convertToXml` because its purpose was to 1) handle
  JSON construction with `aclUtils.constructGetACLsJson` 2) return
  the XML DOM using the XML module
