### PR TITLE
fix: possible eventemitter memory leak

### DIFF
--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -45,8 +45,7 @@ class BucketFileInterface {
                 return undefined;
             }
             this.recoCbDone = true;
-            process.nextTick(() => cb());
-            return undefined;
+            return process.nextTick(() => cb());
         });
         this.notifier.on('refdecr', () => {
             /*
@@ -58,8 +57,7 @@ class BucketFileInterface {
                 return undefined;
             }
             this.recoCbDone = true;
-            process.nextTick(() => this.reConnect(this.reConnectCb));
-            return undefined;
+            return process.nextTick(() => this.reConnect(this.reConnectCb));
         });
         return this;
     }

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -45,7 +45,8 @@ class BucketFileInterface {
                 return undefined;
             }
             this.recoCbDone = true;
-            return cb();
+            process.nextTick(() => cb());
+            return undefined;
         });
         this.notifier.on('refdecr', () => {
             /*
@@ -57,7 +58,7 @@ class BucketFileInterface {
                 return undefined;
             }
             this.recoCbDone = true;
-            process.nextTick(() => this.reConnect(this.reConnectCb()));
+            process.nextTick(() => this.reConnect(this.reConnectCb));
             return undefined;
         });
         return this;

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -29,13 +29,40 @@ class BucketFileInterface {
     constructor() {
         this.logger = logger;
         if (cluster.isMaster) {
-            this.startServer();
-        } else {
-            this.refcnt = 0;
-            this.waitreco = 0;
-            this.realReConnect();
-            this.notifier = new events.EventEmitter();
+            return this.startServer();
         }
+        this.refcnt = 0;
+        this.waitreco = 0;
+        this.realReConnect();
+        this.notifier = new events.EventEmitter();
+        this.recoCbDone = false;
+        /*
+        * We need to wait for somebody to wake us up either by
+        * recodone or refdecr
+        */
+        this.notifier.on('recodone', cb => {
+            if (this.recoCbDone) {
+                return undefined;
+            }
+            this.recoCbDone = true;
+            return cb();
+        });
+        this.notifier.on('refdecr', cb => {
+            /*
+            * We need to recheck for the condition as
+            * somebody might issue a command before we
+            * get the notification
+            */
+            if (this.recoCbDone) {
+                return undefined;
+            }
+            this.recoCbDone = true;
+            process.nextTick(() => {
+                this.reConnect(cb);
+            });
+            return undefined;
+        });
+        return this;
     }
 
     /**
@@ -118,33 +145,11 @@ class BucketFileInterface {
                a reco and notify others */
             this.realReConnect();
             if (this.waitreco > 1) {
-                this.notifier.emit('recodone');
+                this.notifier.emit('recodone', cb);
             }
             return cb();
         }
-        /* We need to wait for somebody to wake us up either by
-           recodone or refdecr */
-        let cbDone = false;
-        this.notifier.once('recodone', () => {
-            if (cbDone) {
-                return undefined;
-            }
-            cbDone = true;
-            return cb();
-        });
-        this.notifier.once('refdecr', () => {
-            /* We need to recheck for the condition as
-               somebody might issue a command before we
-               get the notification */
-            if (cbDone) {
-                return undefined;
-            }
-            cbDone = true;
-            process.nextTick(() => {
-                this.reConnect(cb);
-            });
-            return undefined;
-        });
+        this.recoCbDone = false;
         return undefined;
     }
 
@@ -165,7 +170,7 @@ class BucketFileInterface {
         assert(this.refcnt >= 0);
         if (this.waitreco > 0) {
             /* give a change to wake up waiters */
-            this.notifier.emit('refdecr');
+            this.notifier.emit('refdecr', () => {});
         }
     }
 

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -44,8 +44,10 @@ class BucketFileInterface {
             if (this.recoCbDone) {
                 return undefined;
             }
-            this.recoCbDone = true;
-            return process.nextTick(() => cb());
+            return process.nextTick(() => {
+                this.recoCbDone = true;
+                cb();
+            });
         });
         this.notifier.on('refdecr', () => {
             /*
@@ -56,8 +58,10 @@ class BucketFileInterface {
             if (this.recoCbDone) {
                 return undefined;
             }
-            this.recoCbDone = true;
-            return process.nextTick(() => this.reConnect(this.reConnectCb));
+            return process.nextTick(() => {
+                this.recoCbDone = true;
+                this.reConnect(this.reConnectCb);
+            });
         });
         return this;
     }
@@ -168,7 +172,7 @@ class BucketFileInterface {
         assert(this.refcnt >= 0);
         if (this.waitreco > 0) {
             /* give a change to wake up waiters */
-            this.notifier.emit('refdecr', () => {});
+            this.notifier.emit('refdecr');
         }
     }
 

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -47,7 +47,7 @@ class BucketFileInterface {
             this.recoCbDone = true;
             return cb();
         });
-        this.notifier.on('refdecr', cb => {
+        this.notifier.on('refdecr', () => {
             /*
             * We need to recheck for the condition as
             * somebody might issue a command before we
@@ -57,9 +57,7 @@ class BucketFileInterface {
                 return undefined;
             }
             this.recoCbDone = true;
-            process.nextTick(() => {
-                this.reConnect(cb);
-            });
+            process.nextTick(() => this.reConnect(this.reConnectCb()));
             return undefined;
         });
         return this;
@@ -139,6 +137,7 @@ class BucketFileInterface {
      * @return {undefined}
      */
     reConnect(cb) {
+        this.reConnectCb = cb;
         if (this.refcnt === this.waitreco) {
             /* Either we are alone waiting for reconnect or all
                operations are waiting for reconnect, then force

--- a/tests/functional/aws-node-sdk/test/bucket/testBucketStress.js
+++ b/tests/functional/aws-node-sdk/test/bucket/testBucketStress.js
@@ -23,7 +23,7 @@ function deleteObjects(s3, loopId, cb) {
 }
 
 describe('aws-node-sdk stress test bucket', function testSuite() {
-    this.timeout(120000);
+    this.timeout(150000);
     let s3;
     before(() => {
         const config = getConfig('default', { signatureVersion: 'v4' });


### PR DESCRIPTION
Somehow this increases the time run for tests by a few seconds. Multiple test
runs show that it's somewhere around 128s, so the timeout has been increased to
150 secs. for safety.

fixes #271