### PR TITLE
ft: append IPs to default list for healthchecks

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -182,6 +182,7 @@ class Config {
             }
         }
 
+        this.healthChecks = defaultHealthChecks;
         if (config.healthChecks && config.healthChecks.allowFrom) {
             assert(config.healthChecks.allowFrom instanceof Array,
                 'config: invalid healthcheck configuration. allowFrom must ' +
@@ -191,8 +192,9 @@ class Config {
                 'config: invalid healthcheck configuration. allowFrom IP ' +
                 'address must be a string');
             });
+            this.healthChecks.allowFrom = defaultHealthChecks.allowFrom
+                .concat(config.healthChecks.allowFrom);
         }
-        this.healthChecks = config.healthChecks || defaultHealthChecks;
 
         if (config.certFilePaths) {
             assert(typeof config.certFilePaths === 'object' &&


### PR DESCRIPTION
This commit makes sure that localhost retains access to healthcheck routes
when an additional list of IP addresses are provided as a whitelist.