### PR TITLE
Address additional line breaks in streaming v4

### DIFF
--- a/lib/auth/streamingV4/V4Transform.js
+++ b/lib/auth/streamingV4/V4Transform.js
@@ -59,7 +59,7 @@ export default class V4Transform extends Transform {
      * the parsed metadata piece
      */
     _parseMetadata(remainingChunk) {
-        const lineBreakIndex = remainingChunk.indexOf('\r\n');
+        let lineBreakIndex = remainingChunk.indexOf('\r\n');
         if (lineBreakIndex < 0) {
             this.currentMetadata.push(remainingChunk);
             return { completeMetadata: false };
@@ -67,9 +67,21 @@ export default class V4Transform extends Transform {
         const metadataPiece = remainingChunk.slice(0, lineBreakIndex);
         // add metadataPiece to any prior collected metadata pieces
         this.currentMetadata.push(metadataPiece);
-        const fullMetadata = Buffer.concat(this.currentMetadata);
+        let fullMetadata = Buffer.concat(this.currentMetadata);
         // reset currentMetadata
         this.currentMetadata.length = 0;
+        // handle extra line break on end of data chunk
+        if (fullMetadata.length === 0) {
+            const chunkWithoutLeadingLineBreak = remainingChunk.slice(2);
+            // find second line break
+            lineBreakIndex = chunkWithoutLeadingLineBreak.indexOf('\r\n');
+            if (lineBreakIndex < 0) {
+                this.currentMetadata.push(chunkWithoutLeadingLineBreak);
+                return { completeMetadata: false };
+            }
+            fullMetadata = chunkWithoutLeadingLineBreak.slice(0,
+                lineBreakIndex);
+        }
 
         const splitMeta = fullMetadata.toString().split(';');
         if (splitMeta.length !== 2) {
@@ -93,10 +105,17 @@ export default class V4Transform extends Transform {
         this.currentSignature = chunkSig;
         this.seekingDataSize = dataSize;
         this.haveMetadata = true;
+        // start slice at lineBreak plus 2 to remove line break at end of
+        // metadata piece since length of '\r\n' is 2
+        let unparsedChunk = remainingChunk.slice(lineBreakIndex + 2);
+        // remove extra line break at end of metadata piece
+        // (beginning of data piece) if any
+        if (unparsedChunk.indexOf('\r\n') === 0) {
+            unparsedChunk = unparsedChunk.slice(2);
+        }
         return {
             completeMetadata: true,
-            // start slice at lineBreak plus 2 since length of '\r\n' is 2
-            unparsedChunk: remainingChunk.slice(lineBreakIndex + 2),
+            unparsedChunk,
         };
     }
 

--- a/tests/functional/fog/tests.rb
+++ b/tests/functional/fog/tests.rb
@@ -44,7 +44,8 @@ describe Fog do
         $fileToStreamMd5 = Digest::MD5.file(fileToStream).hexdigest
 
         File.open(smallFile, "wb") do |f|
-            f.write('smallfile\r\nwith\r\nline\r\nbreaks\r\neverywhere\r\n')
+            f.write('\r\n\r\nsmallfile\r\nwith\r\nline\r\n' +
+            'breaks\r\neverywhere\r\n\r\n\r\n')
         end
         $smallFileMd5 = Digest::MD5.file(smallFile).hexdigest
     end


### PR DESCRIPTION
Oracle sbt appears to be adding extra line breaks between the metadata portions and data portions of the chunks in streaming v4 auth.  This PR removes the extra line breaks if any.