### PR TITLE
BF: Fix data retrieval for listMultipartUploads API

### DIFF
--- a/lib/metadata/in_memory/getMultipartUploadListing.js
+++ b/lib/metadata/in_memory/getMultipartUploadListing.js
@@ -83,8 +83,8 @@ export default function getMultipartUploadListing(bucket, params, callback) {
             initiatorID: storedMD.initiator.ID,
             initiatorDisplayName: storedMD.initiator.DisplayName,
             ownerID: storedMD['owner-id'],
-            onwerDisplayName: storedMD['owner-display-name'],
-            storageClass: storedMD.storageClass,
+            ownerDisplayName: storedMD['owner-display-name'],
+            storageClass: storedMD['x-amz-storage-class'],
             initiated: storedMD.initiated,
         };
     });


### PR DESCRIPTION
- `services.getMultipartUploadListing` in listMultipartUploads.js is
  passing an `undefined` DisplayName for the owner of the MPU and
  an `undefined` StorageClass for an upload. This results in the
  following JSON response for the listMultipartUploads API, respectively:
  
  ``` javascript
  "Owner": { "DisplayName": "undefined", ... }
  "Uploads": [{ ... "StorageClass": "undefined", ... }]
  ```
- These changes in getMultipartUploadListing.js fixes the
  issues stated in the above bullet point by retrieving the proper
  values for the keys `DisplayName` and `StorageClass`
