### PR TITLE
Regroup package.json dependencies into Project's package.json

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,18 +35,72 @@ test:
   override:
     - npm run --silent lint -- --max-warnings 0
     - npm run --silent lint_md
-    # lint the python used for testing
     - flake8 $(git ls-files '*.py')
     - yamllint $(git ls-files '*.yml')
+
     - mkdir -p $CIRCLE_TEST_REPORTS/unit
     - npm run unit_coverage
-    - S3BACKEND=mem npm start & sleep 15 &&
-      cd ./tests/functional/jaws && mvn test
-    - S3BACKEND=mem npm start & sleep 4 && npm run ft_test;
-    - S3BACKEND=mem npm start & sleep 4 &&
-      ENABLE_KMS_ENCRYPTION=true npm run ft_test;
-    - S3BACKEND=file S3VAULT=mem npm start & sleep 15 && npm run ft_test;
-    - S3BACKEND=file S3VAULT=mem npm start & sleep 15 &&
-      ENABLE_KMS_ENCRYPTION=true npm run ft_test;
-    - S3BACKEND=mem npm start & sleep 15 &&
-      cd tests/functional/fog && rspec tests.rb
+
+    # Run S3 with mem Backend ; run ft_tests
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_java.txt
+        & bash wait_for_local_port.bash 8000 40
+        && cd ./tests/functional/jaws && mvn test
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_fog.txt
+        & bash wait_for_local_port.bash 8000 40
+        && cd tests/functional/fog && rspec tests.rb
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_awssdk.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_awssdk
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_s3cmd.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_s3cmd
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_s3curl.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_s3curl
+
+    # Run S3 with mem Backend + KMS Encryption ; run ft_tests
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_kms_awssdk.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_awssdk
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_kms_s3cmd.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_s3cmd
+    - S3BACKEND=mem npm start
+            > $CIRCLE_ARTIFACTS/server_mem_kms_s3curl.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_s3curl
+
+    # Run S3 with file Backend ; run ft_tests
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_awssdk.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_awssdk
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_s3cmd.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_s3cmd
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_s3curl.txt
+        & bash wait_for_local_port.bash 8000 40
+        && npm run ft_s3curl
+
+    # Run S3 with file Backend + KMS Encryption ; run ft_tests
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_kms_awssdk.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_awssdk
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_kms_s3cmd.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_s3cmd
+    - S3BACKEND=file S3VAULT=mem npm start
+            > $CIRCLE_ARTIFACTS/server_file_kms_s3curl.txt
+        & bash wait_for_local_port.bash 8000 40
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_s3curl

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "arsenal": "scality/Arsenal#rel/6.2.1",
     "async": "~1.4.2",
-    "babel-core": "^6.2.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.1.18",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.2.0",
-    "babel-plugin-transform-es2015-parameters": "^6.2.0",
+    "babel-core": "^6.5.2",
+    "babel-plugin-transform-es2015-destructuring": "^6.5.2",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
+    "babel-plugin-transform-es2015-parameters": "^6.5.2",
     "bucketclient": "scality/bucketclient#rel/6.2.1",
     "commander": "^2.9.0",
     "ioctl": "^2.0.0",
@@ -39,24 +39,27 @@
     "vaultclient": "scality/vaultclient#rel/6.2.1",
     "werelogs": "scality/werelogs#rel/6.2.1",
     "xml": "~1.0.0",
-    "xml2js": "~0.4.12"
+    "xml2js": "~0.4.16"
   },
   "optionalDependencies": {
     "ioctl": "2.0.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.2.11",
     "babel-cli": "^6.2.0",
     "babel-eslint": "^6.0.0",
+    "bluebird": "^3.3.1",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#rel/6.2.1",
     "istanbul": "1.0.0-alpha.2",
     "istanbul-api": "1.0.0-alpha.13",
     "lolex": "^1.4.0",
-    "mocha": "^2.3.3",
+    "mocha": "^2.3.4",
     "mocha-junit-reporter": "1.11.1",
     "node-mocks-http": "^1.5.2",
-    "s3blaster": "scality/s3blaster"
+    "s3blaster": "scality/s3blaster",
+    "tv4": "^1.2.7"
   },
   "scripts": {
     "ft_test": "mocha tester.js --compilers js:babel-core/register",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ft_s3curl": "cd tests/functional/s3curl && npm test",
     "ft_test": "mocha tester.js --compilers js:babel-core/register",
     "init": "node init.js",
+    "install_ft_deps": "npm install aws-sdk@2.2.11 bluebird@3.3.1 mocha@2.3.4 mocha-junit-reporter@1.11.1 tv4@1.2.7",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
     "mem_backend": "S3BACKEND=mem node index.js",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     "tv4": "^1.2.7"
   },
   "scripts": {
+    "ft_awssdk": "cd tests/functional/aws-node-sdk && npm test",
+    "ft_s3cmd": "cd tests/functional/s3cmd && npm test",
+    "ft_s3curl": "cd tests/functional/s3curl && npm test",
     "ft_test": "mocha tester.js --compilers js:babel-core/register",
     "init": "node init.js",
     "lint": "eslint $(git ls-files '*.js')",

--- a/tester.js
+++ b/tester.js
@@ -9,28 +9,6 @@ function log(message) {
     return process.stdout.write(`${message}\n`);
 }
 
-function installDependency(dir) {
-    log(`installing dependencies ${dir}`);
-
-    try {
-        fs.statSync(path.join(dir, 'package.json'));
-    } catch (e) {
-        return log('package.json file not found, skip installation');
-    }
-
-    try {
-        cp.execSync('npm install', {
-            stdio: 'inherit',
-            cwd: dir,
-        });
-    } catch (e) {
-        log('`npm install` fail');
-        return false;
-    }
-
-    return true;
-}
-
 function runTest(dir, fileName) {
     const testFile = path.join(dir, fileName);
 
@@ -55,10 +33,6 @@ function testing(dir) {
 
     return masterConfig.tests.files.reduce((prev, file) => {
         const cwd = path.join(rootPath, dir);
-        if (!installDependency(cwd)) {
-            return false;
-        }
-
         return prev && runTest(cwd, file);
     }, true);
 }

--- a/tester.js
+++ b/tester.js
@@ -9,32 +9,21 @@ function log(message) {
     return process.stdout.write(`${message}\n`);
 }
 
-function runTest(dir, fileName) {
-    const testFile = path.join(dir, fileName);
-
-    const test = cp.spawnSync('mocha', ['-t', '40000', testFile], {
-        stdio: 'inherit',
-        cwd: dir,
-    });
-
-    return !test.status;
-}
-
 function testing(dir) {
-    let masterConfig;
-
     log(`testing ${dir}`);
 
     try {
-        masterConfig = require(path.join(rootPath, dir, 'master.json'));
-    } catch (err) {
-        return log('master.json file not found, skipping this directory');
+        fs.statSync(path.join(rootPath, dir, 'package.json'));
+    } catch (e) {
+        return log('package.json file not found, skipping this directory');
     }
 
-    return masterConfig.tests.files.reduce((prev, file) => {
-        const cwd = path.join(rootPath, dir);
-        return prev && runTest(cwd, file);
-    }, true);
+    const test = cp.spawnSync('npm', ['test'], {
+        stdio: 'inherit',
+        cwd: path.join(rootPath, dir),
+    });
+
+    return !test.status;
 }
 
 function main() {

--- a/tests/functional/aws-node-sdk/master.json
+++ b/tests/functional/aws-node-sdk/master.json
@@ -1,6 +1,0 @@
-{
-    "tests": {
-        "files": ["/test" ],
-        "on": "aggressor"
-    }
-}

--- a/tests/functional/aws-node-sdk/package.json
+++ b/tests/functional/aws-node-sdk/package.json
@@ -10,8 +10,7 @@
   "scripts": {
     "test-aws": "AWS_ON_AIR=true mocha",
     "test": "mocha",
-    "test-debug": "_mocha",
-    "test-old": "mocha -u tdd tests.js"
+    "test-debug": "_mocha"
   },
   "author": ""
 }

--- a/tests/functional/aws-node-sdk/package.json
+++ b/tests/functional/aws-node-sdk/package.json
@@ -8,9 +8,9 @@
     "test"
   ],
   "scripts": {
-    "test-aws": "AWS_ON_AIR=true mocha",
-    "test": "mocha",
-    "test-debug": "_mocha"
+    "test-aws": "AWS_ON_AIR=true mocha -t 40000 test/",
+    "test": "mocha -t 40000 test/",
+    "test-debug": "_mocha -t 40000 test/"
   },
   "author": ""
 }

--- a/tests/functional/aws-node-sdk/package.json
+++ b/tests/functional/aws-node-sdk/package.json
@@ -7,17 +7,6 @@
   "keywords": [
     "test"
   ],
-  "dependencies": {
-    "aws-sdk": "^2.2.11",
-    "babel-core": "^6.5.1",
-    "babel-plugin-transform-es2015-destructuring": "^6.5.0",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.5.2",
-    "babel-plugin-transform-es2015-parameters": "^6.5.0",
-    "bluebird": "^3.3.1",
-    "mocha": "^2.3.4",
-    "tv4": "^1.2.7",
-    "xml2js": "^0.4.16"
-  },
   "scripts": {
     "test-aws": "AWS_ON_AIR=true mocha",
     "test": "mocha",

--- a/tests/functional/s3cmd/master.json
+++ b/tests/functional/s3cmd/master.json
@@ -1,6 +1,0 @@
-{
-    "tests": {
-        "files": [ "tests.js" ],
-        "on": "aggressor"
-    }
-}

--- a/tests/functional/s3cmd/package.json
+++ b/tests/functional/s3cmd/package.json
@@ -1,9 +1,5 @@
 {
     "name": "s3cmd-tests",
-    "dependencies": {
-        "mocha": "2.3.3",
-        "arsenal": "scality/Arsenal"
-    },
     "scripts": {
         "test": "mocha *.js"
     }

--- a/tests/functional/s3cmd/package.json
+++ b/tests/functional/s3cmd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "s3cmd-tests",
     "scripts": {
-        "test": "mocha *.js"
+        "test": "mocha -t 40000 *.js"
     }
 }

--- a/tests/functional/s3curl/master.json
+++ b/tests/functional/s3curl/master.json
@@ -1,6 +1,0 @@
-{
-    "tests": {
-        "files": [ "tests.js" ],
-        "on": "aggressor"
-    }
-}

--- a/tests/functional/s3curl/package.json
+++ b/tests/functional/s3curl/package.json
@@ -1,10 +1,5 @@
 {
     "name": "s3curl-tests",
-    "dependencies": {
-        "arsenal": "scality/Arsenal",
-        "mocha": "2.3.3",
-        "xml2js": "~0.4.12"
-    },
     "scripts": {
         "test": "mocha *.js"
     }

--- a/tests/functional/s3curl/package.json
+++ b/tests/functional/s3curl/package.json
@@ -1,6 +1,6 @@
 {
     "name": "s3curl-tests",
     "scripts": {
-        "test": "mocha *.js"
+        "test": "mocha -t 40000 *.js"
     }
 }

--- a/wait_for_local_port.bash
+++ b/wait_for_local_port.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+wait_for_local_port() {
+    local port=$1
+    local timeout=$2
+    local count=0
+    local ret=1
+    echo "waiting for S3:$port"
+    while [[ "$ret" -eq "1" && "$count" -lt "$timeout" ]] ; do
+        nc -z -w 1 localhost $port
+        ret=$?
+        if [ ! "$ret" -eq "0" ]; then
+            echo -n .
+            sleep 1
+            count=$(($count+1))
+        fi
+    done
+
+    echo ""
+
+    if [[ "$count" -eq "$timeout" ]]; then
+        echo "Server did not start in less than $timeout seconds. Exiting..."
+        exit 1
+    fi
+
+    echo "Server got ready in ~${count} seconds. Starting test now..."
+}
+
+wait_for_local_port $1 $2


### PR DESCRIPTION
This PR aims at enabling to patch the dependencies for the functional tests that are used in E2E testing (targeted rel/6.2 to have a wide dependency patcher support). 

This PR depends on #360 (included as a cherry-picked dropme commit).

It addresses issue #359, and does a bit of cleanup.