### PR TITLE
FIX: Remove useless object creation

### DIFF
--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -3,6 +3,7 @@ import { errors } from 'arsenal';
 import { markerFilter, prefixFilter } from './bucket_utilities';
 import { ListBucketResult } from './ListBucketResult';
 import getMultipartUploadListing from './getMultipartUploadListing';
+import BucketInfo from '../BucketInfo';
 import { metadata } from './metadata';
 
 const defaultMaxKeys = 1000;
@@ -41,7 +42,8 @@ const metastore = {
             if (!metadata.buckets.has(bucketName)) {
                 return cb(errors.NoSuchBucket);
             }
-            return cb(null, metadata.buckets.get(bucketName));
+            return cb(null, BucketInfo.fromObj(
+                    metadata.buckets.get(bucketName)));
         });
     },
 

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -1,6 +1,5 @@
 import BucketClientInterface from './bucketclient/backend';
 import BucketFileInterface from './bucketfile/backend';
-import BucketInfo from './BucketInfo';
 import inMemory from './in_memory/backend';
 import config from '../Config';
 
@@ -51,7 +50,7 @@ const metadata = {
                 return cb(err);
             }
             log.trace('bucket retrieved from metadata');
-            return cb(err, BucketInfo.fromObj(data));
+            return cb(err, data);
         });
     },
 


### PR DESCRIPTION
There is no need to create a BucketInfo from
another BucketInfo, putting the fromObj in
the in_memory backend fix that.