### PR TITLE
COMPAT putBucketACL return InvalidArgument for bad ID

### DIFF
--- a/lib/api/bucketPutACL.js
+++ b/lib/api/bucketPutACL.js
@@ -215,6 +215,20 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                         .toLowerCase() === 'id');
             }
 
+            // For now, at least make sure ID is 64-char alphanumeric
+            // string before adding to ACL (check can be removed if
+            // verifying with Vault for associated accounts first)
+            for (let i = 0; i < usersIdentifiedByID.length; i++) {
+                const id = usersIdentifiedByID[i].identifier;
+                if (!aclUtils.isValidCanonicalId(id)) {
+                    log.trace('invalid user id argument', {
+                        id,
+                        method: 'bucketPutACL',
+                    });
+                    return callback(errors.InvalidArgument);
+                }
+            }
+
             const justEmails = usersIdentifiedByEmail
                 .map(item => item.identifier);
             // If have to lookup canonicalID's do that asynchronously

--- a/lib/utilities/aclUtils.js
+++ b/lib/utilities/aclUtils.js
@@ -171,6 +171,10 @@ aclUtils.parseGrant = function parseGrant(grantHeader, grantType) {
     });
 };
 
+aclUtils.isValidCanonicalId = function isValidCanonicalId(canonicalID) {
+    return /^[A-Za-z0-9]{64}$/.test(canonicalID);
+};
+
 aclUtils.reconstructUsersIdentifiedByEmail =
     function reconstruct(userInfofromVault, userGrantInfo) {
         return userInfofromVault.map(item => {

--- a/tests/functional/aws-node-sdk/test/bucket/putACL.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putACL.js
@@ -1,0 +1,66 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucketName = 'putbucketaclfttest';
+
+describe('PUT Bucket ACL', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+
+        beforeEach(() => {
+            process.stdout.write('About to create bucket');
+            return bucketUtil.createOne(bucketName).catch(err => {
+                process.stdout.write(`Error in beforeEach ${err}\n`);
+                throw err;
+            });
+        });
+
+        afterEach(() => {
+            process.stdout.write('About to delete bucket');
+            return bucketUtil.deleteOne(bucketName).catch(err => {
+                process.stdout.write(`Error in afterEach ${err}\n`);
+                throw err;
+            });
+        });
+
+        it('should return InvalidArgument if invalid grantee ' +
+            'user ID provided in ACL header request', done => {
+            s3.putBucketAcl({
+                Bucket: bucketName,
+                GrantRead: 'id=invalidUserID' }, err => {
+                assert.strictEqual(err.statusCode, 400);
+                assert.strictEqual(err.code, 'InvalidArgument');
+                done();
+            });
+        });
+
+        it('should return InvalidArgument if invalid grantee ' +
+            'user ID provided in ACL request body', done => {
+            s3.putBucketAcl({
+                Bucket: bucketName,
+                AccessControlPolicy: {
+                    Grants: [
+                        {
+                            Grantee: {
+                                Type: 'CanonicalUser',
+                                ID: 'invalidUserID',
+                            },
+                            Permission: 'WRITE_ACP',
+                        }],
+                    Owner: {
+                        DisplayName: 'Bart',
+                        ID: '79a59df900b949e55d96a1e698fbace' +
+                        'dfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    },
+                },
+            }, err => {
+                assert.strictEqual(err.statusCode, 400);
+                assert.strictEqual(err.code, 'InvalidArgument');
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import AuthInfo from '../../lib/auth/AuthInfo';
 import constants from '../../constants';
 import { metadata } from '../../lib/metadata/in_memory/metadata';
@@ -43,7 +44,7 @@ export function makeAuthInfo(accessKey) {
             + 'cd47ef2be',
         accessKey2: '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7'
             + 'cd47ef2bf',
-        default: `${accessKey}canonicalID`,
+        default: crypto.randomBytes(32).toString('hex'),
     };
     canIdMap[constants.publicId] = constants.publicId;
 


### PR DESCRIPTION
FIXES #365 

Had to modify some existing unit tests to comply with new requirements.