### PR TITLE
COMPAT: Handle `undefined` values for listMultipartUploads API

### DIFF
--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -81,14 +81,32 @@ const _convertToXml = xmlParams => {
     xml.push('<?xml version="1.0" encoding="UTF-8"?>',
              '<ListMultipartUploadsResult ' +
                 'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
-             `<Bucket>${xmlParams.bucketName}</Bucket>`,
-             `<KeyMarker>${escapeForXML(xmlParams.keyMarker)}</KeyMarker>`,
-             `<UploadIdMarker>${xmlParams.uploadIdMarker}</UploadIdMarker>`,
-             `<NextKeyMarker>${escapeForXML(l.NextKeyMarker)}</NextKeyMarker>`,
-             `<NextUploadIdMarker>${l.NextUploadIdMarker}</NextUploadIdMarker>`,
-             `<Delimiter>${escapeForXML(l.Delimiter)}</Delimiter>`,
-             `<Prefix>${escapeForXML(xmlParams.prefix)}</Prefix>`,
-             `<MaxUploads>${l.MaxKeys}</MaxUploads>`,
+             `<Bucket>${xmlParams.bucketName}</Bucket>`
+    );
+
+    // For certain XML elements, if it is `undefined`, AWS returns either an
+    // empty tag or does not include it. Hence the `optional` key in the params.
+    const params = [
+        { tag: 'KeyMarker', value: escapeForXML(xmlParams.keyMarker) },
+        { tag: 'UploadIdMarker', value: xmlParams.uploadIdMarker },
+        { tag: 'NextKeyMarker', value: escapeForXML(l.NextKeyMarker),
+            optional: true },
+        { tag: 'NextUploadIdMarker', value: l.NextUploadIdMarker,
+            optional: true },
+        { tag: 'Delimiter', value: escapeForXML(l.Delimiter), optional: true },
+        { tag: 'Prefix', value: escapeForXML(xmlParams.prefix),
+            optional: true },
+    ];
+
+    params.forEach(param => {
+        if (param.value) {
+            xml.push(`<${param.tag}>${param.value}</${param.tag}>`);
+        } else if (!param.optional) {
+            xml.push(`<${param.tag}></${param.tag}>`);
+        }
+    });
+
+    xml.push(`<MaxUploads>${l.MaxKeys}</MaxUploads>`,
              `<IsTruncated>${l.IsTruncated}</IsTruncated>`
     );
 

--- a/lib/metadata/in_memory/getMultipartUploadListing.js
+++ b/lib/metadata/in_memory/getMultipartUploadListing.js
@@ -83,8 +83,8 @@ export default function getMultipartUploadListing(bucket, params, callback) {
             initiatorID: storedMD.initiator.ID,
             initiatorDisplayName: storedMD.initiator.DisplayName,
             ownerID: storedMD['owner-id'],
-            onwerDisplayName: storedMD['owner-display-name'],
-            storageClass: storedMD.storageClass,
+            ownerDisplayName: storedMD['owner-display-name'],
+            storageClass: storedMD['x-amz-storage-class'],
             initiated: storedMD.initiated,
         };
     });

--- a/tests/functional/aws-node-sdk/lib/utility/bucket-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/bucket-util.js
@@ -90,4 +90,10 @@ export default class BucketUtility {
                 )
             );
     }
+
+    getOwner() {
+        return this.s3
+            .listBucketsAsync()
+            .then(data => data.Owner);
+    }
 }

--- a/tests/functional/aws-node-sdk/test/legacy/tests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/tests.js
@@ -201,40 +201,6 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
         return done();
     });
 
-    it('should list ongoing multipart uploads', done => {
-        const params = {
-            Bucket: bucket,
-        };
-        s3.listMultipartUploads(params, (err, data) => {
-            if (err) {
-                return done(new Error(`error in listMultipartUploads: ${err}`));
-            }
-            assert.strictEqual(data.Uploads.length, 1, 'data.Uploads.length ' +
-            'is incorrect');
-            assert.strictEqual(data.Uploads[0].UploadId,
-                multipartUploadData.secondUploadId, 'multipartUploadData.' +
-                'secondUploadId is incorrect');
-            return done();
-        });
-    });
-
-    it('should list ongoing multipart uploads with params', done => {
-        const params = {
-            Bucket: bucket,
-            Prefix: 'to',
-            MaxUploads: 2,
-        };
-        s3.listMultipartUploads(params, (err, data) => {
-            if (err) {
-                return done(new Error(`error in listMultipartUploads: ${err}`));
-            }
-            assert.strictEqual(data.Uploads.length, 1);
-            assert.strictEqual(data.Uploads[0].UploadId,
-                multipartUploadData.secondUploadId);
-            return done();
-        });
-    });
-
     it('should return an error if do not provide correct ' +
         // completempu test
         'xml when completing a multipart upload', done => {

--- a/tests/functional/aws-node-sdk/test/object/mpu.js
+++ b/tests/functional/aws-node-sdk/test/object/mpu.js
@@ -1,0 +1,83 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucket = 'object-test-mpu';
+const objectKey = 'toAbort&<>"\'';
+
+const throwErr = (str, err) => {
+    process.stdout.write(`${str}: ${err}\n`);
+    throw err;
+};
+
+const checkValues = (res, uploadId, displayName, cb) => {
+    const prefix = res.Prefix ? res.Prefix : undefined;
+    const delimeter = res.Delimiter ? res.Delimiter : undefined;
+    assert.deepStrictEqual(res.KeyMarker, '');
+    assert.deepStrictEqual(res.UploadIdMarker, '');
+    assert.deepStrictEqual(res.Prefix, prefix);
+    assert.deepStrictEqual(res.Delimiter, delimeter);
+    assert.deepStrictEqual(res.Uploads.length, 1);
+    assert.deepStrictEqual(res.Uploads[0].UploadId, uploadId);
+    assert.deepStrictEqual(res.Uploads[0].StorageClass, 'STANDARD');
+    assert.deepStrictEqual(res.Uploads[0].Owner.DisplayName, displayName);
+    cb();
+};
+
+describe('aws-node-sdk test suite of listMultipartUploads', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+        let uploadId;
+        let displayName;
+
+        beforeEach(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+
+            return s3.createBucketAsync({ Bucket: bucket })
+            .then(() => bucketUtil.getOwner())
+            .then(res => {
+                // In this case, the owner of the bucket will also be the MPU
+                // upload owner. We need this value for testing comparison.
+                displayName = res.DisplayName;
+            })
+            .then(() => s3.createMultipartUploadAsync({
+                Bucket: bucket,
+                Key: objectKey,
+            }))
+            .then(res => {
+                uploadId = res.UploadId;
+            })
+            .catch(err => throwErr('Error in beforeEach', err));
+        });
+
+        afterEach(() =>
+            s3.abortMultipartUploadAsync({
+                Bucket: bucket,
+                Key: objectKey,
+                UploadId: uploadId,
+            })
+            .then(() => bucketUtil.empty(bucket))
+            .then(() => bucketUtil.deleteOne(bucket))
+            .catch(err => throwErr('Error in afterEach', err))
+        );
+
+        it('should list ongoing multipart uploads', done => {
+            s3.listMultipartUploadsAsync({ Bucket: bucket })
+            .then(res => checkValues(res, uploadId, displayName, done))
+            .catch(done);
+        });
+
+        it('should list ongoing multipart uploads with params', done => {
+            s3.listMultipartUploadsAsync({
+                Bucket: bucket,
+                Prefix: 'to',
+                MaxUploads: 1,
+            })
+            .then(res => checkValues(res, uploadId, displayName, done))
+            .catch(done);
+        });
+    });
+});


### PR DESCRIPTION
This commit fixes issues that were causing listMultipartUploads
to contain 'undefined' as XML content:
* `services.getMultipartUploadListing` in listMultipartUploads.js is
  passing an `undefined` DisplayName for the owner of the MPU and
  an `undefined` StorageClass for an upload. This results in the
  following JSON response for the listMultipartUploads API,
  respectively:

  ```javascript
  "Owner": { "DisplayName": "undefined", ... }
  "Uploads": [{ ... "StorageClass": "undefined", ... }]

  ```
* Changes in getMultipartUploadListing.js fixes the
  issues stated in the above bullet point by retrieving the proper
  values for the keys `DisplayName` and `StorageClass`
* For values that could be `undefined` in the listMultipartUploads
  API, use empty XML elements if the value is, in fact, `undefined`
* Add tests that check for previously `undefined` values, and remove
  legacy 'list ongoing multipart uploads' tests which would
  be redundant with this commit