### PR TITLE
PERF: Remove Buffer.concat for data chunks

### DIFF
--- a/lib/auth/streamingV4/V4Transform.js
+++ b/lib/auth/streamingV4/V4Transform.js
@@ -42,8 +42,12 @@ export default class V4Transform extends Transform {
         this.lastSignature = signatureFromRequest;
         this.currentSignature = undefined;
         this.haveMetadata = false;
+        // keep this as -1 to start since a seekingDataSize of 0
+        // means that chunk is just metadata (as is the case with the
+        // last chunk)
         this.seekingDataSize = -1;
-        this.currentData = Buffer.alloc(0);
+        this.currentData = undefined;
+        this.dataCursor = 0;
         this.currentMetadata = [];
     }
 
@@ -104,6 +108,7 @@ export default class V4Transform extends Transform {
         chunkSig = chunkSig.replace('chunk-signature=', '');
         this.currentSignature = chunkSig;
         this.seekingDataSize = dataSize;
+        this.currentData = Buffer.alloc(dataSize);
         this.haveMetadata = true;
         // start slice at lineBreak plus 2 to remove line break at end of
         // metadata piece since length of '\r\n' is 2
@@ -208,8 +213,8 @@ export default class V4Transform extends Transform {
                 }
                 if (unparsedChunk.length < this.seekingDataSize) {
                     // add chunk to currentData and get next chunk
-                    this.currentData =
-                        Buffer.concat([this.currentData, unparsedChunk]);
+                    unparsedChunk.copy(this.currentData, this.dataCursor);
+                    this.dataCursor += unparsedChunk.length;
                     this.seekingDataSize -= unparsedChunk.length;
                     chunkLeftToEvaluate = false;
                     return done();
@@ -218,18 +223,19 @@ export default class V4Transform extends Transform {
                 const nextDataPiece =
                     unparsedChunk.slice(0, this.seekingDataSize);
                 // add parsed data piece to other currentData pieces
-                const fullDataPiece =
-                    Buffer.concat([this.currentData, nextDataPiece]);
-                return this._authenticate(fullDataPiece, err => {
+                // so that this.currentData is the full data piece
+                nextDataPiece.copy(this.currentData, this.dataCursor);
+                return this._authenticate(this.currentData, err => {
                     if (err) {
                         return done(err);
                     }
                     unparsedChunk =
                         unparsedChunk.slice(this.seekingDataSize + 1);
-                    this.push(fullDataPiece);
+                    this.push(this.currentData);
                     this.haveMetadata = false;
                     this.seekingDataSize = -1;
-                    this.currentData = Buffer.alloc(0);
+                    this.currentData = undefined;
+                    this.dataCursor = 0;
                     chunkLeftToEvaluate = unparsedChunk.length > 0;
                     return done();
                 });


### PR DESCRIPTION
Improve performance of streaming v4 auth by avoiding buffer.concat when know the buffer size.