### PR TITLE
FIX: maven source

### DIFF
--- a/tests/functional/jaws/pom.xml
+++ b/tests/functional/jaws/pom.xml
@@ -1,6 +1,34 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
         <modelVersion>4.0.0</modelVersion>
+
+        <repositories>
+          <repository>
+            <id>central</id>
+            <name>Maven Repository Switchboard</name>
+            <layout>default</layout>
+            <url>http://repo1.maven.org/maven2</url>
+            <snapshots>
+              <enabled>false</enabled>
+            </snapshots>
+          </repository>
+        </repositories>
+
+        <pluginRepositories>
+          <pluginRepository>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>http://repo1.maven.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+              <enabled>false</enabled>
+            </snapshots>
+            <releases>
+              <updatePolicy>never</updatePolicy>
+            </releases>
+          </pluginRepository>
+        </pluginRepositories>
+
         <groupId>com.scality</groupId>
         <artifactId>SampleExample</artifactId>
         <packaging>jar</packaging>


### PR DESCRIPTION
Pulling maven from the following no longer works: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom


Need to specify http://repo1.maven.org/maven2 per https://maven.apache.org/guides/introduction/introduction-to-the-pom.html
