### PR TITLE
COMPAT: Handle url encoding in bucketGet API

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -90,6 +90,7 @@ export default function bucketGet(authInfo, request, log, callback) {
                 { tag: 'Marker', value: listParams.marker },
                 { tag: 'MaxKeys', value: listParams.maxKeys },
                 { tag: 'Delimiter', value: listParams.delimiter },
+                { tag: 'EncodingType', value: encoding },
                 { tag: 'IsTruncated', value: isTruncated },
             ];
 

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -617,6 +617,22 @@ describe('s3curl getBucket', () => {
                 });
             });
     });
+
+    it('should return an EncodingType XML tag with the value "url"', done => {
+        provideRawOutput(
+            ['--', bucketPath, '-G', '-d', 'encoding-type=url', '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '200 OK');
+                parseString(rawOutput.stdout, (err, result) => {
+                    if (err) {
+                        assert.ifError(err);
+                    }
+                    assert.strictEqual(result.ListBucketResult
+                        .EncodingType[0], 'url');
+                    done();
+                });
+            });
+    });
 });
 
 describe('s3curl head bucket', () => {


### PR DESCRIPTION
Fixes #380

If url encoding is specified, the response object needs to include
an XML tag EncodingType with the value 'url'.