### PR TITLE
Wait for positive backend healthchecks on startup

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -8,7 +8,7 @@ import routeHEAD from './routes/routeHEAD';
 import routePOST from './routes/routePOST';
 import routesUtils from './routes/routesUtils';
 import utils from './utils';
-import healthcheckHandler from './utilities/healthcheckHandler';
+import { healthcheckHandler } from './utilities/healthcheckHandler';
 import _config from './Config';
 
 const routeMap = {

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@ import cluster from 'cluster';
 import arsenal from 'arsenal';
 
 import { logger } from './utilities/logger';
+import { clientCheck } from './utilities/healthcheckHandler';
 import _config from './Config';
 import routes from './routes';
 
@@ -96,6 +97,23 @@ class S3Server {
         }, 2000);
         killTimer.unref();
     }
+
+    initiateStartup(log) {
+        clientCheck(log, (err, results) => {
+            if (err) {
+                log.warn('initial health check failed, delaying startup', {
+                    error: err,
+                    healthStatus: results,
+                });
+                setTimeout(() => this.initiateStartup(log), 2000);
+            } else {
+                log.info('initial health check succeeded', {
+                    healthStatus: results,
+                });
+                this.startup();
+            }
+        });
+    }
 }
 
 export default function main() {
@@ -133,6 +151,6 @@ export default function main() {
         });
     } else {
         const server = new S3Server(cluster.worker);
-        server.startup();
+        server.initiateStartup(logger.newRequestLogger());
     }
 }

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -32,7 +32,7 @@ function writeResponse(res, error, log, results, cb) {
     });
 }
 
-function clientCheck(req, res, log, cb) {
+export function clientCheck(log, cb) {
     const clients = [
         data,
         metadata,
@@ -53,7 +53,7 @@ function routeHandler(deep, req, res, log, cb) {
     if (isHealthy()) {
         if (req.method === 'GET' || req.method === 'POST') {
             if (deep) {
-                return clientCheck(req, res, log, cb);
+                return clientCheck(log, cb);
             }
             return cb(null, []);
         }
@@ -77,7 +77,7 @@ function checkIP(clientIP) {
 * @param {object} res - http response object
 * @param {object} log - werelogs logger instance
 */
-export default function healthcheckHandler(clientIP, deep, req, res, log) {
+export function healthcheckHandler(clientIP, deep, req, res, log) {
     function healthcheckEndHandler(err, results) {
         writeResponse(res, err, log, results, (error, body) => {
             if (error) {


### PR DESCRIPTION
This change makes sure that all backends are working properly before listening for requests on the service port, allowing load balancers to try another server for write requests without introducing non-idempotent retries, because ECONNREFUSED is a clean failure.