### PR TITLE
CLEANUP: Reorder so MD is deleted before data

### DIFF
--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -26,6 +26,28 @@ if (config.backends.data === 'mem') {
     implName = 'sproxyd';
 }
 
+/**
+ * _retryDelete - Attempt to delete key again if it failed previously
+ * @param {string} key - location of the object to delete
+ * @param {object} log - Werelogs request logger
+ * @param {number} count - keeps count of number of times function has been run
+ * @param {function} cb - callback
+ * @returns undefined and calls callback
+ */
+const MAX_RETRY = 2;
+
+function _retryDelete(key, log, count, cb) {
+    if (count > MAX_RETRY) {
+        return cb(errors.InternalError);
+    }
+    return client.delete(key, log.getSerializedUids(), err => {
+        if (err) {
+            return _retryDelete(key, log, count + 1, cb);
+        }
+        return cb();
+    });
+}
+
 const data = {
     put: (cipherBundle, value, valueSize, keyContext, log, cb) => {
         assert.strictEqual(typeof valueSize, 'number');
@@ -93,17 +115,21 @@ const data = {
     },
 
     delete: (objectGetInfo, log, cb) => {
+        const callback = cb || log.end;
         // If objectGetInfo.key exists the md-model-version is 2 or greater.
         // Otherwise, the objectGetInfo is just the key string.
         const key = objectGetInfo.key ? objectGetInfo.key : objectGetInfo;
-        log.debug('sending delete to datastore', { implName, key,
-            method: 'delete' });
-        client.delete(key, log.getSerializedUids(), err => {
+        log.debug('sending delete to datastore', {
+            implName,
+            key,
+            method: 'delete',
+        });
+        _retryDelete(key, log, 0, err => {
             if (err) {
-                log.error('error from sproxyd', { error: err });
-                return cb(errors.InternalError);
+                log.error('error deleting object from datastore',
+                    { error: err, key });
             }
-            return cb();
+            return callback(err);
         });
     },
 
@@ -111,15 +137,14 @@ const data = {
     // replace this
     batchDelete: (locations, log) => {
         async.eachLimit(locations, 5, (loc, next) => {
-            data.delete(loc, log, err => {
-                if (err) {
-                    log.error('one part of a batch delete failed',
-                    { location: loc });
-                }
-                return next();
-            });
+            data.delete(loc, log, next);
         },
-        () => {
+        err => {
+            if (err) {
+                log.error('batch delete failed', { error: err });
+            } else {
+                log.trace('batch delete successfully completed');
+            }
             log.end();
         });
     },

--- a/lib/services.js
+++ b/lib/services.js
@@ -11,6 +11,7 @@ import data from './data/wrapper';
 import { isBucketAuthorized, isObjAuthorized } from
     './api/apiUtils/authorization/aclChecks';
 import metadata from './metadata/wrapper';
+import { logger } from './utilities/logger';
 import V4Transform from './auth/streamingV4/V4Transform';
 import removeAWSChunked from './api/apiUtils/object/removeAWSChunked';
 
@@ -367,47 +368,30 @@ export default {
             log.trace('object identified as non-versioned');
             // non-versioned buckets
             log.trace('deleteObject: deleting non-versioned object');
-            if (objectMD.location === null) {
-                return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
-            } else if (!Array.isArray(objectMD.location)) {
-                return data.delete(objectMD.location, log, err => {
+            return metadata.deleteObjectMD(bucketName, objectKey, log,
+                err => {
                     if (err) {
-                        log.error('error deleting from dataStore', {
-                            error: err,
-                        });
                         return cb(err);
                     }
-                    log.trace('deleteobject: data delete ok');
-                    metadata.deleteObjectMD(bucketName, objectKey, log, cb);
-                    return undefined;
-                });
-            }
-            const errs = [];
-            async.eachLimit(objectMD.location, 5, (loc, ok) => {
-                data.delete(loc, log, err => {
-                    if (err) {
-                        errs.push(err);
-                        log.error('error deleting from dataStore', {
-                            error: err,
-                        });
+                    cb();
+                    // TODO: The method of persistence of sproxy delete key will
+                    // be finalized; refer Issue #312 for the discussion. In the
+                    // meantime, we at least log the location of the data we are
+                    // about to delete before attempting its deletion.
+                    log.trace('deleteObject: metadata delete OK; about to ' +
+                    'delete object in data', { location: objectMD.location });
+                    const deleteLog = logger.newRequestLogger();
+                    if (objectMD.location === null) {
+                        return undefined;
+                    } else if (!Array.isArray(objectMD.location)) {
+                        return data.delete(objectMD.location, deleteLog);
                     }
-                    log.trace('deleteobject: data delete ok');
-                    ok();
+                    return data.batchDelete(objectMD.location, deleteLog);
                 });
-            }, () => {
-                // Arrays are only used internally for MPU objects
-                if (errs[0]) {
-                    return cb(errs[0]);
-                }
-                metadata.deleteObjectMD(bucketName, objectKey, log, cb);
-                return undefined;
-            });
-        } else {
-            // versioning
-            log.warn('deleteObject: versioning not fully implemented');
-            return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
         }
-        return undefined;
+        // versioning
+        log.warn('deleteObject: versioning not fully implemented');
+        return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
     },
 
     /**

--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -1,0 +1,83 @@
+import assert from 'assert';
+import Promise from 'bluebird';
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucketName = 'testdeletempu';
+const objectName = 'key';
+
+describe('DELETE object', () => {
+    withV4(sigCfg => {
+        let uploadId;
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        const testfile = new Buffer(1024 * 1024 * 54);
+
+        before(() => {
+            process.stdout.write('creating bucket\n');
+            return s3.createBucketAsync({ Bucket: bucketName })
+            .then(() => {
+                process.stdout.write('initiating multipart upload\n');
+                return s3.createMultipartUploadAsync({ Bucket: bucketName,
+                    Key: objectName });
+            })
+            .then(res => {
+                process.stdout.write('uploading parts\n');
+                uploadId = res.UploadId;
+                const uploads = [];
+                for (let i = 1; i <= 3; i++) {
+                    uploads.push(
+                        s3.uploadPartAsync({ Bucket: bucketName,
+                            Key: objectName, PartNumber: i, Body: testfile,
+                            UploadId: uploadId })
+                    );
+                }
+                return Promise.all(uploads);
+            })
+            .catch(err => {
+                process.stdout.write(`Error with uploadPart ${err}\n`);
+                throw err;
+            })
+            .then(res => {
+                process.stdout.write('about to complete multipart upload\n');
+                return s3.completeMultipartUploadAsync({
+                    Bucket: bucketName,
+                    Key: objectName,
+                    UploadId: uploadId,
+                    MultipartUpload: {
+                        Parts: [
+                            { ETag: res[0].ETag, PartNumber: 1 },
+                            { ETag: res[1].ETag, PartNumber: 2 },
+                            { ETag: res[2].ETag, PartNumber: 3 },
+                        ],
+                    },
+                });
+            })
+            .catch(err => {
+                process.stdout.write(`completeMultipartUpload error: ${err}\n`);
+                throw err;
+            });
+        });
+
+        after(() => {
+            process.stdout.write('Emptying bucket\n');
+            return bucketUtil.empty(bucketName)
+            .then(() => {
+                process.stdout.write('Deleting bucket\n');
+                return bucketUtil.deleteOne(bucketName);
+            })
+            .catch(err => {
+                process.stdout.write('Error in after\n');
+                throw err;
+            });
+        });
+
+        it('should delete a object uploaded in parts successfully', done => {
+            s3.deleteObject({ Bucket: bucketName, Key: objectName }, err => {
+                assert.strictEqual(err, null,
+                    `Expected success, got error ${JSON.stringify(err)}`);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Related to issue #312
- Add optional callback to batchDelete so it can be used to delete object(s) instead of duplicating code
- Swap order so MD is deleted before data
- Remove redundant log traces and errors
- Add functional test for deleteObject to test deleting an object uploaded in parts

This at least swaps the order of deletion so MD is deleted before data, which is preferable to potential ghost MD of a deleted data object. The issue of how to persist the delete keys for confirmation of data deletion still needs to be resolved.
