### PR TITLE
ft: add stats to healthcheck route

### DIFF
--- a/Healthchecks.md
+++ b/Healthchecks.md
@@ -1,0 +1,77 @@
+# S3 Healthcheck
+
+Scality S3 exposes a healthcheck route `/_/healthcheck` which returns a
+response with HTTP code
+
+- 200 OK
+
+ Server is up and running
+
+- 500 Internal Server error
+
+ Server is experiencing an Internal Error
+
+- 400 Bad Request
+
+ Bad Request due to unsupported HTTP methods
+
+- 403 Forbidden
+
+ Request is not allowed due to IP restriction
+
+## Stats
+
+The healthcheck route's successful response (200 OK) is appended with
+additional statistics in the request body indicating the number of requests
+performed, number of 500 errors occurred over the time interval
+specified in the response.
+
+A sample response would look something like
+
+```json
+{
+    "requests": 5000,
+    "500s": 2,
+    "sampleDuration": 30
+}
+```
+
+## Redis schema
+
+The goal is to return stats for the set interval, i.e., if interval is 30
+seconds, return stats only for the last 30 seconds.
+
+The stats use simple keys with INCR command for every new push. Each key is
+appended with a normalized unix timestamp, as the idea is to store the stats in
+5 second interval(default but configurable) keys. A default TTL of 30
+seconds is associated with each key, this way any keys older than the TTL are
+automatically removed.
+
+When a stats query is received, the results for the prior 30 seconds will be
+returned. This is accomplished by retrieving the 6 keys that represent the 6
+five-second intervals. As Redis does not have a performant RANGE query, the
+list of keys are built manually as follows
+
+* Take current timestamp
+
+* Build each key by subtracting the interval from the timestamp (5 seconds)
+
+* Total keys for each metric (total requests, 500s etc.) is TTL / interval
+  30/5  = 6
+
+Note: When Redis is queried, results from non-existent keys are set to 0.
+
+## Configuration
+
+To gather stats, S3 uses a local Redis instance as a temporary
+datastore. By adding the following config to `config.json`, stats
+will be recorded in Redis.
+
+```json
+{
+    "localCache": {
+        "host": "127.0.0.1",
+        "port": 6379
+    }
+}
+```

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,11 @@ machine:
     version: 4.5.0
   ruby:
     version: "2.0"
+  services:
+    - redis
   environment:
     CXX: g++-4.9
+    ENABLE_LOCAL_CACHE: true
 
 dependencies:
   post:

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -7,6 +7,7 @@ import authDataChecker from './auth/in_memory/checker';
 // whitelist IP, CIDR for health checks
 const defaultHealthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
 
+const defaultLocalCache = { host: '127.0.0.1', port: 6379 };
 /**
  * Reads from a config file and returns the content as a config object
  */
@@ -194,6 +195,23 @@ class Config {
             });
             this.healthChecks.allowFrom = defaultHealthChecks.allowFrom
                 .concat(config.healthChecks.allowFrom);
+        }
+
+        if (process.env.ENABLE_LOCAL_CACHE) {
+            this.localCache = defaultLocalCache;
+        }
+        if (config.localCache) {
+            assert(typeof config.localCache === 'object',
+                'config: invalid local cache configuration. localCache must ' +
+                'be an object');
+            assert(typeof config.localCache.host === 'string',
+                'config: invalid host for localCache. host must be a string');
+            assert(typeof config.localCache.port === 'number',
+                'config: invalid port for localCache. port must be a number');
+            this.localCache = {
+                host: config.localCache.host,
+                port: config.localCache.port,
+            };
         }
 
         if (config.certFilePaths) {

--- a/lib/RedisClient.js
+++ b/lib/RedisClient.js
@@ -1,0 +1,54 @@
+import Redis from 'ioredis';
+
+import { logger } from './utilities/logger';
+
+export default class RedisClient {
+    /**
+    * @constructor
+    * @param {string} host - Redis host
+    * @param {number} port - Redis port
+    */
+    constructor(host, port) {
+        this._client = new Redis({
+            host,
+            port,
+        });
+        this._client.on('error', err =>
+            logger.trace('error from redis', {
+                error: err,
+                method: 'RedisClient.constructor',
+                redisHost: host,
+                redisPort: port,
+            })
+        );
+        return this;
+    }
+
+    /**
+    * increment value of a key by 1 and set a ttl
+    * @param {string} key - key holding the value
+    * @param {number} expiry - expiry in seconds
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    incrEx(key, expiry, cb) {
+        return this._client
+            .multi([['incr', key], ['expire', key, expiry]])
+            .exec(cb);
+    }
+
+
+    /**
+    * execute a batch of commands
+    * @param {string[]} cmds - list of commands
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    batch(cmds, cb) {
+        return this._client.pipeline(cmds).exec(cb);
+    }
+
+    clear(cb) {
+        return this._client.flushDb(cb);
+    }
+}

--- a/lib/StatsClient.js
+++ b/lib/StatsClient.js
@@ -1,0 +1,154 @@
+import async from 'async';
+
+export default class StatsClient {
+
+    /**
+    * @constructor
+    * @param {object} redisClient - RedisClient instance
+    * @param {number} interval - sampling interval
+    * @param {number} expiry - sampling duration
+    */
+    constructor(redisClient, interval, expiry) {
+        this._redis = redisClient;
+        this._interval = interval;
+        this._expiry = expiry;
+        return this;
+    }
+
+    /*
+    * Utility function to use when callback is undefined
+    */
+    _noop() {}
+
+    /**
+    * normalize to the nearest interval
+    * @param {object} d - Date instance
+    * @return {number} timestamp - normalized to the nearest interval
+    */
+    _normalizeTimestamp(d) {
+        const s = d.getSeconds();
+        return d.setSeconds(s - s % this._interval, 0);
+    }
+
+    /**
+    * set timestamp to the previous interval
+    * @param {object} d - Date instance
+    * @return {number} timestamp - set to the previous interval
+    */
+    _setPrevInterval(d) {
+        return d.setSeconds(d.getSeconds() - this._interval);
+    }
+
+    /**
+    * build redis key to get total number of requests received
+    * @param {object} d - Date instance
+    * @return {string} key
+    */
+    _buildRequestsKey(d) {
+        return `s3:requests:${this._normalizeTimestamp(d)}`;
+    }
+
+    /**
+    * build redis key to get total number of 500s occurred on the server
+    * @param {object} d - Date instance
+    * @return {string} key - key for redis
+    */
+    _build500sKey(d) {
+        return `s3:500s:${this._normalizeTimestamp(d)}`;
+    }
+
+    /**
+    * reduce the array of values to a single value
+    * typical input looks like [[null, '1'], [null, '2'], [null, null]...]
+    * @param {array} arr - Date instance
+    * @return {string} key - key for redis
+    */
+    _getCount(arr) {
+        return arr.reduce((prev, a) => {
+            let num = parseInt(a[1], 10);
+            num = Number.isNaN(num) ? 0 : num;
+            return prev + num;
+        }, 0);
+    }
+
+    /**
+    * report/record a new request received on the server
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    reportNewRequest(cb) {
+        if (!this._redis) {
+            return undefined;
+        }
+        const callback = cb || this._noop;
+        const key = this._buildRequestsKey(new Date());
+        return this._redis.incrEx(key, this._expiry, callback);
+    }
+
+    /**
+    * report/record a request that ended up being a 500 on the server
+    * @param {callback} cb - callback
+    * @return {undefined}
+    */
+    report500(cb) {
+        if (!this._redis) {
+            return undefined;
+        }
+        const callback = cb || this._noop;
+        const key = this._build500sKey(new Date());
+        return this._redis.incrEx(key, this._expiry, callback);
+    }
+
+    /**
+    * get stats for the last x seconds, x being the sampling duration
+    * @param {object} log - Werelogs request logger
+    * @param {callback} cb - callback to call with the err/result
+    * @return {undefined}
+    */
+    getStats(log, cb) {
+        if (!this._redis) {
+            return cb(null, {});
+        }
+        const d = new Date();
+        const totalKeys = Math.floor(this._expiry / this._interval);
+        const reqsKeys = [];
+        const req500sKeys = [];
+        for (let i = 0; i < totalKeys; i++) {
+            reqsKeys.push(['get', this._buildRequestsKey(d)]);
+            req500sKeys.push(['get', this._build500sKey(d)]);
+            this._setPrevInterval(d);
+        }
+        return async.parallel([
+            next => this._redis.batch(reqsKeys, next),
+            next => this._redis.batch(req500sKeys, next),
+        ], (err, results) => {
+            /**
+            * Batch result is of the format
+            * [ [null, '1'], [null, '2'], [null, '3'] ] where each
+            * item is the result of the each batch command
+            * Foreach item in the result, index 0 signifies the error and
+            * index 1 contains the result
+            */
+            const statsRes = {
+                'requests': 0,
+                '500s': 0,
+                'sampleDuration': this._expiry,
+            };
+            if (err) {
+                log.error('error getting stats', {
+                    error: err,
+                    method: 'StatsClient.getStats',
+                });
+                /**
+                * Redis for stats is not a critial component, ignoring
+                * any error here as returning an InternalError
+                * would be confused with the health of the service
+                */
+                return cb(null, statsRes);
+            }
+            statsRes.requests = this._getCount(results[0]);
+            statsRes['500s'] = this._getCount(results[1]);
+            return cb(null, statsRes);
+        });
+    }
+}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -10,6 +10,8 @@ import routesUtils from './routes/routesUtils';
 import utils from './utils';
 import { healthcheckHandler } from './utilities/healthcheckHandler';
 import _config from './Config';
+import RedisClient from './RedisClient';
+import StatsClient from './StatsClient';
 
 const routeMap = {
     GET: routeGET,
@@ -21,6 +23,17 @@ const routeMap = {
 
 // setup utapi client
 const utapi = new UtapiClient(_config.utapi);
+// redis client
+let localCacheClient;
+if (_config.localCache) {
+    localCacheClient = new RedisClient(_config.localCache.host,
+        _config.localCache.port);
+}
+// stats client
+const STATS_INTERVAL = 5; // 5 seconds
+const STATS_EXPIRY = 30; // 30 seconds
+const statsClient = new StatsClient(localCacheClient, STATS_INTERVAL,
+    STATS_EXPIRY);
 
 function checkUnsuportedRoutes(req, res, log) {
     if (req.query.policy !== undefined ||
@@ -31,7 +44,7 @@ function checkUnsuportedRoutes(req, res, log) {
     }
     const method = routeMap[req.method.toUpperCase()];
     if (method) {
-        return method(req, res, log, utapi);
+        return method(req, res, log, utapi, statsClient);
     }
     return routesUtils.responseXMLBody(errors.MethodNotAllowed, null, res, log);
 }
@@ -50,10 +63,13 @@ export default function routes(req, res, logger) {
     log.end().addDefaultFields(clientInfo);
 
     if (req.url === '/_/healthcheck') {
-        return healthcheckHandler(clientInfo.clientIP, false, req, res, log);
+        return healthcheckHandler(clientInfo.clientIP, false, req, res, log,
+            statsClient);
     } else if (req.url === '/_/healthcheck/deep') {
         return healthcheckHandler(clientInfo.clientIP, true, req, res, log);
     }
+    // report new request for stats
+    statsClient.reportNewRequest();
 
     try {
         utils.normalizeRequest(req);

--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -1,12 +1,15 @@
 import api from '../api/api';
 import routesUtils from './routesUtils';
 import pushMetrics from '../utilities/pushMetrics';
+import statsReport500 from '../utilities/statsReport500';
 
-export default function routeDELETE(request, response, log, utapi) {
+export default function routeDELETE(request, response, log, utapi,
+    statsClient) {
     log.debug('routing request', { method: 'routeDELETE' });
 
     if (request.objectKey === undefined) {
         api.callApiMethod('bucketDelete', request, log, (err, resHeaders) => {
+            statsReport500(err, statsClient);
             pushMetrics(err, log, utapi, 'bucketDelete', request.bucketName);
             return routesUtils.responseNoBody(err, resHeaders, response, 204,
                 log);
@@ -15,6 +18,7 @@ export default function routeDELETE(request, response, log, utapi) {
         if (request.query.uploadId) {
             api.callApiMethod('multipartDelete', request, log,
                 (err, resHeaders) => {
+                    statsReport500(err, statsClient);
                     pushMetrics(err, log, utapi, 'multipartDelete',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, resHeaders, response,
@@ -32,6 +36,7 @@ export default function routeDELETE(request, response, log, utapi) {
                       return routesUtils.responseNoBody(err, null,
                         response, null, log);
                   }
+                  statsReport500(err, statsClient);
                   pushMetrics(err, log, utapi, 'objectDelete',
                     request.bucketName, contentLength);
                   return routesUtils.responseNoBody(null, null, response,

--- a/lib/routes/routeGET.js
+++ b/lib/routes/routeGET.js
@@ -2,20 +2,24 @@ import api from '../api/api';
 import { errors } from 'arsenal';
 import routesUtils from './routesUtils';
 import pushMetrics from '../utilities/pushMetrics';
+import statsReport500 from '../utilities/statsReport500';
 
-export default function routerGET(request, response, log, utapi) {
+export default function routerGET(request, response, log, utapi, statsClient) {
     log.debug('routing request', { method: 'routerGET' });
     if (request.bucketName === undefined && request.objectKey !== undefined) {
         routesUtils.responseXMLBody(errors.NoSuchBucket, null, response, log);
     } else if (request.bucketName === undefined
         && request.objectKey === undefined) {
         // GET service
-        api.callApiMethod('serviceGet', request, log, (err, xml) =>
-            routesUtils.responseXMLBody(err, xml, response, log));
+        api.callApiMethod('serviceGet', request, log, (err, xml) => {
+            statsReport500(err, statsClient);
+            return routesUtils.responseXMLBody(err, xml, response, log);
+        });
     } else if (request.objectKey === undefined) {
         // GET bucket ACL
         if (request.query.acl !== undefined) {
             api.callApiMethod('bucketGetACL', request, log, (err, xml) => {
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'bucketGetACL',
                     request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
@@ -26,12 +30,14 @@ export default function routerGET(request, response, log, utapi) {
                     // TODO push metrics for gucketGetVersioning
                     // pushMetrics(err, log, utapi, 'bucketGetVersioning',
                     //     request.bucketName);
+                    statsReport500(err, statsClient);
                     routesUtils.responseXMLBody(err, xml, response, log);
                 });
         } else if (request.query.uploads !== undefined) {
             // List MultipartUploads
             api.callApiMethod('listMultipartUploads', request, log,
                 (err, xml) => {
+                    statsReport500(err, statsClient);
                     pushMetrics(err, log, utapi, 'listMultipartUploads',
                         request.bucketName);
                     return routesUtils.responseXMLBody(err, xml, response, log);
@@ -39,6 +45,7 @@ export default function routerGET(request, response, log, utapi) {
         } else {
             // GET bucket
             api.callApiMethod('bucketGet', request, log, (err, xml) => {
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'bucketGet', request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
@@ -47,6 +54,7 @@ export default function routerGET(request, response, log, utapi) {
         if (request.query.acl !== undefined) {
             // GET object ACL
             api.callApiMethod('objectGetACL', request, log, (err, xml) => {
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'objectGetACL',
                     request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
@@ -54,6 +62,7 @@ export default function routerGET(request, response, log, utapi) {
             // List parts of an open multipart upload
         } else if (request.query.uploadId !== undefined) {
             api.callApiMethod('listParts', request, log, (err, xml) => {
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'listParts', request.bucketName);
                 return routesUtils.responseXMLBody(err, xml, response, log);
             });
@@ -66,6 +75,7 @@ export default function routerGET(request, response, log, utapi) {
                     contentLength = resMetaHeaders['Content-Length'];
                 }
                 log.end().addDefaultFields({ contentLength });
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'objectGet', request.bucketName,
                     contentLength);
                 return routesUtils.responseStreamData(err, request.headers,

--- a/lib/routes/routeHEAD.js
+++ b/lib/routes/routeHEAD.js
@@ -2,8 +2,9 @@ import api from '../api/api';
 import { errors } from 'arsenal';
 import routesUtils from './routesUtils';
 import pushMetrics from '../utilities/pushMetrics';
+import statsReport500 from '../utilities/statsReport500';
 
-export default function routeHEAD(request, response, log, utapi) {
+export default function routeHEAD(request, response, log, utapi, statsClient) {
     log.debug('routing request', { method: 'routeHEAD' });
     if (request.bucketName === undefined) {
         log.trace('head request without bucketName');
@@ -12,6 +13,7 @@ export default function routeHEAD(request, response, log, utapi) {
     } else if (request.objectKey === undefined) {
         // HEAD bucket
         api.callApiMethod('bucketHead', request, log, (err, resHeaders) => {
+            statsReport500(err, statsClient);
             pushMetrics(err, log, utapi, 'bucketHead', request.bucketName);
             return routesUtils.responseNoBody(err, resHeaders, response, 200,
                 log);
@@ -19,6 +21,7 @@ export default function routeHEAD(request, response, log, utapi) {
     } else {
         // HEAD object
         api.callApiMethod('objectHead', request, log, (err, resHeaders) => {
+            statsReport500(err, statsClient);
             pushMetrics(err, log, utapi, 'objectHead', request.bucketName);
             return routesUtils.responseContentHeaders(err, {}, resHeaders,
                                                response, log);

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -5,6 +5,8 @@ import api from '../api/api';
 import routesUtils from './routesUtils';
 import utils from '../utils';
 import pushMetrics from '../utilities/pushMetrics';
+import statsReport500 from '../utilities/statsReport500';
+
 const encryptionHeaders = [
     'x-amz-server-side-encryption',
     'x-amz-server-side-encryption-customer-algorithm',
@@ -18,7 +20,7 @@ const validStatuses = ['Enabled', 'Suspended'];
 const validMfaDeletes = [undefined, 'Enabled', 'Disabled'];
 
 /* eslint-disable no-param-reassign */
-export default function routePUT(request, response, log, utapi) {
+export default function routePUT(request, response, log, utapi, statsClient) {
     log.debug('routing request', { method: 'routePUT' });
 
     if (request.objectKey === undefined || request.objectKey === '/') {
@@ -31,6 +33,7 @@ export default function routePUT(request, response, log, utapi) {
             // PUT bucket ACL
             if (request.query.acl !== undefined) {
                 api.callApiMethod('bucketPutACL', request, log, err => {
+                    statsReport500(err, statsClient);
                     pushMetrics(err, log, utapi, 'bucketPutACL',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
@@ -73,6 +76,7 @@ export default function routePUT(request, response, log, utapi) {
                             // pushMetrics(err, log, utapi,
                             //         'bucketPutVersioning',
                             //         request.bucketName);
+                            statsReport500(err, statsClient);
                             routesUtils.responseNoBody(
                                 err, null, response, 200, log);
                         });
@@ -99,6 +103,7 @@ export default function routePUT(request, response, log, utapi) {
                             { locationConstraint });
                         return api.callApiMethod('bucketPut', request, log,
                         err => {
+                            statsReport500(err, statsClient);
                             pushMetrics(err, log, utapi, 'bucketPut',
                                 request.bucketName);
                             return routesUtils.responseNoBody(err, null,
@@ -107,6 +112,7 @@ export default function routePUT(request, response, log, utapi) {
                     });
                 }
                 return api.callApiMethod('bucketPut', request, log, err => {
+                    statsReport500(err, statsClient);
                     pushMetrics(err, log, utapi, 'bucketPut',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
@@ -153,16 +159,17 @@ export default function routePUT(request, response, log, utapi) {
         if (request.query.partNumber) {
             if (request.headers['x-amz-copy-source']) {
                 api.callApiMethod('objectPutCopyPart', request, log,
-                (err, xml,
-                    additionalHeaders) =>
-                    routesUtils.responseXMLBody(err, xml, response, log,
-                        additionalHeaders)
-                );
+                (err, xml, additionalHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                            additionalHeaders);
+                });
             } else {
                 api.callApiMethod('objectPutPart', request, log,
                     (err, calculatedHash) => {
                         // ETag's hex should always be enclosed in quotes
                         const resMetaHeaders = { ETag: `"${calculatedHash}"` };
+                        statsReport500(err, statsClient);
                         pushMetrics(err, log, utapi, 'objectPutPart',
                             request.bucketName, request.parsedContentLength);
                         routesUtils.responseNoBody(err, resMetaHeaders,
@@ -176,6 +183,7 @@ export default function routePUT(request, response, log, utapi) {
             });
             request.on('end', () => {
                 api.callApiMethod('objectPutACL', request, log, err => {
+                    statsReport500(err, statsClient);
                     pushMetrics(err, log, utapi, 'objectPutACL',
                         request.bucketName);
                     return routesUtils.responseNoBody(err, null, response, 200,
@@ -185,6 +193,7 @@ export default function routePUT(request, response, log, utapi) {
         } else if (request.headers['x-amz-copy-source']) {
             return api.callApiMethod('objectCopy', request, log, (err, xml,
                 additionalHeaders, sourceObjSize, destObjPrevSize) => {
+                statsReport500(err, statsClient);
                 pushMetrics(err, log, utapi, 'objectCopy', request.bucketName,
                     sourceObjSize, destObjPrevSize);
                 routesUtils.responseXMLBody(err, xml, response, log,
@@ -208,6 +217,7 @@ export default function routePUT(request, response, log, utapi) {
             api.callApiMethod('objectPut', request, log,
                 (err, contentMD5, prevContentLen) => {
                     // ETag's hex should always be enclosed in quotes
+                    statsReport500(err, statsClient);
                     const resMetaHeaders = {
                         ETag: `"${contentMD5}"`,
                     };

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -20,15 +20,10 @@ function writeResponse(res, error, log, results, cb) {
             statusCode = 500;
         }
     }
-    // If we're here then s3 is considered ok
-    const initial = { S3: { code: 200, message: 'OK' } };
-    const merged = results.reduce(
-        (prev, value) => Object.assign(prev, value), initial);
-
     res.writeHead(statusCode, { 'Content-Type': 'application/json' });
-    res.write(JSON.stringify(merged));
+    res.write(JSON.stringify(results));
     res.end(() => {
-        cb(error, merged);
+        cb(error, results);
     });
 }
 
@@ -49,13 +44,13 @@ export function clientCheck(log, cb) {
     async.parallel(clientTasks, cb);
 }
 
-function routeHandler(deep, req, res, log, cb) {
+function routeHandler(deep, req, res, log, statsClient, cb) {
     if (isHealthy()) {
         if (req.method === 'GET' || req.method === 'POST') {
             if (deep) {
                 return clientCheck(log, cb);
             }
-            return cb(null, []);
+            return statsClient.getStats(log, cb);
         }
         return cb(errors.BadRequest, []);
     }
@@ -76,23 +71,22 @@ function checkIP(clientIP) {
 * @param {object} req - http request object
 * @param {object} res - http response object
 * @param {object} log - werelogs logger instance
+* @param {object} statsClient - StatsClient Instance
 */
-export function healthcheckHandler(clientIP, deep, req, res, log) {
+export function healthcheckHandler(clientIP, deep, req, res, log,
+    statsClient) {
     function healthcheckEndHandler(err, results) {
         writeResponse(res, err, log, results, (error, body) => {
             if (error) {
-                return log.end().warn('healthcheck error', {
-                    error,
-                });
+                return log.end().warn('healthcheck error', { err: error });
             }
-            return log.end().info('healthcheck ended', {
-                result: body,
-            });
+            return log.end().info('healthcheck ended', { result: body });
         });
     }
 
     if (!checkIP(clientIP)) {
         return healthcheckEndHandler(errors.AccessDenied, []);
     }
-    return routeHandler(deep, req, res, log, healthcheckEndHandler);
+    return routeHandler(deep, req, res, log, statsClient,
+        healthcheckEndHandler);
 }

--- a/lib/utilities/statsReport500.js
+++ b/lib/utilities/statsReport500.js
@@ -1,0 +1,12 @@
+/**
+* Report 500 to stats when an Internal Error occurs
+* @param {object} err - Arsenal error
+* @param {object} statsClient - StatsClient instance
+* @returns {undefined}
+*/
+export default function statsReport500(err, statsClient) {
+    if (err && err.code === 500) {
+        statsClient.report500();
+    }
+    return undefined;
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-plugin-transform-es2015-parameters": "^6.2.0",
     "bucketclient": "scality/bucketclient",
     "commander": "^2.9.0",
+    "ioredis": "2.4.0",
     "level": "^1.4.0",
     "level-sublevel": "^6.5.4",
     "multilevel": "^7.3.0",

--- a/tests/functional/config.json
+++ b/tests/functional/config.json
@@ -2,5 +2,9 @@
     "accessKey": "accessKey1",
     "secretKey": "verySecretKey1",
     "transport": "http",
-    "ipAddress": "127.0.0.1"
+    "ipAddress": "127.0.0.1",
+    "localCache": {
+        "host": "127.0.0.1",
+        "port": 6379
+    }
 }


### PR DESCRIPTION
This commit introduces stats for healthcheck route. On a successful healthcheck, the response
includes the total number of requests received and the number of 500s occured over a sampling
duration. The current default for sampling duration is 30 seconds.