### PR TITLE
Dockerfile: Make s3 container lighter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM node:4
+FROM node:4-slim
 MAINTAINER Giorgio Regni <gr@scality.com>
 
 WORKDIR /usr/src/app
 
 COPY . /usr/src/app
-RUN npm install
+
+RUN apt-get update \
+    && apt-get install -y python git build-essential \
+    && npm install \
+    && apt-get autoremove -y python build-essential
 
 CMD [ "npm", "start" ]
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 
 EXPOSE 8000
-

--- a/DockerfileMem
+++ b/DockerfileMem
@@ -1,10 +1,15 @@
-FROM node:4
+FROM node:4-slim
 MAINTAINER Giorgio Regni <gr@scality.com>
 
 WORKDIR /usr/src/app
 
 COPY . /usr/src/app
-RUN npm install
+
+RUN apt-get update \
+    && apt-get install -y python git build-essential \
+    && npm install \
+    && apt-get autoremove -y python build-essential
+
 ENV S3BACKEND mem
 CMD [ "npm", "start" ]
 


### PR DESCRIPTION
These changes make the Docker S3Sever container lighter from 841.4 MB to 550.8 MB.

This new image has been tested with and without HTTPS.

I think it was better to keep `git` dependency.

_use-cases:_ `git describe` to get the release and commit.