### PR TITLE
COMPAT: Set 'Accept-Range' header for all ranges in getObject API

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -50,12 +50,12 @@ function objectGet(authInfo, request, log, callback) {
             maxContentLength =
                 parseInt(responseMetaHeaders['Content-Length'], 10);
             range = parseRange(request.headers.range, maxContentLength);
+            responseMetaHeaders['Accept-Ranges'] = 'bytes';
             if (range) {
                 // End of range should be included so + 1
                 responseMetaHeaders['Content-Length'] =
                     Math.min(maxContentLength - range[0],
                     range[1] - range[0] + 1);
-                responseMetaHeaders['Accept-Ranges'] = 'bytes';
                 responseMetaHeaders['Content-Range'] = `bytes ${range[0]}-`
                     + `${Math.min(maxContentLength - 1, range[1])}` +
                     `/${maxContentLength}`;

--- a/tests/functional/aws-node-sdk/test/legacy/tests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/tests.js
@@ -439,6 +439,7 @@ describe('aws-node-sdk test suite as registered user', function testSuite() {
                     return done(new Error(
                         `error getting object range: ${err}`));
                 }
+                assert.strictEqual(data.AcceptRanges, 'bytes');
                 assert.strictEqual(data.ContentLength, test.contentLength);
                 assert.strictEqual(data.ContentRange, test.contentRange);
                 assert.deepStrictEqual(data.Body, test.expectedBuff);


### PR DESCRIPTION
Fixes #378

If `Range` parameter is given to getObject API, the 'Accept-Range'
  header should be set to 'bytes' regardless whether or not the
  given range is valid. Prior to this change, [this test](https://github.com/scality/S3/blob/master/tests/functional/aws-node-sdk/test/legacy/tests.js#L418)
  would not return an object with an `AcceptRanges` key-value pair.