### PR TITLE
BF: Fix off by one range

### DIFF
--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -244,7 +244,7 @@ const routesUtils = {
             }
             const partStart = parseInt(dataLocations[i].start, 10);
             const partSize = parseInt(dataLocations[i].size, 10);
-            if (partStart + partSize < begin) {
+            if (partStart + partSize <= begin) {
                 continue;
             }
             if (partStart >= begin) {

--- a/tests/functional/aws-node-sdk/test/legacy/tests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/tests.js
@@ -307,9 +307,11 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
         },
         { it: 'should get a range from the second part of an object ' +
             'put by multipart upload',
-            range: 'bytes=5242881-5242890',
+            // The completed MPU byte count starts at 0, so the first part ends
+            // at byte 5242879 and the second part begins at byte 5242880
+            range: 'bytes=5242880-5242889',
             contentLength: '10',
-            contentRange: 'bytes 5242881-5242890/10485760',
+            contentRange: 'bytes 5242880-5242889/10485760',
             // A range from the second part should just contain 1
             expectedBuff: Buffer.alloc(10, 1),
         },


### PR DESCRIPTION
* When the byte range is half the object size from a MPU, an error
  is thrown by fs.ReadStream (`Error: start must be <= end`). This
  causes a `NetworkingError: socket hang up` error in file backend.
  This commit fixes that and modifies the test to ensure that the
  range is handled properly.