### PR TITLE
Make Docker image even lighter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 RUN apt-get update \
-    && apt-get install -y python git build-essential \
-    && npm install \
-    && apt-get autoremove -y python build-essential
+    && apt-get install -y python git build-essential --no-install-recommends \
+    && npm install --production \
+    && apt-get autoremove -y python build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm cache clear \
+    && rm -rf ~/.node-gyp \
+    && rm -rf /tmp/npm-*
 
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
 

--- a/DockerfileMem
+++ b/DockerfileMem
@@ -6,9 +6,13 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 RUN apt-get update \
-    && apt-get install -y python git build-essential \
-    && npm install \
-    && apt-get autoremove -y python build-essential
+    && apt-get install -y python git build-essential --no-install-recommends \
+    && npm install --production \
+    && apt-get autoremove -y python build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm cache clear \
+    && rm -rf ~/.node-gyp \
+    && rm -rf /tmp/npm-*
 
 ENV S3BACKEND mem
 


### PR DESCRIPTION
I was happy to see that you made the Docker image lighter in 244a5f12cbc5fd3193d1a14a3b3be9ca160ec7b9.

I was able to reduce the image size even further.

Here are the commands I used to check the image size before and after each change:

    docker build -f DockerfileMem -t scality/s3server:mem-latest .
    docker save scality/s3server:mem-latest | pxz > 01.tar.xz && du -h 01.tar.xz

## Results

**master**

    119M    01.tar.xz

**After 'rm -rf /var/lib/apt/lists/*'**

    110M	01.tar.xz

**After 'npm cache clear':**

     95M	01.tar.xz
