### PR TITLE
Add backend healthcheck functionality

### DIFF
--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -108,6 +108,11 @@ export const backend = {
             return callback();
         });
     },
+
+    healthcheck: (log, callback) => {
+        process.nextTick(() =>
+            callback(null, { statusCode: 200, statusMessage: 'OK' }));
+    },
 };
 
 export default backend;

--- a/lib/data/in_memory/backend.js
+++ b/lib/data/in_memory/backend.js
@@ -86,6 +86,11 @@ export const backend = {
             return callback(null);
         });
     },
+
+    healthcheck: (log, callback) => {
+        process.nextTick(() =>
+            callback(null, { statusCode: 200, statusMessage: 'OK' }));
+    },
 };
 
 export default backend;

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -153,6 +153,25 @@ const data = {
         client = newClient;
         return client;
     },
+
+    checkHealth: (log, cb) => {
+        client.healthcheck(log, (err, result) => {
+            const respBody = {};
+            if (err) {
+                log.error(`error from ${implName}`, { error: err });
+                respBody[implName] = {
+                    error: err,
+                };
+                // respBody also returned so error is written to response
+                return cb(err, respBody);
+            }
+            respBody[implName] = {
+                code: result.statusCode,
+                message: result.statusMessage,
+            };
+            return cb(null, respBody);
+        });
+    },
 };
 
 export default data;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,4 +1,4 @@
-import { errors, ipCheck } from 'arsenal';
+import { errors } from 'arsenal';
 import { UtapiClient } from 'utapi';
 
 import routeGET from './routes/routeGET';
@@ -8,6 +8,7 @@ import routeHEAD from './routes/routeHEAD';
 import routePOST from './routes/routePOST';
 import routesUtils from './routes/routesUtils';
 import utils from './utils';
+import healthcheckHandler from './utilities/healthcheckHandler';
 import _config from './Config';
 
 const routeMap = {
@@ -35,46 +36,6 @@ function checkUnsuportedRoutes(req, res, log) {
     return routesUtils.responseXMLBody(errors.MethodNotAllowed, null, res, log);
 }
 
-// current function utility is minimal, but will be expanded
-export function isHealthy() {
-    return true;
-}
-
-function writeResponse(res, error, log) {
-    const statusCode = error ? error.code : 200;
-    const body = Buffer.from(error ? JSON.stringify(error) : '{}', 'utf8');
-
-    res.writeHead(statusCode, {
-        'content-type': 'application/json',
-        'content-length': body.length,
-    });
-    res.write(body);
-
-    res.end(() => {
-        log.end().info('healthcheck ended', {
-            httpCode: res.statusCode,
-        });
-    });
-}
-
-function healthcheckRouteHandler(req, res, log) {
-    if (isHealthy()) {
-        if (req.method === 'GET' || req.method === 'POST') {
-            writeResponse(res, null, log);
-        } else {
-            writeResponse(res, errors.BadRequest, log);
-        }
-    } else {
-        writeResponse(res, errors.InternalError, log);
-    }
-    return res.statusCode;
-}
-
-function checkIP(clientIP) {
-    return ipCheck.ipMatchCidrList(
-        _config.healthChecks.allowFrom, clientIP);
-}
-
 export default function routes(req, res, logger) {
     const clientInfo = {
         clientIP: req.socket.remoteAddress,
@@ -89,10 +50,9 @@ export default function routes(req, res, logger) {
     log.end().addDefaultFields(clientInfo);
 
     if (req.url === '/_/healthcheck') {
-        if (!checkIP(clientInfo.clientIP)) {
-            return writeResponse(res, errors.AccessDenied, log);
-        }
-        return healthcheckRouteHandler(req, res, log);
+        return healthcheckHandler(clientInfo.clientIP, false, req, res, log);
+    } else if (req.url === '/_/healthcheck/deep') {
+        return healthcheckHandler(clientInfo.clientIP, true, req, res, log);
     }
 
     try {

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -1,0 +1,98 @@
+import { errors, ipCheck } from 'arsenal';
+import _config from '../Config';
+import data from '../data/wrapper';
+import vault from '../auth/vault';
+import metadata from '../metadata/wrapper';
+import async from 'async';
+
+// current function utility is minimal, but will be expanded
+export function isHealthy() {
+    return true;
+}
+
+function writeResponse(res, error, log, results, cb) {
+    let statusCode = 200;
+    if (error) {
+        // error.code can be a string (such as ECONNREFUSED)
+        if (Number.isInteger(error.code)) {
+            statusCode = error.code;
+        } else {
+            statusCode = 500;
+        }
+    }
+    // If we're here then s3 is considered ok
+    const initial = { S3: { code: 200, message: 'OK' } };
+    const merged = results.reduce(
+        (prev, value) => Object.assign(prev, value), initial);
+
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.write(JSON.stringify(merged));
+    res.end(() => {
+        cb(error, merged);
+    });
+}
+
+function clientCheck(req, res, log, cb) {
+    const clients = [
+        data,
+        metadata,
+        vault,
+    ];
+    const clientTasks = [];
+    clients.forEach(client => {
+        if (typeof client.checkHealth === 'function') {
+            clientTasks.push(done => {
+                client.checkHealth(log, done);
+            });
+        }
+    });
+    async.parallel(clientTasks, cb);
+}
+
+function routeHandler(deep, req, res, log, cb) {
+    if (isHealthy()) {
+        if (req.method === 'GET' || req.method === 'POST') {
+            if (deep) {
+                return clientCheck(req, res, log, cb);
+            }
+            return cb(null, []);
+        }
+        return cb(errors.BadRequest, []);
+    }
+    return cb(errors.InternalError, []);
+}
+
+function checkIP(clientIP) {
+    return ipCheck.ipMatchCidrList(
+        _config.healthChecks.allowFrom, clientIP);
+}
+
+/*
+* Checks if client IP address is allowed to make http request to
+* S3 server. Defines function 'healthcheckEndHandler', which is
+* called if IP not allowed or passed as callback.
+* @param {object} clientIP - IP address of client
+* @param {boolean} deep - true if healthcheck will check backends
+* @param {object} req - http request object
+* @param {object} res - http response object
+* @param {object} log - werelogs logger instance
+*/
+export default function healthcheckHandler(clientIP, deep, req, res, log) {
+    function healthcheckEndHandler(err, results) {
+        writeResponse(res, err, log, results, (error, body) => {
+            if (error) {
+                return log.end().warn('healthcheck error', {
+                    error,
+                });
+            }
+            return log.end().info('healthcheck ended', {
+                result: body,
+            });
+        });
+    }
+
+    if (!checkIP(clientIP)) {
+        return healthcheckEndHandler(errors.AccessDenied, []);
+    }
+    return routeHandler(deep, req, res, log, healthcheckEndHandler);
+}

--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -60,4 +60,12 @@ describe('Healthcheck routes', () => {
         const req = transport.request(putOptions, makeChecker(400, done));
         req.end();
     });
+    it('should return 200 on deep GET request', done => {
+        const deepOptions = deepCopy(options);
+        deepOptions.method = 'GET';
+        deepOptions.path = '/_/healthcheck/deep';
+        deepOptions.agent = makeAgent();
+        const req = transport.request(deepOptions, makeChecker(200, done));
+        req.end();
+    });
 });

--- a/tests/unit/healthchecks/healthcheckResponse.js
+++ b/tests/unit/healthchecks/healthcheckResponse.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { isHealthy } from '../../../lib/routes';
+import { isHealthy } from '../../../lib/utilities/healthcheckHandler';
 
 describe('isHealthy function for setHealthCheckResponse', () => {
     it('should return true', () => {


### PR DESCRIPTION
Creates route that will be called by load balancers, skips backends that don't have a `check` function. Includes the first implementation of a check for sproxyd for each backend option.
Depends on sproxydclient PR https://github.com/scality/sproxydclient/pull/92