### PR TITLE
DOCKER: using Environment Variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update \
     && npm install \
     && apt-get autoremove -y python build-essential
 
-CMD [ "npm", "start" ]
-
 VOLUME ["/usr/src/app/localData","/usr/src/app/localMetadata"]
+
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+CMD [ "npm", "start" ]
 
 EXPOSE 8000

--- a/DockerfileMem
+++ b/DockerfileMem
@@ -11,6 +11,8 @@ RUN apt-get update \
     && apt-get autoremove -y python build-essential
 
 ENV S3BACKEND mem
+
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
 CMD [ "npm", "start" ]
 
 EXPOSE 8000

--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -28,5 +28,15 @@
             "access": "accessKey2",
             "secret": "verySecretKey2"
         }]
+    }, {
+        "name": "Docker",
+        "email": "sampleaccount3@sampling.com",
+        "arn": "aws::iam:accessKeyDocker:user/Docker",
+        "canonicalID": "sd359df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47eh3hd",
+        "shortid": "123456789012",
+        "keys": [{
+            "access": "accessKeyDocker",
+            "secret": "verySecretKeyDocker"
+        }]
     }]
 }

--- a/config.json
+++ b/config.json
@@ -16,7 +16,8 @@
         "us-gov-west-1": ["s3-us-gov-west-1.amazonaws.com",
                           "s3-fips-us-gov-west-1.amazonaws.com"],
         "localregion": ["localhost"],
-        "test-region": ["s3.scality.test"]
+        "test-region": ["s3.scality.test"],
+        "docker-region": ["s3.docker.test"]
     },
     "sproxyd": {
         "bootstrap": ["localhost:8181"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# set -e stops the execution of a script if a command or pipeline has an error
+set -e
+
+if [[ "$ACCESS_KEY" && "$SECRET_KEY" ]]; then
+    sed -i "s/accessKeyDocker/$ACCESS_KEY/" ./conf/authdata.json
+    sed -i "s/verySecretKeyDocker/$SECRET_KEY/" ./conf/authdata.json
+    echo "Access key and secret key have been modified successfully"
+fi
+
+if [[ "$HOST_NAME" ]]; then
+    sed -i "s/s3.docker.test/$HOST_NAME/" ./config.json
+    echo "Host name has been modified to $HOST_NAME"
+fi
+
+if [[ "$LOG_LEVEL" ]]; then
+    if [[ "$LOG_LEVEL" == "info" || "$LOG_LEVEL" == "debug" || "$LOG_LEVEL" == "trace" ]]; then
+        sed -i "s/\"logLevel\": \"info\"/\"logLevel\": \"$LOG_LEVEL\"/" ./config.json
+        echo "Log level has been modified to $LOG_LEVEL"
+    else
+        echo "The log level you provided is incorrect (info/debug/trace)"
+    fi
+fi
+
+exec "$@"


### PR DESCRIPTION
This PR adds an entrypoint that allows user to:

- Modify Docker user credentials
- Specify an host name 
- Log level

using [Docker environment variables](https://docs.docker.com/engine/reference/run/#/env-environment-variables).

**Docker command:**
` docker run -d --name s3server -p 8000:8000 -e HOST_NAME=new.host.com -e ACCESS_KEY=newAccessKey -e SECRET_KEY=newSecretKey scality/s3server`

If you want to try these changes, you will have to build an image from this branch 
`docker build ./ -t s3` and run the container.