### PR TITLE
COMPAT: Return an error for an invalid encoding in getBucket API

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -44,6 +44,10 @@ export default function bucketGet(authInfo, request, log, callback) {
     const params = request.query;
     const bucketName = request.bucketName;
     const encoding = params['encoding-type'];
+    if (encoding !== undefined && encoding !== 'url') {
+        return callback(errors.InvalidArgument.customizeDescription('Invalid ' +
+            'Encoding Method specified in Request'));
+    }
     let maxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
     if (maxKeys < 0) {

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -633,6 +633,24 @@ describe('s3curl getBucket', () => {
                 });
             });
     });
+
+    it('should return an InvalidArgument error when given an invalid ' +
+        'encoding type', done => {
+        provideRawOutput(
+            ['--', bucketPath, '-G', '-d', 'encoding-type=invalidURI', '-v'],
+            (httpCode, rawOutput) => {
+                assert.strictEqual(httpCode, '400 BAD REQUEST');
+                parseString(rawOutput.stdout, (err, result) => {
+                    if (err) {
+                        assert.ifError(err);
+                    }
+                    assert.strictEqual(result.Error.Code[0], 'InvalidArgument');
+                    assert.strictEqual(result.Error.Message[0],
+                        'Invalid Encoding Method specified in Request');
+                    done();
+                });
+            });
+    });
 });
 
 describe('s3curl head bucket', () => {


### PR DESCRIPTION
If an encoding type is given (i.e., it is not `undefined`)
and the encoding type is not 'url', then an `InvalidArgument`
error is returned with a message 'Invalid Encoding Method 
specified in Request'.