### PR TITLE
fix: set content-length on healthcheck route

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -42,9 +42,12 @@ export function isHealthy() {
 
 function writeResponse(res, error, log) {
     const statusCode = error ? error.code : 200;
-    const body = error ? JSON.stringify(error) : '{}';
+    const body = Buffer.from(error ? JSON.stringify(error) : '{}', 'utf8');
 
-    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.writeHead(statusCode, {
+        'content-type': 'application/json',
+        'content-length': body.length,
+    });
     res.write(body);
 
     res.end(() => {


### PR DESCRIPTION
set content-length to avoid transfer-encoding chunked on responses

fix #354