### PR TITLE
chore: Fix flake8 linting error following package upgrade

### DIFF
--- a/tests/functional/boto/boto/setup.py
+++ b/tests/functional/boto/boto/setup.py
@@ -17,6 +17,7 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
+
 setup(
     name='test-boto',
     url='http://www.scality.com',

--- a/tests/functional/boto/boto/tests/test_boto.py
+++ b/tests/functional/boto/boto/tests/test_boto.py
@@ -23,6 +23,7 @@ class Test(object):
         """delete this function once the below 2 are uncommented"""
         assert True
 
+
 ''' 2015/10/28 commented as crashing the server
     def test_create_bucket(self):
         """Can we create a bucket ?"""


### PR DESCRIPTION
This will "unblock" the CI by fixing the linting error that came with flake8's pip package update.
Another option would be to set the version we install in the circle.yml, but would probably be easily out-of-sync with the developer's setup. As such I took the "fix-it" approach.