### PR TITLE
BF: typo https

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -60,7 +60,7 @@ class S3Server {
                 req.socket.setNoDelay();
                 routes(req, res, logger);
             });
-            logger.info('Https server configuration', {
+            logger.info('Http server configuration', {
                 https: false,
             });
         }


### PR DESCRIPTION
`http` log typo.
That can be confusing when looking at the log.