### PR TITLE
Redirect CI test output and quiet AWS SDK logs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,13 +40,20 @@ test:
     - yamllint $(git ls-files '*.yml')
     - mkdir -p $CIRCLE_TEST_REPORTS/unit
     - npm run unit_coverage
-    - S3BACKEND=mem npm start & sleep 15 &&
-      cd ./tests/functional/jaws && mvn test
-    - S3BACKEND=mem npm start & sleep 4 && npm run ft_test;
-    - S3BACKEND=mem npm start & sleep 4 &&
+    - S3BACKEND=mem npm start > $CIRCLE_ARTIFACTS/javaServerTest.txt &
+      sleep 15 &&
+      cd ./tests/functional/jaws && mvn test;
+    - S3BACKEND=mem npm start > $CIRCLE_ARTIFACTS/memServerTest.txt &
+      sleep 4 && npm run ft_test;
+    - S3BACKEND=mem npm start > $CIRCLE_ARTIFACTS/memServerEnryptTest.txt &
+      sleep 4 && ENABLE_KMS_ENCRYPTION=true npm run ft_test;
+    - S3BACKEND=file S3VAULT=mem npm start > $CIRCLE_ARTIFACTS/fileTest.txt &
+      sleep 15 &&
+      npm run ft_test;
+    - S3BACKEND=file
+      S3VAULT=mem npm start > $CIRCLE_ARTIFACTS/fileEncryptTest.txt &
+      sleep 15 &&
       ENABLE_KMS_ENCRYPTION=true npm run ft_test;
-    - S3BACKEND=file S3VAULT=mem npm start & sleep 15 && npm run ft_test;
-    - S3BACKEND=file S3VAULT=mem npm start & sleep 15 &&
-      ENABLE_KMS_ENCRYPTION=true npm run ft_test;
-    - S3BACKEND=mem npm start & sleep 15 &&
-      cd tests/functional/fog && rspec tests.rb
+    - S3BACKEND=mem npm start > $CIRCLE_ARTIFACTS/rubyServerTest.txt &
+      sleep 15 &&
+      cd tests/functional/fog && rspec tests.rb;

--- a/tests/functional/aws-node-sdk/test/support/config.js
+++ b/tests/functional/aws-node-sdk/test/support/config.js
@@ -19,7 +19,6 @@ if (ssl && ssl.ca) {
 }
 
 const DEFAULT_GLOBAL_OPTIONS = {
-    logger: process.stdout,
     httpOptions,
     apiVersions: { s3: '2006-03-01' },
     signatureCache: false,


### PR DESCRIPTION
Due to the large CI output, browsers crash when trying to open the CI and there is a lot of noise in the output.
This is EXTREMELY frustrating.
Here, I send the server logs to files in the artifacts and quiet AWS-SDK logs.