### PR TITLE
TEST: Refactor range tests to use getRange.c

### DIFF
--- a/tests/functional/aws-node-sdk/lib/utility/getRange.c
+++ b/tests/functional/aws-node-sdk/lib/utility/getRange.c
@@ -1,0 +1,227 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+/*
+Crude test of this program:
+
+for size in 0 1 2 7 8 9 15 16 17 18 29;
+do ./knownfile --size=$size toto.$size ;
+   for offset in 1 2 3 4 5 6 7 8 ;
+   do
+       if [ $offset -lt $size ] ;
+       then dd if=toto.$size of=toto.$size.$offset bs=1 skip=$offset \
+            2>/dev/null;
+            if ./knownfile --size=$(($size-$offset)) toto.$size.$offset \
+                --check --offset=$offset;
+            then rm -f toto.$size.$offset; else echo Oops toto.$s.$offset ;
+            fi ;
+       fi;
+   done;
+done
+*/
+
+int usage(const char *reason)
+{
+    fprintf(stderr,
+"Usage: knownfile [-h] [--check] [--size SIZE] [--offset OFFSET] [--quiet] \
+filename\n"
+"\n"
+"Create a file of specified length / Check extract\n"
+"\n"
+"positional arguments:\n"
+"filename                    file to use\n"
+"\n"
+"optional arguments:\n"
+"-h, --help                  show this help message and exit\n"
+"--check, -c                 check mode\n"
+"--size SIZE, -s SIZE        size of the file\n"
+"--offset OFFSET, -o OFFSET  offset of the file\n"
+"--quiet, -q                 quiet mode\n"
+        );
+    if (reason) {
+        fprintf(stderr, "ERR: %s\n", reason);
+    }
+    return 1;
+}
+
+static int quietmode = 0;
+void quietprint(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    if (!quietmode) {
+        vfprintf(stderr, fmt, args);
+        fprintf(stderr, "\n");
+    }
+    va_end(args);
+}
+
+static inline uint8_t offset2val(uint64_t a)
+{
+    a = (a ^ 61) ^ (a >> 16);
+    a = a + (a << 3);
+    a = a ^ (a >> 4);
+    a = a * 0x27d4eb2d;
+    a = a ^ (a >> 15);
+    return a % 256;
+}
+
+void makevals(uint8_t *vals, uint64_t offset, uint64_t size)
+{
+    int i;
+    for (i = 0; i < size; i++) {
+        vals[i] = offset2val(offset + i);
+    }
+}
+
+static uint8_t values[120 * 1024];
+int kf_create(const char *filename, uint64_t size)
+{
+    FILE *f = NULL;
+    uint64_t cur, towrite;
+    int ret = 1;
+    f = fopen(filename, "wb+");
+    if (!f) {
+        quietprint("Cannot open '%s' for writing", filename);
+        goto end;
+    }
+    for (cur = 0; cur < size; cur += towrite) {
+        towrite = size - cur;
+        if (towrite > 120 * 1024) {
+            towrite = 120 * 1024;
+        }
+        makevals(values, cur, towrite);
+        if (fwrite(values, towrite, 1, f) != 1) {
+            quietprint("Failed writing to '%s' at offset %lu", filename, cur);
+            goto end;
+        }
+    }
+    ret = 0;
+end:
+    if (f) {
+        fclose(f);
+        f = NULL;
+    }
+    return ret;
+}
+
+int kf_check(const char *filename, uint64_t size, uint64_t offset)
+{
+    int fd = -1;
+    uint8_t *ptr = MAP_FAILED;
+    uint64_t cur;
+    int ret = 1;
+    struct stat sb;
+
+    fd = open(filename, O_RDONLY);
+    quietprint("Checking %s / size:%lu / offset:%lu", filename, size, offset);
+    if (fd == -1) {
+        quietprint("open of \"%s\" for reading failed", filename);
+        goto end;
+    }
+    if (fstat(fd, &sb) == -1) {
+        quietprint("fstat failed on \"%s\"", filename);
+        goto end;
+    }
+    if (sb.st_size != size) {
+        quietprint("size check failed on \"%s\". Expected %lu, got %lu",
+            filename, size, sb.st_size);
+        goto end;
+    }
+    ptr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (ptr == MAP_FAILED) {
+        quietprint("mmap failed on \"%s\"", filename);
+        goto end;
+    }
+    for (cur = 0; cur < sb.st_size; cur++) {
+        if (ptr[cur] != offset2val(offset + cur)) {
+            quietprint("Content check failed at offset %lu in  \"%s\", offset \
+                %lu in knownfile", cur, filename, offset + cur);
+            goto end;
+        }
+    }
+    ret = 0;
+    quietprint("Success");
+end:
+    if (ptr != MAP_FAILED) {
+        munmap(ptr, sb.st_size);
+    }
+    if (fd >= 0) {
+        close(fd);
+    }
+    return ret;
+}
+
+int main(int argc, char **argv)
+{
+    int c;
+    int checkmode = 0;
+    uint64_t size, offset;
+    const char * filename;
+    int size_set = 0;
+    int offset_set = 0;
+
+    while (1) {
+        int this_option_optind = optind ? optind : 1;
+        int option_index = 0;
+        static struct option long_options[] = {
+            {"help", no_argument, 0, 'h'},
+            {"quiet", no_argument, 0, 'q'},
+            {"check", no_argument, 0, 'c'},
+            {"size", required_argument, 0, 's'},
+            {"offset", required_argument, 0, 'o'},
+            {0, 0, 0, 0}
+        };
+        c = getopt_long(argc, argv, "h?qcs:o:", long_options, & option_index);
+        if (c == -1) {
+            break;
+        }
+        switch (c) {
+            case 0:
+                return usage(NULL);
+                break;
+            case 'c':
+                checkmode = 1;
+                break;
+            case 's':
+                size = strtoll(optarg, NULL, 10);
+                size_set = 1;
+                break;
+            case 'o':
+                offset = strtoll(optarg, NULL, 10);
+                offset_set = 1;
+                break;
+            case 'q':
+                quietmode = 1;
+                break;
+            case 'h':
+            case '?':
+                return usage(NULL);
+                break;
+        }
+    }
+    if (optind != argc - 1) {
+        return usage("Wrong number of arguments");
+    }
+    filename = argv[optind];
+    if (!size_set) {
+        return usage("Missing size\n");
+    }
+    if (checkmode) {
+        if (!offset_set) {
+            offset = 0;
+        }
+        return kf_check(filename, size, offset);
+    } else {
+        return kf_create(filename, size);
+    }
+    return 0;
+}

--- a/tests/functional/aws-node-sdk/test/object/rangeTest.js
+++ b/tests/functional/aws-node-sdk/test/object/rangeTest.js
@@ -1,0 +1,246 @@
+import { exec, execFile } from 'child_process';
+import { writeFile, createReadStream } from 'fs';
+
+import assert from 'assert';
+import Promise from 'bluebird';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucket = 'bucket-for-range-test';
+const key = 'key-for-range-test';
+let s3;
+
+const execAsync = Promise.promisify(exec);
+const execFileAsync = Promise.promisify(execFile);
+const writeFileAsync = Promise.promisify(writeFile);
+
+// Get the expected end values for various ranges (e.g., '-10', '10-', '-')
+function getOuterRange(range, bytes) {
+    const arr = range.split('-');
+    if (arr[0] === '' && arr[1] !== '') {
+        arr[0] = Number.parseInt(bytes, 10) - Number.parseInt(arr[1], 10);
+        arr[1] = Number.parseInt(bytes, 10) - 1;
+    } else {
+        arr[0] = arr[0] === '' ? 0 : Number.parseInt(arr[0], 10);
+        arr[1] = arr[1] === '' || Number.parseInt(arr[1], 10) >= bytes ?
+            Number.parseInt(bytes, 10) - 1 : arr[1];
+    }
+    return {
+        begin: arr[0],
+        end: arr[1],
+    };
+}
+
+// Get the ranged object from a bucket. Write the response body to a file, then
+// use getRangeExec to check that all the bytes are in the correct location.
+function checkRanges(range, bytes) {
+    return s3.getObjectAsync({
+        Bucket: bucket,
+        Key: key,
+        Range: `bytes=${range}`,
+    })
+    .then(res => {
+        const { begin, end } = getOuterRange(range, bytes);
+        const total = (end - begin) + 1;
+        // If the range header is '-' (i.e., it is invalid), content range
+        // should be undefined
+        const contentRange = range === '-' ? undefined :
+            `bytes ${begin}-${end}/${bytes}`;
+
+        assert.deepStrictEqual(res.ContentLength, total.toString());
+        assert.deepStrictEqual(res.ContentRange, contentRange);
+        assert.deepStrictEqual(res.ContentType, 'application/octet-stream');
+        assert.deepStrictEqual(res.Metadata, {});
+
+        // Write a file using the buffer so getRangeExec can then check bytes.
+        // If the getRangeExec program fails, then the range is incorrect.
+        return writeFileAsync(`hashedFile.${bytes}.${range}`, res.Body)
+        .then(() => execFileAsync('./getRangeExec', ['--check', '--size', total,
+            '--offset', begin, `hashedFile.${bytes}.${range}`]));
+    });
+}
+
+// Create 5MB parts and upload them as parts of a MPU
+function uploadParts(bytes, uploadId) {
+    const name = `hashedFile.${bytes}`;
+
+    return Promise.map([1, 2], part =>
+        execFileAsync('dd', [`if=${name}`, `of=${name}.mpuPart${part}`,
+            'bs=5242880', `skip=${part - 1}`, 'count=1'])
+        .then(() => s3.uploadPartAsync({
+            Bucket: bucket,
+            Key: key,
+            PartNumber: part,
+            UploadId: uploadId,
+            Body: createReadStream(`${name}.mpuPart${part}`),
+        }))
+    );
+}
+
+// Create a hashed file of size bytes
+function createHashedFile(bytes) {
+    const name = `hashedFile.${bytes}`;
+    return execFileAsync('./getRangeExec', ['--size', bytes, name]);
+}
+
+describe('aws-node-sdk range tests', () => {
+    before(() => execFileAsync('gcc', ['-o', 'getRangeExec',
+        'lib/utility/getRange.c']));
+    after(() => execAsync('rm getRangeExec'));
+
+    describe('aws-node-sdk range test for object put by MPU', () =>
+        withV4(sigCfg => {
+            const bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            const fileSize = 10 * 1024 * 1024;
+            let uploadId;
+
+            beforeEach(() =>
+                s3.createBucketAsync({ Bucket: bucket })
+                .then(() => s3.createMultipartUploadAsync({
+                    Bucket: bucket,
+                    Key: key,
+                }))
+                .then(res => {
+                    uploadId = res.UploadId;
+                })
+                .then(() => createHashedFile(fileSize))
+                .then(() => uploadParts(fileSize, uploadId))
+                .then(res => s3.completeMultipartUploadAsync({
+                    Bucket: bucket,
+                    Key: key,
+                    UploadId: uploadId,
+                    MultipartUpload: {
+                        Parts: [
+                            {
+                                ETag: res[0].ETag,
+                                PartNumber: 1,
+                            },
+                            {
+                                ETag: res[1].ETag,
+                                PartNumber: 2,
+                            },
+                        ],
+                    },
+                }))
+            );
+
+            afterEach(() => bucketUtil.empty(bucket)
+                .then(() => s3.abortMultipartUploadAsync({
+                    Bucket: bucket,
+                    Key: key,
+                    UploadId: uploadId,
+                }))
+                .catch(err => new Promise((resolve, reject) => {
+                    if (err.code !== 'NoSuchUpload') {
+                        reject(err);
+                    }
+                    resolve();
+                }))
+                .then(() => bucketUtil.deleteOne(bucket))
+                .then(() => execAsync(`rm hashedFile.${fileSize}*`))
+            );
+
+            it('should get a range from the first part of an object', () =>
+                checkRanges('0-9', fileSize));
+
+            it('should get a range from the second part of an object', () =>
+                checkRanges('5242880-5242889', fileSize));
+
+            it('should get a range that spans both parts of an object', () =>
+                checkRanges('5242875-5242884', fileSize));
+
+            it('should get a range from the second part of an object and ' +
+                'include the end if the range requested goes beyond the ' +
+                'actual object end', () =>
+                checkRanges('10485750-10485790', fileSize));
+        }));
+
+    describe('aws-node-sdk range test of regular object put (non-MPU)', () =>
+        withV4(sigCfg => {
+            const bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            const fileSize = 2000;
+
+            beforeEach(() =>
+                s3.createBucketAsync({ Bucket: bucket })
+                .then(() => createHashedFile(fileSize))
+                .then(() => s3.putObjectAsync({
+                    Bucket: bucket,
+                    Key: key,
+                    Body: createReadStream(`hashedFile.${fileSize}`),
+                })));
+
+            afterEach(() =>
+                bucketUtil.empty(bucket)
+                .then(() => bucketUtil.deleteOne(bucket))
+                .then(() => execAsync(`rm hashedFile.${fileSize}*`)));
+
+            const putRangeTests = [
+                '-', // Test for invalid range
+                '-1',
+                '-10',
+                '-512',
+                '-2000',
+                '0-',
+                '1-',
+                '190-',
+                '512-',
+                '0-7',
+                '0-9',
+                '8-15',
+                '10-99',
+                '0-511',
+                '0-512',
+                '0-513',
+                '0-1023',
+                '0-1024',
+                '0-1025',
+                '0-2000',
+                '1-2000',
+                '1000-1999',
+                '1023-1999',
+                '1024-1999',
+                '1025-1999',
+                '1976-1999',
+                '1999-2001',
+            ];
+
+            putRangeTests.forEach(range => {
+                it(`should get a range of ${range} bytes using a ${fileSize} ` +
+                    'byte sized object', () =>
+                    checkRanges(range, fileSize));
+            });
+        }));
+
+    describe('aws-node-sdk range test for large end position', () => {
+        withV4(sigCfg => {
+            const bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            const fileSize = 2900;
+
+            beforeEach(() =>
+                s3.createBucketAsync({ Bucket: bucket })
+                .then(() => createHashedFile(fileSize))
+                .then(() => s3.putObjectAsync({
+                    Bucket: bucket,
+                    Key: key,
+                    Body: createReadStream(`hashedFile.${fileSize}`),
+                })));
+
+            afterEach(() =>
+                bucketUtil.empty(bucket)
+                .then(() => bucketUtil.deleteOne(bucket))
+                .then(() => execAsync(`rm hashedFile.${fileSize}*`)));
+
+            it('should get the final 90 bytes of a 2890 byte object for a ' +
+                'byte range of 2800-', () =>
+                checkRanges('2800-', fileSize));
+
+            it('should get the final 90 bytes of a 2890 byte object for a ' +
+                'byte range of 2800-Number.MAX_SAFE_INTEGER', () =>
+                checkRanges(`2800-${Number.MAX_SAFE_INTEGER}`, fileSize));
+        });
+    });
+});


### PR DESCRIPTION
This PR refactors range tests by using files created with the executable file of getRange.c where each byte of the file is a hash of its offset. The C code is written by Flavien Lebarbe. The general approach for each test: 
1. Generate a hashed file of a certain number of bytes with the executable and put that file in a bucket. 
2. Use the getObject API to retrieve the byte range from the object in the bucket and write a file with the response body.
3. Check the file's bytes (the one written in step 2) with the getRange executable program.
3. Success!