### PR TITLE
FIX: Signing key binary

### DIFF
--- a/lib/auth/in_memory/vaultUtilities.js
+++ b/lib/auth/in_memory/vaultUtilities.js
@@ -25,6 +25,6 @@ export function calculateSigningKey(secretKey, region, scopeDate) {
     const dateRegionServiceKey = crypto.createHmac('sha256', dateRegionKey)
         .update('s3', 'binary').digest();
     const signingKey = crypto.createHmac('sha256', dateRegionServiceKey)
-        .update('aws4_request', 'binary').digest('binary');
+        .update('aws4_request', 'binary').digest();
     return signingKey;
 }


### PR DESCRIPTION
The binary digest for the signing key make
s3 under node v6 to generate wrong signature.
This pull request fix that.