### PR TITLE
FT: Add putBucketWebsite to API

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -10,6 +10,7 @@ import bucketHead from './bucketHead';
 import bucketPut from './bucketPut';
 import bucketPutACL from './bucketPutACL';
 import bucketPutVersioning from './bucketPutVersioning';
+import bucketPutWebsite from './bucketPutWebsite';
 import completeMultipartUpload from './completeMultipartUpload';
 import initiateMultipartUpload from './initiateMultipartUpload';
 import listMultipartUploads from './listMultipartUploads';
@@ -92,6 +93,7 @@ const api = {
     bucketPut,
     bucketPutACL,
     bucketPutVersioning,
+    bucketPutWebsite,
     completeMultipartUpload,
     initiateMultipartUpload,
     listMultipartUploads,

--- a/lib/api/apiUtils/bucket/bucketShield.js
+++ b/lib/api/apiUtils/bucket/bucketShield.js
@@ -9,14 +9,14 @@ import { invisiblyDelete } from './bucketDeletion';
  */
 export default function (bucket, requestType) {
     const invisiblyDeleteRequests = ['bucketGet', 'bucketHead',
-        'bucketGetACL', 'objectGet', 'objectGetACL', 'objectHead',
-        'objectPutACL', 'objectDelete'];
+        'bucketGetACL', 'bucketPutWebsite', 'objectGet', 'objectGetACL',
+        'objectHead', 'objectPutACL', 'objectDelete'];
     if (invisiblyDeleteRequests.indexOf(requestType) > -1 &&
         bucket.hasDeletedFlag()) {
         invisiblyDelete(bucket.getName(), bucket.getOwner());
         return true;
     }
-     // If request is initatieMultipartUpload (requestType objectPut),
+     // If request is initiateMultipartUpload (requestType objectPut),
      // objectPut, bucketPutACL or bucketDelete, proceed with request.
      // Otherwise return an error to the client
     if ((bucket.hasDeletedFlag() || bucket.hasTransientFlag()) &&

--- a/lib/api/apiUtils/bucket/bucketWebsite.js
+++ b/lib/api/apiUtils/bucket/bucketWebsite.js
@@ -1,0 +1,364 @@
+import { parseString } from 'xml2js';
+
+import { errors } from 'arsenal';
+import {
+    WebsiteConfiguration,
+} from '../../../metadata/WebsiteConfiguration';
+/*
+   Format of xml request:
+
+   <WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
+     <IndexDocument>
+       <Suffix>index.html</Suffix>
+     </IndexDocument>
+     <ErrorDocument>
+       <Key>Error.html</Key>
+     </ErrorDocument>
+
+     <RoutingRules>
+       <RoutingRule>
+       <Condition>
+         <KeyPrefixEquals>docs/</KeyPrefixEquals>
+       </Condition>
+       <Redirect>
+         <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+       </Redirect>
+       </RoutingRule>
+       ...
+    </RoutingRules>
+   </WebsiteConfiguration>
+   */
+
+
+// Key names of redirect object values to check if are valid strings
+const redirectValuesToCheck = ['HostName', 'ReplaceKeyPrefixWith',
+    'ReplaceKeyWith'];
+
+/** Helper function for validating format of parsed xml element
+* @param {array} elem - element to check
+* @return {boolean} true / false - elem meets expected format
+*/
+function _isValidElem(elem) {
+    return (Array.isArray(elem) && elem.length === 1);
+}
+
+/** Check if parsed xml element contains a specified child element
+* @param {array} parent - represents xml element to check for child element
+* @param {(string|string[])} requiredElem - name of child element(s)
+* @param {object} [options] - specify additional options
+* @param {boolean} [isList] - indicates if parent is list of children elements,
+* used only in conjunction a singular requiredElem argument
+* @param {boolean} [checkForAll] - return true only if parent element contains
+* all children elements specified in requiredElem; by default, returns true if
+* parent element contains at least one
+* @param {boolean} [validateParent] - validate format of parent element
+* @return {boolean} true / false - if parsed xml element contains child
+*/
+export function xmlContainsElem(parent, requiredElem, options) {
+    // Non-top level xml is parsed into object in the following manner.
+
+    // Example: <Parent><requiredElem>value</requiredElem>
+    //          <anotherElem>value2</anotherElem></Parent>
+    // Result: { Parent: [{ requiredElem: ["value"],
+    //            anotherElem: ["value2"] }] }
+
+    // Example for xml list:
+    //  <ParentList>
+    //      <requiredElem>value</requiredElem>
+    //      <requiredElem>value</requiredElem>
+    //      <requiredElem>value</requiredElem>
+    //  </ParentList>
+    // Result: { ParentList: [{ requiredElem: ['value', 'value', 'value'] }] }
+
+    const isList = options ? options.isList : false;
+    const checkForAll = options ? options.checkForAll : false;
+    // true by default, validateParent only designated as false when
+    // parent was validated in previous check
+    const validateParent = (options && options.validateParent !== undefined) ?
+        options.validateParent : true;
+
+    if (validateParent && !_isValidElem(parent)) {
+        return false;
+    }
+    if (Array.isArray(requiredElem)) {
+        if (checkForAll) {
+            return requiredElem.every(elem => _isValidElem(parent[0][elem]));
+        }
+        return requiredElem.some(elem => _isValidElem(parent[0][elem]));
+    }
+    if (isList) {
+        if (!Array.isArray(parent[0][requiredElem]) ||
+        parent[0][requiredElem].length === 0) {
+            return false;
+        }
+    } else {
+        return _isValidElem(parent[0][requiredElem]);
+    }
+
+    return true;
+}
+
+
+/** Validate XML, returning an error if any part is not valid
+* @param {object} parsingResult - object parsed from xml to be validated
+* @param {object[]} parsingResult.IndexDocument -
+*   Required if RedirectAllRequestsTo is not defined
+* @param {string[]} parsingResult.IndexDocument[].Suffix -
+*   Key that specifies object in bucket to serve as index
+* @param {object[]=} parsingResult.ErrorDocument - Optional
+* @param {string[]} parsingResult.ErrorDocument[].Key -
+*   Key that specifies object in bucket to serve as error document.
+* @param {object[]} parsingResult.RedirectAllRequestsTo -
+*   Contains fields to specify how to redirect all requests to bucket.
+* @param {string[]} parsingResult.RedirectAllRequestsTo[].HostName -
+*   Hostname to use when redirecting all requests.
+* @param {string[]=} parsingResult.RedirectAllRequestsTo[].Protocol -
+*   Optional, protocol to use when redirecting all request ('http' or 'https')
+* @param {object[]=} parsingResult.RoutingRules -
+*   Contains list of rules for redirecting specific requests.
+* @param {object[]} parsingResult.RoutingRules[].RoutingRule -
+*   Contains redirect and condition information for specific redirects.
+* @param {object[]} parsingResult.RoutingRules[].RoutingRule[].Redirect -
+*   Contains information for how to redirect, required for a RoutingRule.
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[].Redirect[]
+*   .Protocol - Protocol to use for a specific redirect.
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[].Redirect[]
+*   .HostName - Hostname to use in a specific redirect.
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[].Redirect[]
+*   .ReplaceKeyPrefixWith - What to replace a key prefix specified in a
+*   Condition with in a redirect
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[].Redirect[]
+*   .ReplaceKeyWith - What to replace the object key with in a redirect
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[].Redirect[]
+*   .HttpRedirectCode - Http code (301-399) to use in redirect.
+* @param {object[]=} parsingResult.RoutingRules[].RoutingRule[].Condition
+    - Optional, contains fields for conditions to make a specific redirect
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[]
+*   .Condition[].KeyPrefixEquals - Specify the prefix to match for a redirect
+* @param {string[]=} parsingResult.RoutingRules[].RoutingRule[]
+*   .Condition[].HttpErrorCodeReturnedEquals - Error code to match for redirect
+* @return {(Error|WebsiteConfiguration)} return WebsiteConfiguration on success;
+*   otherwise return error
+*/
+function _validateWebsiteConfigXml(parsingResult) {
+    const websiteConfig = new WebsiteConfiguration();
+    let errMsg;
+
+    function _isValidString(value) {
+        return (typeof value === 'string' && value !== '');
+    }
+
+    if (!parsingResult.IndexDocument && !parsingResult.RedirectAllRequestsTo) {
+        errMsg = 'Value for IndexDocument Suffix must be provided if ' +
+        'RedirectAllRequestsTo is empty';
+        return errors.InvalidArgument.customizeDescription(errMsg);
+    }
+
+    if (parsingResult.RedirectAllRequestsTo) {
+        const parent = parsingResult.RedirectAllRequestsTo;
+        const redirectAllObj = {};
+        if (parsingResult.IndexDocument || parsingResult.ErrorDocument ||
+        parsingResult.RoutingRules) {
+            errMsg = 'RedirectAllRequestsTo cannot be provided in ' +
+            'conjunction with other Routing Rules.';
+            return errors.InvalidRequest.customizeDescription(errMsg);
+        }
+        if (!xmlContainsElem(parent, 'HostName')) {
+            errMsg = 'RedirectAllRequestsTo not well-formed';
+            return errors.MalformedXML.customizeDescription(errMsg);
+        }
+        if (!_isValidString(parent[0].HostName[0])) {
+            errMsg = 'Valid HostName required in RedirectAllRequestsTo';
+            return errors.InvalidRequest.customizeDescription(errMsg);
+        }
+        redirectAllObj.hostName = parent[0].HostName[0];
+        if (xmlContainsElem(parent, 'Protocol', { validateParent: false })) {
+            if (parent[0].Protocol[0] !== 'http' &&
+            parent[0].Protocol[0] !== 'https') {
+                errMsg = 'Invalid protocol, protocol can be http or https. ' +
+                'If not defined, the protocol will be selected automatically.';
+                return errors.InvalidRequest.customizeDescription(errMsg);
+            }
+            redirectAllObj.protocol = parent[0].Protocol[0];
+        }
+        websiteConfig.setRedirectAllRequestsTo(redirectAllObj);
+    }
+
+    if (parsingResult.IndexDocument) {
+        const parent = parsingResult.IndexDocument;
+        if (!xmlContainsElem(parent, 'Suffix')) {
+            errMsg = 'IndexDocument is not well-formed';
+            return errors.MalformedXML.customizeDescription(errMsg);
+        } else if (!_isValidString(parent[0].Suffix[0])
+        || parent[0].Suffix[0].indexOf('/') !== -1) {
+            errMsg = 'IndexDocument Suffix is not well-formed';
+            return errors.InvalidArgument.customizeDescription(errMsg);
+        }
+        websiteConfig.setIndexDocument(parent[0].Suffix[0]);
+    }
+
+    if (parsingResult.ErrorDocument) {
+        const parent = parsingResult.ErrorDocument;
+        if (!xmlContainsElem(parent, 'Key')) {
+            errMsg = 'ErrorDocument is not well-formed';
+            return errors.MalformedXML.customizeDescription(errMsg);
+        }
+        if (!_isValidString(parent[0].Key[0])) {
+            errMsg = 'ErrorDocument Key is not well-formed';
+            return errors.InvalidArgument.customizeDescription(errMsg);
+        }
+        websiteConfig.setErrorDocument(parent[0].Key[0]);
+    }
+
+    if (parsingResult.RoutingRules) {
+        const parent = parsingResult.RoutingRules;
+        if (!xmlContainsElem(parent, 'RoutingRule', { isList: true })) {
+            errMsg = 'RoutingRules is not well-formed';
+            return errors.MalformedXML.customizeDescription(errMsg);
+        }
+        for (let i = 0; i < parent[0].RoutingRule.length; i++) {
+            const rule = parent[0].RoutingRule[i];
+            const ruleObj = { redirect: {} };
+            if (!_isValidElem(rule.Redirect)) {
+                errMsg = 'RoutingRule requires Redirect, which is ' +
+                'missing or not well-formed';
+                return errors.MalformedXML.customizeDescription(errMsg);
+            }
+            // Looks like AWS doesn't actually make this check, but AWS
+            // documentation specifies at least one of the following elements
+            // must be in a Redirect rule. We also need at least one of the
+            // elements to know how to implement a redirect for a rule.
+            // http://docs.aws.amazon.com/AmazonS3/latest/API/
+            // RESTBucketPUTwebsite.html
+            if (!xmlContainsElem(rule.Redirect, ['Protocol', 'HostName',
+            'ReplaceKeyPrefixWith', 'ReplaceKeyWith', 'HttpRedirectCode'],
+            { validateParent: false })) {
+                errMsg = 'Redirect must contain at least one of ' +
+                'following: Protocol, HostName, ReplaceKeyPrefixWith, ' +
+                'ReplaceKeyWith, or HttpRedirectCode element';
+                return errors.MalformedXML.customizeDescription(errMsg);
+            }
+            if (rule.Redirect[0].Protocol) {
+                if (!_isValidElem(rule.Redirect[0].Protocol) ||
+                (rule.Redirect[0].Protocol[0] !== 'http' &&
+                rule.Redirect[0].Protocol[0] !== 'https')) {
+                    errMsg = 'Invalid protocol, protocol can be http or ' +
+                    'https. If not defined, the protocol will be selected ' +
+                    'automatically.';
+                    return errors.InvalidRequest.customizeDescription(errMsg);
+                }
+                ruleObj.redirect.protocol = rule.Redirect[0].Protocol[0];
+            }
+            if (rule.Redirect[0].HttpRedirectCode) {
+                errMsg = 'The provided HTTP redirect code is not valid. ' +
+                'It should be a string containing a number.';
+                if (!_isValidElem(rule.Redirect[0].HttpRedirectCode)) {
+                    return errors.MalformedXML.customizeDescription(errMsg);
+                }
+                const code = parseInt(rule.Redirect[0].HttpRedirectCode[0], 10);
+                if (isNaN(code)) {
+                    return errors.MalformedXML.customizeDescription(errMsg);
+                }
+                if (!(code > 300 && code < 400)) {
+                    errMsg = `The provided HTTP redirect code (${code}) is ` +
+                    'not valid. Valid codes are 3XX except 300';
+                    return errors.InvalidRequest.customizeDescription(errMsg);
+                }
+                ruleObj.redirect.httpRedirectCode = code;
+            }
+            for (let j = 0; j < redirectValuesToCheck.length; j++) {
+                const elemName = redirectValuesToCheck[j];
+                const elem = rule.Redirect[0][elemName];
+                if (elem) {
+                    if (!_isValidElem(elem) || !_isValidString(elem[0])) {
+                        errMsg = `Redirect ${elem} is not well-formed`;
+                        return errors.InvalidArgument
+                            .customizeDescription(errMsg);
+                    }
+                    ruleObj.redirect[`${elemName.charAt(0).toLowerCase()}` +
+                    `${elemName.slice(1)}`] = elem[0];
+                }
+            }
+            if (xmlContainsElem(rule.Redirect, ['ReplaceKeyPrefixWith',
+            'ReplaceKeyWith'], { validateParent: false, checkForAll: true })) {
+                errMsg = 'Redirect must not contain both ReplaceKeyWith ' +
+                'and ReplaceKeyPrefixWith';
+                return errors.InvalidRequest.customizeDescription(errMsg);
+            }
+            if (Array.isArray(rule.Condition) && rule.Condition.length === 1) {
+                ruleObj.condition = {};
+                if (!xmlContainsElem(rule.Condition, ['KeyPrefixEquals',
+                'HttpErrorCodeReturnedEquals'])) {
+                    errMsg = 'Condition is not well-formed. ' +
+                    'Condition should contain valid KeyPrefixEquals or ' +
+                    'HttpErrorCodeReturnEquals element.';
+                    return errors.InvalidRequest.customizeDescription(errMsg);
+                }
+                if (rule.Condition[0].KeyPrefixEquals) {
+                    const keyPrefixEquals = rule.Condition[0].KeyPrefixEquals;
+                    if (!_isValidElem(keyPrefixEquals) ||
+                    !_isValidString(keyPrefixEquals[0])) {
+                        errMsg = 'Condition KeyPrefixEquals is not well-formed';
+                        return errors.InvalidArgument
+                            .customizeDescription(errMsg);
+                    }
+                    ruleObj.condition.keyPrefixEquals = keyPrefixEquals[0];
+                }
+                if (rule.Condition[0].HttpErrorCodeReturnedEquals) {
+                    errMsg = 'The provided HTTP error code is not valid. ' +
+                    'It should be a string containing a number.';
+                    if (!_isValidElem(rule.Condition[0]
+                        .HttpErrorCodeReturnedEquals)) {
+                        return errors.MalformedXML.customizeDescription(errMsg);
+                    }
+                    const code = parseInt(rule.Condition[0]
+                        .HttpErrorCodeReturnedEquals[0], 10);
+                    if (isNaN(code)) {
+                        return errors.MalformedXML.customizeDescription(errMsg);
+                    }
+                    if (!(code > 399 && code < 600)) {
+                        errMsg = `The provided HTTP error code (${code}) is ` +
+                        'not valid. Valid codes are 4XX or 5XX.';
+                        return errors.InvalidRequest
+                            .customizeDescription(errMsg);
+                    }
+                    ruleObj.condition.httpErrorCodeReturnedEquals = code;
+                }
+            }
+            websiteConfig.addRoutingRule(ruleObj);
+        }
+    }
+    return websiteConfig;
+}
+
+export function parseWebsiteConfigXml(xml, log, cb) {
+    parseString(xml, (err, result) => {
+        if (err) {
+            log.trace('xml parsing failed', {
+                error: err,
+                method: 'parseWebsiteConfigXml',
+            });
+            log.debug('invalid xml', { xmlObj: xml });
+            return cb(errors.MalformedXML);
+        }
+
+        if (!result || !result.WebsiteConfiguration) {
+            const errMsg = 'Invalid website configuration xml';
+            return cb(errors.MalformedXML.customizeDescription(errMsg));
+        }
+
+        const validationRes =
+            _validateWebsiteConfigXml(result.WebsiteConfiguration);
+        if (validationRes instanceof Error) {
+            log.debug('xml validation failed', {
+                error: validationRes,
+                method: '_validateWebsiteConfigXml',
+                xml,
+            });
+            return cb(validationRes);
+        }
+        // if no error, validation returns instance of WebsiteConfiguration
+        log.trace('website configuration', { validationRes });
+        return cb(null, validationRes);
+    });
+}

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -1,0 +1,65 @@
+import { errors } from 'arsenal';
+import async from 'async';
+
+import bucketShield from './apiUtils/bucket/bucketShield';
+import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
+import metadata from '../metadata/wrapper';
+import { parseWebsiteConfigXml } from './apiUtils/bucket/bucketWebsite';
+
+/**
+ * Bucket Put Website - Create bucket website configuration
+ * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
+ * @param {object} request - http request object
+ * @param {object} log - Werelogs logger
+ * @param {function} callback - callback to server
+ * @return {undefined}
+ */
+export default function bucketPutWebsite(authInfo, request, log, callback) {
+    log.debug('processing request', { method: 'bucketPutWebsite' });
+    const bucketName = request.bucketName;
+    const requestType = 'bucketPutWebsite';
+    const canonicalID = authInfo.getCanonicalID();
+
+    if (!request.post) {
+        return callback(errors.MissingRequestBodyError);
+    }
+    return async.waterfall([
+        function parseXmlBody(next) {
+            log.trace('parsing website configuration');
+            return parseWebsiteConfigXml(request.post, log, next);
+        },
+        function getBucketfromMetadata(config, next) {
+            metadata.getBucket(bucketName, log, (err, bucket) => {
+                if (err) {
+                    log.debug('metadata getbucket failed', { error: err });
+                    return next(err);
+                }
+                if (bucketShield(bucket, requestType)) {
+                    return next(errors.NoSuchBucket);
+                }
+                log.trace('found bucket in metadata');
+                return next(null, bucket, config);
+            });
+        },
+        function validateBucketAuthorization(bucket, config, next) {
+            if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
+                log.debug('access denied for user on bucket', {
+                    requestType,
+                });
+                return next(errors.AccessDenied);
+            }
+            return next(null, bucket, config);
+        },
+        function updateBucketMetadata(bucket, config, next) {
+            log.trace('updating bucket website configuration in metadata');
+            bucket.setWebsiteConfiguration(config);
+            metadata.updateBucket(bucketName, bucket, log, next);
+        },
+    ], err => {
+        if (err) {
+            log.trace('error processing request', { error: err,
+                method: 'bucketPutWebsite' });
+        }
+        return callback(err);
+    });
+}

--- a/lib/metadata/BucketInfo.js
+++ b/lib/metadata/BucketInfo.js
@@ -1,7 +1,8 @@
 import assert from 'assert';
+import { WebsiteConfiguration } from './WebsiteConfiguration';
 
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
-const modelVersion = 3;
+const modelVersion = 4;
 
 export default class BucketInfo {
     /**
@@ -30,10 +31,13 @@ export default class BucketInfo {
     * @param {object} versioningConfiguration - versioning configuration
     * @param {string} versioningConfiguration.Status - versioning status
     * @param {object} versioningConfiguration.MfaDelete - versioning mfa delete
+    * @param {WebsiteConfiguration} [websiteConfiguration] - website
+    * configuration
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
-                serverSideEncryption, versioningConfiguration) {
+                serverSideEncryption, versioningConfiguration,
+                websiteConfiguration) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -68,6 +72,19 @@ export default class BucketInfo {
                 MfaDelete === 'Enabled' ||
                 MfaDelete === 'Disabled');
         }
+        if (websiteConfiguration) {
+            assert(websiteConfiguration instanceof WebsiteConfiguration);
+            const { indexDocument, errorDocument, redirectAllRequestsTo,
+                routingRules } = websiteConfiguration;
+            assert(indexDocument === undefined ||
+                typeof indexDocument === 'string');
+            assert(errorDocument === undefined ||
+                typeof errorDocument === 'string');
+            assert(redirectAllRequestsTo === undefined ||
+                typeof redirectAllRequestsTo === 'object');
+            assert(routingRules === undefined ||
+                Array.isArray(routingRules));
+        }
         const aclInstance = acl || {
             Canned: 'private',
             FULL_CONTROL: [],
@@ -88,6 +105,7 @@ export default class BucketInfo {
         this._deleted = deleted || false;
         this._serverSideEncryption = serverSideEncryption || null;
         this._versioningConfiguration = versioningConfiguration || null;
+        this._websiteConfiguration = websiteConfiguration || null;
         return this;
     }
     /**
@@ -107,6 +125,10 @@ export default class BucketInfo {
             serverSideEncryption: this._serverSideEncryption,
             versioningConfiguration: this._versioningConfiguration,
         };
+        if (this._websiteConfiguration) {
+            bucketInfos.websiteConfiguration =
+                this._websiteConfiguration.getConfig();
+        }
         return JSON.stringify(bucketInfos);
     }
     /**
@@ -116,10 +138,12 @@ export default class BucketInfo {
      */
     static deSerialize(stringBucket) {
         const obj = JSON.parse(stringBucket);
+        const websiteConfig = obj.websiteConfiguration ?
+            new WebsiteConfiguration(obj.websiteConfiguration) : null;
         return new BucketInfo(obj.name, obj.owner, obj.ownerDisplayName,
             obj.creationDate, obj.mdBucketModelVersion, obj.acl,
             obj.transient, obj.deleted, obj.serverSideEncryption,
-            obj.versioningConfiguration);
+            obj.versioningConfiguration, websiteConfig);
     }
 
     /**
@@ -140,7 +164,7 @@ export default class BucketInfo {
         return new BucketInfo(data._name, data._owner, data._ownerDisplayName,
             data._creationDate, data._mdBucketModelVersion, data._acl,
             data._transient, data._deleted, data._serverSideEncryption,
-            data._versioningConfiguration);
+            data._versioningConfiguration, data._websiteConfiguration);
     }
 
     /**
@@ -208,6 +232,22 @@ export default class BucketInfo {
      */
     setVersioningConfiguration(versioningConfiguration) {
         this._versioningConfiguration = versioningConfiguration;
+        return this;
+    }
+    /**
+     * Get the website configuration information
+     * @return {object} websiteConfiguration
+     */
+    getWebsiteConfiguration() {
+        return this._websiteConfiguration;
+    }
+    /**
+     * Set website configuration information
+     * @param {object} websiteConfiguration - configuration for bucket website
+     * @return {BucketInfo} - bucket info instance
+     */
+    setWebsiteConfiguration(websiteConfiguration) {
+        this._websiteConfiguration = websiteConfiguration;
         return this;
     }
     /**

--- a/lib/metadata/ModelVersion.md
+++ b/lib/metadata/ModelVersion.md
@@ -42,3 +42,15 @@ this._serverSideEncryption = serverSideEncryption || null;
 ### Usage
 
 Used to store the server bucket encryption info
+
+## Model version 4
+
+### Properties Added
+
+```
+this._websiteConfiguration = websiteConfiguration || null;
+```
+
+### Usage
+
+Used to store the bucket website configuration info

--- a/lib/metadata/WebsiteConfiguration.js
+++ b/lib/metadata/WebsiteConfiguration.js
@@ -1,0 +1,190 @@
+export class RoutingRule {
+    /**
+    * Represents a routing rule in a website configuration.
+    * @constructor
+    * @param {object} params - object containing redirect and condition objects
+    * @param {object} params.redirect - specifies how to redirect requests
+    * @param {string} [params.redirect.protocol] - protocol to use for redirect
+    * @param {string} [params.redirect.hostName] - hostname to use for redirect
+    * @param {string} [params.redirect.replaceKeyPrefixWith] - string to replace
+    *   keyPrefixEquals specified in condition
+    * @param {string} [params.redirect.replaceKeyWith] - string to replace key
+    * @param {string} [params.redirect.httpRedirectCode] - http redirect code
+    * @param {object} [params.condition] - specifies conditions for a redirect
+    * @param {string} [params.condition.keyPrefixEquals] - key prefix that
+    *   triggers a redirect
+    * @param {string} [params.condition.httpErrorCodeReturnedEquals] - http code
+    *   that triggers a redirect
+    */
+    constructor(params) {
+        if (params) {
+            this._redirect = params.redirect;
+            this._condition = params.condition;
+        }
+    }
+
+    /**
+    * Return copy of rule as plain object
+    * @return {object} rule;
+    */
+    getRuleObject() {
+        const rule = {
+            redirect: this._redirect,
+            condition: this._condition,
+        };
+        return rule;
+    }
+
+    /**
+    * Return the condition object
+    * @return {object} condition;
+    */
+    getCondition() {
+        return this._condition;
+    }
+
+    /**
+    * Return the redirect object
+    * @return {object} redirect;
+    */
+    getRedirect() {
+        return this._redirect;
+    }
+}
+
+export class WebsiteConfiguration {
+    /**
+    * Object that represents website configuration
+    * @constructor
+    * @param {object} params - object containing params to construct Object
+    * @param {string} params.indexDocument - key for index document object
+    *   required when redirectAllRequestsTo is undefined
+    * @param {string} [params.errorDocument] - key for error document object
+    * @param {object} params.redirectAllRequestsTo - object containing info
+    *   about how to redirect all requests
+    * @param {string} params.redirectAllRequestsTo.hostName - hostName to use
+    *   when redirecting all requests
+    * @param {string} [params.redirectAllRequestsTo.protocol] - protocol to use
+    *   when redirecting all requests ('http' or 'https')
+    * @param {(RoutingRule[]|object[])} params.routingRules - array of Routing
+    *   Rule instances or plain routing rule objects to cast as RoutingRule's
+    */
+    constructor(params) {
+        if (params) {
+            this._indexDocument = params.indexDocument;
+            this._errorDocument = params.errorDocument;
+            this._redirectAllRequestsTo = params.redirectAllRequestsTo;
+            this.setRoutingRules(params.routingRules);
+        }
+    }
+
+    /**
+    * Return plain object with configuration info
+    * @return {object} - Object copy of class instance
+    */
+    getConfig() {
+        const websiteConfig = {
+            indexDocument: this._indexDocument,
+            errorDocument: this._errorDocument,
+            redirectAllRequestsTo: this._redirectAllRequestsTo,
+        };
+        if (this._routingRules) {
+            websiteConfig.routingRules =
+            this._routingRules.map(rule => rule.getRuleObject());
+        }
+        return websiteConfig;
+    }
+
+    /**
+    * Set the redirectAllRequestsTo
+    * @param {object} obj - object to set as redirectAllRequestsTo
+    * @param {string} obj.hostName - hostname for redirecting all requests
+    * @param {object} [obj.protocol] - protocol for redirecting all requests
+    * @return {undefined};
+    */
+    setRedirectAllRequestsTo(obj) {
+        this._redirectAllRequestsTo = obj;
+    }
+
+    /**
+    * Return the redirectAllRequestsTo object
+    * @return {object} redirectAllRequestsTo;
+    */
+    getRedirectAllRequestsTo() {
+        return this._redirectAllRequestsTo;
+    }
+
+    /**
+    * Set the index document object name
+    * @param {string} suffix - index document object key
+    * @return {undefined};
+    */
+    setIndexDocument(suffix) {
+        this._indexDocument = suffix;
+    }
+
+    /**
+     * Get the index document object name
+     * @return {string} indexDocument
+     */
+    getIndexDocument() {
+        return this._indexDocument;
+    }
+
+    /**
+     * Set the error document object name
+     * @param {string} key - error document object key
+     * @return {undefined};
+     */
+    setErrorDocument(key) {
+        this._errorDocument = key;
+    }
+
+    /**
+     * Get the error document object name
+     * @return {string} errorDocument
+     */
+    getErrorDocument() {
+        return this._errorDocument;
+    }
+
+    /**
+    * Set the whole RoutingRules array
+    * @param {array} array - array to set as instance's RoutingRules
+    * @return {undefined};
+    */
+    setRoutingRules(array) {
+        if (array) {
+            this._routingRules = array.map(rule => {
+                if (rule instanceof RoutingRule) {
+                    return rule;
+                }
+                return new RoutingRule(rule);
+            });
+        }
+    }
+
+    /**
+     * Add a RoutingRule instance to routingRules array
+     * @param {object} obj - rule to add to array
+     * @return {undefined};
+     */
+    addRoutingRule(obj) {
+        if (!this._routingRules) {
+            this._routingRules = [];
+        }
+        if (obj && obj instanceof RoutingRule) {
+            this._routingRules.push(obj);
+        } else if (obj) {
+            this._routingRules.push(new RoutingRule(obj));
+        }
+    }
+
+    /**
+     * Get routing rules
+     * @return {RoutingRule[]} - array of RoutingRule instances
+     */
+    getRoutingRules() {
+        return this._routingRules;
+    }
+}

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -91,6 +91,14 @@ export default function routePUT(request, response, log, utapi, statsClient) {
                                 err, null, response, 200, log);
                         });
                 });
+            } else if (request.query.website !== undefined) {
+                api.callApiMethod('bucketPutWebsite', request, log, err => {
+                    statsReport500(err, statsClient);
+                    pushMetrics(err, log, utapi, 'bucketPutWebsite',
+                        request.bucketName);
+                    return routesUtils.responseNoBody(err, null, response, 200,
+                        log);
+                });
             } else if (request.query.acl === undefined) {
                 // PUT bucket
                 if (request.post) {

--- a/lib/utilities/pushMetrics.js
+++ b/lib/utilities/pushMetrics.js
@@ -6,6 +6,9 @@ export default function pushMetrics(err, log, utapi, action, resource,
         case 'bucketPutACL':
             utapi.pushMetricPutBucketAcl(reqUid, resource);
             break;
+        case 'bucketPutWebsite':
+            utapi.pushMetricPutBucketWebsite(reqUid, resource);
+            break;
         case 'bucketPut':
             utapi.pushMetricCreateBucket(reqUid, resource);
             break;

--- a/tests/functional/aws-node-sdk/lib/utility/website-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/website-util.js
@@ -1,0 +1,35 @@
+
+export class WebsiteConfigTester {
+    constructor(indexDocument, errorDocument, redirectAllReqTo) {
+        if (indexDocument) {
+            this.IndexDocument = {};
+            this.IndexDocument.Suffix = indexDocument;
+        }
+        if (errorDocument) {
+            this.ErrorDocument = {};
+            this.ErrorDocument.Key = errorDocument;
+        }
+        if (redirectAllReqTo) {
+            this.RedirectAllRequestsTo = redirectAllReqTo;
+        }
+    }
+    addRoutingRule(redirectParams, conditionParams) {
+        const newRule = {};
+        if (!this.RoutingRules) {
+            this.RoutingRules = [];
+        }
+        if (redirectParams) {
+            newRule.Redirect = {};
+            Object.keys(redirectParams).forEach(key => {
+                newRule.Redirect[key] = redirectParams[key];
+            });
+        }
+        if (conditionParams) {
+            newRule.Condition = {};
+            Object.keys(conditionParams).forEach(key => {
+                newRule.Condition[key] = conditionParams[key];
+            });
+        }
+        this.RoutingRules.push(newRule);
+    }
+}

--- a/tests/functional/aws-node-sdk/test/bucket/putWebsite.js
+++ b/tests/functional/aws-node-sdk/test/bucket/putWebsite.js
@@ -1,0 +1,144 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+import { WebsiteConfigTester } from '../../lib/utility/website-util';
+
+const bucketName = 'testbucketwebsitebucket';
+
+describe('PUT bucket website', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+
+        function _testPutBucketWebsite(config, statusCode, errMsg, cb) {
+            s3.putBucketWebsite({ Bucket: bucketName,
+                WebsiteConfiguration: config }, err => {
+                assert(err, 'Expected err but found none');
+                assert.strictEqual(err.code, errMsg);
+                assert.strictEqual(err.statusCode, statusCode);
+                cb();
+            });
+        }
+        beforeEach(done => {
+            process.stdout.write('about to create bucket\n');
+            s3.createBucket({ Bucket: bucketName }, err => {
+                if (err) {
+                    process.stdout.write('error in beforeEach', err);
+                    done(err);
+                }
+                done();
+            });
+        });
+
+        afterEach(() => {
+            process.stdout.write('about to empty bucket\n');
+            return bucketUtil.empty(bucketName).then(() => {
+                process.stdout.write('about to delete bucket\n');
+                return bucketUtil.deleteOne(bucketName);
+            }).catch(err => {
+                if (err) {
+                    process.stdout.write('error in afterEach', err);
+                    throw err;
+                }
+            });
+        });
+
+        it('should put a bucket website successfully', done => {
+            const config = new WebsiteConfigTester('index.html');
+            s3.putBucketWebsite({ Bucket: bucketName,
+                WebsiteConfiguration: config }, err => {
+                assert.strictEqual(err, null, `Found unexpected err ${err}`);
+                done();
+            });
+        });
+
+        it('should return InvalidArgument if IndexDocument or ' +
+        'RedirectAllRequestsTo is not provided', done => {
+            const config = new WebsiteConfigTester();
+            _testPutBucketWebsite(config, 400, 'InvalidArgument', done);
+        });
+
+        it('should return an InvalidRequest if both ' +
+        'RedirectAllRequestsTo and IndexDocument are provided', done => {
+            const redirectAllTo = {
+                HostName: 'test',
+                Protocol: 'http',
+            };
+            const config = new WebsiteConfigTester(null, null,
+            redirectAllTo);
+            config.addRoutingRule({ Protocol: 'http' });
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return InvalidArgument if index has slash', done => {
+            const config = new WebsiteConfigTester('in/dex.html');
+            _testPutBucketWebsite(config, 400, 'InvalidArgument', done);
+        });
+
+        it('should return InvalidRequest if both ReplaceKeyWith and ' +
+        'ReplaceKeyPrefixWith are present in same rule', done => {
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ ReplaceKeyPrefixWith: 'test',
+            ReplaceKeyWith: 'test' });
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return InvalidRequest if both ReplaceKeyWith and ' +
+        'ReplaceKeyPrefixWith are present in same rule', done => {
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ ReplaceKeyPrefixWith: 'test',
+            ReplaceKeyWith: 'test' });
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return InvalidRequest if Redirect Protocol is ' +
+        'not http or https', done => {
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ Protocol: 'notvalidprotocol' });
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return InvalidRequest if RedirectAllRequestsTo Protocol ' +
+        'is not http or https', done => {
+            const redirectAllTo = {
+                HostName: 'test',
+                Protocol: 'notvalidprotocol',
+            };
+            const config = new WebsiteConfigTester(null, null, redirectAllTo);
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return MalformedXML if Redirect HttpRedirectCode ' +
+        'is a string that does not contains a number', done => {
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ HttpRedirectCode: 'notvalidhttpcode' });
+            _testPutBucketWebsite(config, 400, 'MalformedXML', done);
+        });
+
+        it('should return InvalidRequest if Redirect HttpRedirectCode ' +
+        'is not a valid http redirect code (3XX excepting 300)', done => {
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ HttpRedirectCode: '400' });
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+
+        it('should return InvalidRequest if Condition ' +
+        'HttpErrorCodeReturnedEquals is a string that does ' +
+        ' not contain a number', done => {
+            const condition = { HttpErrorCodeReturnedEquals: 'notvalidcode' };
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ HostName: 'test' }, condition);
+            _testPutBucketWebsite(config, 400, 'MalformedXML', done);
+        });
+
+        it('should return InvalidRequest if Condition ' +
+        'HttpErrorCodeReturnedEquals is not a valid http' +
+        'error code (4XX or 5XX)', done => {
+            const condition = { HttpErrorCodeReturnedEquals: '300' };
+            const config = new WebsiteConfigTester('index.html');
+            config.addRoutingRule({ HostName: 'test' }, condition);
+            _testPutBucketWebsite(config, 400, 'InvalidRequest', done);
+        });
+    });
+});

--- a/tests/unit/api/bucketPutWebsite.js
+++ b/tests/unit/api/bucketPutWebsite.js
@@ -1,0 +1,179 @@
+import assert from 'assert';
+import { parseString } from 'xml2js';
+
+import bucketPut from '../../../lib/api/bucketPut';
+import bucketPutWebsite from '../../../lib/api/bucketPutWebsite';
+import { xmlContainsElem }
+    from '../../../lib/api/apiUtils/bucket/bucketWebsite';
+import { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo,
+    WebsiteConfig }
+from '../helpers';
+import metadata from '../../../lib/metadata/wrapper';
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
+const testBucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+
+function _getPutWebsiteRequest(xml) {
+    const request = {
+        bucketName,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+        },
+        url: '/?website',
+        query: { website: '' },
+    };
+    request.post = xml;
+    return request;
+}
+
+describe('putBucketWebsite API', () => {
+    before(() => cleanup());
+    beforeEach(done => bucketPut(authInfo, testBucketPutRequest,
+        locationConstraint, log, done));
+    afterEach(() => cleanup());
+
+    it('should update a bucket\'s metadata with website config obj', done => {
+        const config = new WebsiteConfig('index.html', 'error.html');
+        config.addRoutingRule({ ReplaceKeyPrefixWith: 'documents/' },
+        { KeyPrefixEquals: 'docs/' });
+        const testBucketPutWebsiteRequest =
+            _getPutWebsiteRequest(config.getXml());
+        bucketPutWebsite(authInfo, testBucketPutWebsiteRequest, log, err => {
+            if (err) {
+                process.stdout.write(`Err putting website config ${err}`);
+                return done(err);
+            }
+            return metadata.getBucket(bucketName, log, (err, bucket) => {
+                if (err) {
+                    process.stdout.write(`Err retrieving bucket MD ${err}`);
+                    return done(err);
+                }
+                const bucketWebsiteConfig = bucket.getWebsiteConfiguration();
+                assert.strictEqual(bucketWebsiteConfig._indexDocument,
+                    config.IndexDocument.Suffix);
+                assert.strictEqual(bucketWebsiteConfig._errorDocument,
+                    config.ErrorDocument.Key);
+                assert.strictEqual(bucketWebsiteConfig._routingRules[0]
+                    ._condition.keyPrefixEquals,
+                    config.RoutingRules[0].Condition.KeyPrefixEquals);
+                assert.strictEqual(bucketWebsiteConfig._routingRules[0]
+                    ._redirect.replaceKeyPrefixWith,
+                    config.RoutingRules[0].Redirect.ReplaceKeyPrefixWith);
+                return done();
+            });
+        });
+    });
+
+    describe('helper functions', () => {
+        it('xmlContainsElem should return true if xml contains ' +
+        'specified element', done => {
+            const xml = '<Toplevel><Parent>' +
+            '<Element>value</Element>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    'Element');
+                assert.strictEqual(containsRes, true);
+                return done();
+            });
+        });
+        it('xmlContainsElem should return false if xml does not contain ' +
+        'specified element', done => {
+            const xml = '<Toplevel><Parent>' +
+            '<ElementA>value</ElementA>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    'Element');
+                assert.strictEqual(containsRes, false);
+                return done();
+            });
+        });
+        it('xmlContainsElem should return true if parent contains list of ' +
+        'elements and isList is specified in options', done => {
+            const xml = '<Toplevel><Parent>' +
+            '<Element>value</Element>' +
+            '<Element>value</Element>' +
+            '<Element>value</Element>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    'Element', { isList: true });
+                assert.strictEqual(containsRes, true);
+                return done();
+            });
+        });
+        it('xmlContainsElem should return true if parent contains at least ' +
+        'one of the elements specified, if multiple', done => {
+            const xml = '<Toplevel><Parent>' +
+            '<ElementB>value</ElementB>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    ['ElementA', 'ElementB']);
+                assert.strictEqual(containsRes, true);
+                return done();
+            });
+        });
+        it('xmlContainsElem should return false if parent contains only one ' +
+        'of multiple elements specified and checkForAll specified in options',
+        done => {
+            const xml = '<Toplevel><Parent>' +
+            '<ElementB>value</ElementB>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    ['ElementA', 'ElementB'], { checkForAll: true });
+                assert.strictEqual(containsRes, false);
+                return done();
+            });
+        });
+        it('xmlContainsElem should return true if parent contains all ' +
+        'of multiple elements specified and checkForAll specified in options',
+        done => {
+            const xml = '<Toplevel><Parent>' +
+            '<ElementA>value</ElementA>' +
+            '<ElementB>value</ElementB>' +
+            '</Parent></Toplevel>';
+            parseString(xml, (err, result) => {
+                if (err) {
+                    process.stdout.write(`Unexpected err ${err} parsing xml`);
+                    return done(err);
+                }
+                const containsRes = xmlContainsElem(result.Toplevel.Parent,
+                    ['ElementA', 'ElementB'], { checkForAll: true });
+                assert.strictEqual(containsRes, true);
+                return done();
+            });
+        });
+    });
+});

--- a/tests/unit/bucket/WebsiteConfiguration.js
+++ b/tests/unit/bucket/WebsiteConfiguration.js
@@ -1,0 +1,183 @@
+import assert from 'assert';
+import {
+    WebsiteConfiguration,
+    RoutingRule,
+} from '../../../lib/metadata/WebsiteConfiguration';
+
+const testRoutingRuleParams = {
+    redirect: {
+        protocol: 'http',
+        hostName: 'test',
+        replaceKeyPrefixWith: '/docs',
+        replaceKeyWith: 'cat',
+        httpRedirectCode: '303',
+    },
+    condition: {
+        keyPrefixEquals: '/documents',
+        httpErrorCodeReturnedEquals: '404',
+    },
+};
+
+describe('RoutingRule class', () => {
+    it('should initialize even if no parameters are provided', done => {
+        const routingRule = new RoutingRule();
+        assert.strictEqual(routingRule._redirect, undefined);
+        assert.strictEqual(routingRule._condition, undefined);
+        done();
+    });
+
+    it('should return a new routing rule', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepStrictEqual(routingRule._condition,
+            testRoutingRuleParams.condition);
+        done();
+    });
+
+    it('getRedirect should fetch the instance\'s redirect', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule.getRedirect(),
+            testRoutingRuleParams.redirect);
+        done();
+    });
+
+    it('getCondition should fetch the instance\'s condition', done => {
+        const routingRule = new RoutingRule(testRoutingRuleParams);
+        assert.deepStrictEqual(routingRule.getCondition(),
+            testRoutingRuleParams.condition);
+        done();
+    });
+});
+
+describe('WebsiteConfiguration class', () => {
+    it('should initialize even if no parameters are provided', done => {
+        const websiteConfig = new WebsiteConfiguration();
+        assert.strictEqual(websiteConfig._indexDocument, undefined);
+        assert.strictEqual(websiteConfig._errorDocument, undefined);
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo, undefined);
+        assert.strictEqual(websiteConfig._routingRules, undefined);
+        done();
+    });
+
+    it('should initialize indexDocument, errorDocument during construction ' +
+    'if provided in params', done => {
+        const testWebsiteConfigParams = {
+            indexDocument: 'index.html',
+            errorDocument: 'error.html',
+        };
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.strictEqual(websiteConfig._indexDocument, 'index.html');
+        assert.strictEqual(websiteConfig._errorDocument, 'error.html');
+        done();
+    });
+
+    it('should initialize redirectAllRequestsTo during construction if ' +
+    'provided in params', done => {
+        const testWebsiteConfigParams = {
+            redirectAllRequestsTo: {
+                hostName: 'test',
+                protocol: 'https',
+            },
+        };
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo.hostName,
+            'test');
+        assert.strictEqual(websiteConfig._redirectAllRequestsTo.protocol,
+            'https');
+        done();
+    });
+
+    it('should initialize routingRules properly during construction from ' +
+    'array of RoutingRule class instances', done => {
+        const testWebsiteConfigParams = {
+            routingRules: [],
+        };
+        const testRoutingRule = new RoutingRule(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        testWebsiteConfigParams.routingRules.push(testRoutingRule);
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.deepStrictEqual(websiteConfig._routingRules,
+            testWebsiteConfigParams.routingRules);
+        done();
+    });
+
+    it('should initialize routingRules properly during construction from ' +
+    'array of plain objects', done => {
+        const testWebsiteConfigParams = {
+            routingRules: [],
+        };
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        testWebsiteConfigParams.routingRules.push(testRoutingRuleParams);
+        const websiteConfig = new WebsiteConfiguration(testWebsiteConfigParams);
+        assert.deepEqual(websiteConfig._routingRules[0]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[1]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[2]._condition,
+            testRoutingRuleParams.condition);
+        assert.deepEqual(websiteConfig._routingRules[0]._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepEqual(websiteConfig._routingRules[1]._redirect,
+            testRoutingRuleParams.redirect);
+        assert.deepEqual(websiteConfig._routingRules[2]._redirect,
+            testRoutingRuleParams.redirect);
+        assert(websiteConfig._routingRules[0] instanceof RoutingRule);
+        done();
+    });
+
+    describe('Getter/setter methods', () => {
+        it('for indexDocument should get/set indexDocument property', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            websiteConfig.setIndexDocument('index.html');
+            assert.strictEqual(websiteConfig.getIndexDocument(), 'index.html');
+            done();
+        });
+
+        it('for errorDocument should get/set errorDocument property', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            websiteConfig.setErrorDocument('error.html');
+            assert.strictEqual(websiteConfig.getErrorDocument(), 'error.html');
+            done();
+        });
+
+        it('for redirectAllRequestsTo should get/set redirectAllRequestsTo ' +
+        'object', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            const redirectAllRequestsTo = {
+                hostName: 'test',
+                protocol: 'http',
+            };
+            websiteConfig.setRedirectAllRequestsTo(redirectAllRequestsTo);
+            assert.deepStrictEqual(websiteConfig.getRedirectAllRequestsTo(),
+                redirectAllRequestsTo);
+            done();
+        });
+
+        it('for routingRules should get/set routingRules', done => {
+            const websiteConfig = new WebsiteConfiguration();
+            const routingRules = [testRoutingRuleParams];
+            websiteConfig.setRoutingRules(routingRules);
+            assert.strictEqual(websiteConfig.getRoutingRules()[0]._condition,
+                routingRules[0].condition);
+            assert.strictEqual(websiteConfig.getRoutingRules()[0]._redirect,
+                routingRules[0].redirect);
+            assert(websiteConfig._routingRules[0] instanceof RoutingRule);
+            done();
+        });
+    });
+
+    it('addRoutingRule should add a RoutingRule to routingRules', done => {
+        const websiteConfig = new WebsiteConfiguration();
+        websiteConfig.addRoutingRule(testRoutingRuleParams);
+        assert(Array.isArray(websiteConfig._routingRules));
+        assert.strictEqual(websiteConfig._routingRules.length, 1);
+        assert.strictEqual(websiteConfig._routingRules[0].getCondition(),
+            testRoutingRuleParams.condition);
+        assert.strictEqual(websiteConfig._routingRules[0].getRedirect(),
+            testRoutingRuleParams.redirect);
+        done();
+    });
+});


### PR DESCRIPTION
Depends on
scality/Arsenal#196,
scality/utapi#67, &
scality/Integration#321

Call action for ?website query in routePUT
* Add putBucketWebsite to shielded actions
* Update BucketInfo modelVersion to 4: include website configuration info
* Parse and validate xml WebsiteConfiguration body
* Send API metrics to utapi & deliver success or err response