### PR TITLE
Extend expiration time in v2 query test.

### DIFF
--- a/tests/functional/aws-node-sdk/test/legacy/authV2QueryTests.js
+++ b/tests/functional/aws-node-sdk/test/legacy/authV2QueryTests.js
@@ -39,10 +39,10 @@ describe('aws-node-sdk v2auth query tests', function testSuite() {
     });
 
     // AWS allows an expiry further in the future
-    // 100001 seconds is higher that the Expires time limit: 100000 seconds
+    // 100010 seconds is higher that the Expires time limit: 100000 seconds
     itSkipAWS('should return an error code if expires header is too far ' +
         'in the future', done => {
-        const params = { Bucket: bucket, Expires: 100001 };
+        const params = { Bucket: bucket, Expires: 100010 };
         const url = s3.getSignedUrl('createBucket', params);
         provideRawOutput(['-verbose', '-X', 'PUT', url], httpCode => {
             assert.strictEqual(httpCode, '403 FORBIDDEN');


### PR DESCRIPTION
Test is testing whether expiration time is too far
in the future.  With the public CI, 1 second is not
long enough to give the public CI time to make the call
and fail as expected (meaning pass the test) on some runs.