### PR TITLE
COMPAT: AWS rejects invalid max-keys for listObjects

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -46,7 +46,7 @@ export default function bucketGet(authInfo, request, log, callback) {
     const encoding = params['encoding-type'];
     let maxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
-    if (maxKeys < 0) {
+    if (Number.isNaN(maxKeys) || maxKeys < 0) {
         return callback(errors.InvalidArgument);
     }
     if (maxKeys > constants.listingHardLimit) {

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -644,6 +644,24 @@ describe('s3curl getBucket', () => {
                 });
             });
     });
+
+    it('should return InvalidArgument error with negative max-keys', done => {
+        provideRawOutput(
+            ['--', `${bucketPath}?&max-keys=-2`, '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '400 BAD REQUEST');
+                assertError(rawOutput.stdout, 'InvalidArgument', done);
+            });
+    });
+
+    it('should return InvalidArgument error with invalid max-keys', done => {
+        provideRawOutput(
+            ['--', `${bucketPath}?max-keys='slash'`, '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '400 BAD REQUEST');
+                assertError(rawOutput.stdout, 'InvalidArgument', done);
+            });
+    });
 });
 
 describe('s3curl head bucket', () => {


### PR DESCRIPTION
FIXES #395