### PR TITLE
FIX: Refactor objectPutPart API

### DIFF
--- a/lib/api/apiUtils/object/storeObject.js
+++ b/lib/api/apiUtils/object/storeObject.js
@@ -1,0 +1,102 @@
+import { errors } from 'arsenal';
+import V4Transform from '../../../auth/streamingV4/V4Transform';
+import data from '../../../data/wrapper';
+
+/**
+ * Prepares the stream if the chunks are sent in a v4 Auth request
+ * @param {object} stream - stream containing the data
+ * @param {object | null } streamingV4Params - if v4 auth, object containing
+ * accessKey, signatureFromRequest, region, scopeDate, timestamp, and
+ * credentialScope (to be used for streaming v4 auth if applicable)
+ * @param {RequestLogger} log - the current request logger
+ * @param {function} cb - callback containing the result for V4Transform
+ * @return {object} - V4Transform object if v4 Auth request, or else the stream
+ */
+function prepareStream(stream, streamingV4Params, log, cb) {
+    if (stream.headers['x-amz-content-sha256'] ===
+        'STREAMING-AWS4-HMAC-SHA256-PAYLOAD') {
+        const v4Transform = new V4Transform(streamingV4Params, log, cb);
+        stream.pipe(v4Transform);
+        return v4Transform;
+    }
+    return stream;
+}
+
+/**
+ * Check that `hashedStream.completedHash` matches header `stream.contentMD5`
+ * and delete old data or remove 'hashed' listeners, if applicable.
+ * @param {object} stream - stream containing the data
+ * @param {object} hashedStream - instance of MD5Sum
+ * @param {object} dataRetrievalInfo - object containing the keys of stored data
+ * @param {number} dataRetrievalInfo.key - key of the stored data
+ * @param {string} dataRetrievalInfo.dataStoreName - the implName of the data
+ * @param {object} log - request logger instance
+ * @param {function} cb - callback to send error or move to next task
+ * @return {function} - calls callback with arguments:
+ * error, dataRetrievalInfo, and completedHash (if any)
+ */
+function checkHashMatchMD5(stream, hashedStream, dataRetrievalInfo, log, cb) {
+    const contentMD5 = stream.contentMD5;
+    const completedHash = hashedStream.completedHash;
+    if (contentMD5 && completedHash && contentMD5 !== completedHash) {
+        log.debug('contentMD5 and completedHash do not match', {
+            method: 'storeObject::dataStore',
+            completedHash,
+            contentMD5,
+        });
+        log.trace('contentMD5 does not match, deleting data');
+        data.batchDelete(dataRetrievalInfo, log);
+        return cb(errors.BadDigest);
+    }
+    if (completedHash) {
+        hashedStream.removeAllListeners('hashed');
+    }
+    return cb(null, dataRetrievalInfo, completedHash);
+}
+
+/**
+ * Stores object and responds back with location and storage type
+ * @param {object} objectContext - object's keyContext for sproxyd Key
+ * computation (put API)
+ * @param {object} cipherBundle - cipher bundle that encrypt the data
+ * @param {object} stream - the stream containing the data
+ * @param {number} size - data size in the stream
+ * @param {object | null } streamingV4Params - if v4 auth, object containing
+ * accessKey, signatureFromRequest, region, scopeDate, timestamp, and
+ * credentialScope (to be used for streaming v4 auth if applicable)
+ * @param {RequestLogger} log - the current stream logger
+ * @param {function} cb - callback containing result for the next task
+ * @return {undefined}
+ */
+export function dataStore(objectContext, cipherBundle, stream, size,
+    streamingV4Params, log, cb) {
+    const dataStream = prepareStream(stream, streamingV4Params, log, cb);
+    data.put(cipherBundle, dataStream, size, objectContext, log,
+        (err, dataRetrievalInfo, hashedStream) => {
+            if (err) {
+                log.error('error in datastore', {
+                    error: err,
+                });
+                return cb(err);
+            }
+            if (!dataRetrievalInfo) {
+                log.fatal('data put returned neither an error nor a key', {
+                    method: 'storeObject::dataStore',
+                });
+                return cb(errors.InternalError);
+            }
+            log.trace('dataStore: backend stored key', {
+                dataRetrievalInfo,
+            });
+            hashedStream.on('hashed', () => {
+                log.trace('hashed event emitted');
+                return checkHashMatchMD5(stream, hashedStream,
+                    dataRetrievalInfo, log, cb);
+            });
+            if (hashedStream.completedHash) {
+                return checkHashMatchMD5(stream, hashedStream,
+                    dataRetrievalInfo, log, cb);
+            }
+            return undefined;
+        });
+}

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -1,57 +1,25 @@
+import assert from 'assert';
+import async from 'async';
 import { errors } from 'arsenal';
 
-import services from '../services';
 import constants from '../../constants';
 import kms from '../kms/wrapper';
+import { dataStore } from './apiUtils/object/storeObject';
+import metadata from '../metadata/wrapper';
+import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 
-/*
- * Private function
- */
-function doStore(objectKeyContext, cipherBundle, request, log,
-                 partNumber, size, uploadId, streamingV4Params, cb) {
-    return function mdValidateMPU(err, mpuBucket) {
-        if (err) {
-            return cb(err);
-        }
-        return services.dataStore(
-            null, objectKeyContext, cipherBundle, request,
-            size, streamingV4Params, log, (err, extraArg, dataGetInfo,
-                calculatedHash) => {
-                if (err) {
-                    return cb(err);
-                }
-                let splitter = constants.splitter;
-                // BACKWARD: Remove to remove the old splitter
-                if (mpuBucket.getMdBucketModelVersion() < 2) {
-                    splitter = constants.oldSplitter;
-                }
-                // To be consistent with objectPutCopyPart where there could be
-                // multiple locations, use an array here.
-                const dataGetInfoArr = [dataGetInfo];
-                if (cipherBundle) {
-                    dataGetInfoArr[0].sseAlgorithm = cipherBundle.algorithm;
-                    dataGetInfoArr[0].sseMasterKeyId = cipherBundle.masterKeyId;
-                    dataGetInfoArr[0].sseCryptoScheme =
-                        cipherBundle.cryptoScheme;
-                    dataGetInfoArr[0].sseCipheredDataKey =
-                        cipherBundle.cipheredDataKey;
-                }
-                const mdParams = {
-                    partNumber,
-                    contentMD5: calculatedHash,
-                    size,
-                    uploadId,
-                    splitter,
-                };
-                return services.metadataStorePart(mpuBucket.getName(),
-                    dataGetInfoArr, mdParams, log, err => {
-                        if (err) {
-                            return cb(err);
-                        }
-                        return cb(null, calculatedHash);
-                    });
-            });
-    };
+
+// We pad the partNumbers so that the parts will be sorted in numerical order.
+function _getPaddedPartNumber(number) {
+    return `000000${number}`.substr(-5);
+}
+
+function _getOverviewKey(splitter, objectKey, uploadId) {
+    return `overview${splitter}${objectKey}${splitter}${uploadId}`;
+}
+
+function _getPartKey(uploadId, splitter, paddedPartNumber) {
+    return `${uploadId}${splitter}${paddedPartNumber}`;
 }
 
 /**
@@ -72,13 +40,22 @@ function doStore(objectKeyContext, cipherBundle, request, log,
  * @param {function} cb - final callback to call with the result
  * @return {undefined}
  */
-export default function objectPutPart(authInfo, request, streamingV4Params,
-    log, cb) {
+export default function objectPutPart(authInfo, request, streamingV4Params, log,
+    cb) {
     log.debug('processing request', { method: 'objectPutPart' });
-
-    const bucketName = request.bucketName;
-    const objectKey = request.objectKey;
     const size = request.parsedContentLength;
+
+    // Part sizes cannot be greater than 5GB in size.
+    if (Number.parseInt(size, 10) > 5368709120) {
+        return cb(errors.EntityTooLarge);
+    }
+
+    // Note: Part sizes cannot be less than 5MB in size except for the last.
+    // However, we do not check this value here because we cannot know which
+    // part will be the last until a complete MPU request is made. Thus, we let
+    // the completeMultipartUpload API check that all parts except the last are
+    // at least 5MB.
+
     const partNumber = Number.parseInt(request.query.partNumber, 10);
     // AWS caps partNumbers at 10,000
     if (partNumber > 10000) {
@@ -87,80 +64,160 @@ export default function objectPutPart(authInfo, request, streamingV4Params,
     if (!Number.isInteger(partNumber) || partNumber < 1) {
         return cb(errors.InvalidArgument);
     }
-    // If part size is greater than 5GB, reject it
-    if (Number.parseInt(size, 10) > 5368709120) {
-        return cb(errors.EntityTooLarge);
-    }
-    // Note: Parts are supposed to be at least 5MB except for last part.
-    // However, there is no way to know whether a part is the last part
-    // since keep taking parts until get a completion request.  But can
-    // expect parts of at least 5MB until last part.  Also, we check that
-    // part sizes are large enough when mutlipart upload completed.
-
-    // Note that keys in the query object retain their case, so
-    // request.query.uploadId must be called with that exact
-    // capitalization
-    const uploadId = request.query.uploadId;
-    const metadataValMPUparams = {
-        authInfo,
-        bucketName,
-        objectKey,
-        uploadId,
-        requestType: 'putPart or complete',
-        log,
-        splitter: constants.splitter,
-    };
-    // For validating the request at the destinationBucket level
-    // params are the same as validating at the MPU level
-    // but the requestType is the more general 'objectPut'
-    const metadataValParams = Object.assign({}, metadataValMPUparams);
-    metadataValParams.requestType = 'objectPut';
+    const bucketName = request.bucketName;
+    assert.strictEqual(typeof bucketName, 'string');
+    const canonicalID = authInfo.getCanonicalID();
+    assert.strictEqual(typeof canonicalID, 'string');
     log.trace('owner canonicalid to send to data', {
         canonicalID: authInfo.getCanonicalID,
     });
-    const objectKeyContext = {
-        bucketName,
-        owner: authInfo.getCanonicalID(),
-        namespace: request.namespace,
-    };
+    // Note that keys in the query object retain their case, so
+    // `request.query.uploadId` must be called with that exact capitalization.
+    const uploadId = request.query.uploadId;
+    const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
+    const objectKey = request.objectKey;
 
-    return services.metadataValidateAuthorization(
-        metadataValParams,
-        (err, bucket) => {
-            if (err) {
-                return cb(err);
+    // If bucket has no server-side encryption, `cipherBundle` remains `null`.
+    let cipherBundle = null;
+    let splitter = constants.splitter;
+    return async.waterfall([
+        // Get the destination bucket.
+        next => metadata.getBucket(bucketName, log, (err, bucket) => {
+            if (err && err.NoSuchBucket) {
+                return next(errors.NoSuchBucket);
             }
-            return services.getMPUBucket(
-                bucket, bucketName, log,
-                (err, mpuBucket) => {
+            if (err) {
+                log.error('error getting the destination bucket', {
+                    error: err,
+                    method: 'objectPutPart::metadata.getBucket',
+                });
+                return next(err);
+            }
+            return next(null, bucket);
+        }),
+        // Check the bucket authorization.
+        (bucket, next) => {
+            // For validating the request at the destinationBucket level the
+            // `requestType` is the general 'objectPut'.
+            const requestType = 'objectPut';
+            if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
+                log.debug('access denied for user on bucket', { requestType });
+                return next(errors.AccessDenied);
+            }
+            return next(null, bucket);
+        },
+        // Get bucket server-side encryption, if it exists.
+        (bucket, next) => {
+            const encryption = bucket.getServerSideEncryption();
+            if (encryption) {
+                return kms.createCipherBundle(encryption, log, (err, res) => {
                     if (err) {
-                        return cb(err);
-                    }
-                    // BACKWARD: Remove to remove the old splitter
-                    if (mpuBucket.getMdBucketModelVersion() < 2) {
-                        metadataValMPUparams.splitter = constants.oldSplitter;
-                    }
-                    // We pad the partNumbers so that the parts will be sorted
-                    // in numerical order
-                    const paddedPartNumber = `000000${partNumber}`.substr(-5);
-                    const serverSideEncryption =
-                              bucket.getServerSideEncryption();
-                    if (serverSideEncryption) {
-                        return kms.createCipherBundle(
-                            serverSideEncryption, log, (err, cipherBundle) => {
-                                services.metadataValidateMultipart(
-                                    metadataValMPUparams,
-                                    doStore(objectKeyContext, cipherBundle,
-                                            request, log, paddedPartNumber,
-                                            size, uploadId,
-                                            streamingV4Params, cb));
+                        log.error('error processing the cipher bundle for ' +
+                            'the destination bucket', {
+                                error: err,
                             });
                     }
-                    return services.metadataValidateMultipart(
-                        metadataValMPUparams,
-                        doStore(objectKeyContext, null, request, log,
-                                paddedPartNumber, size, uploadId,
-                                streamingV4Params, cb));
+                    cipherBundle = res;
+                    return next(err);
                 });
-        });
+            }
+            return next();
+        },
+        // Get the MPU shadow bucket.
+        next => metadata.getBucket(mpuBucketName, log, (err, mpuBucket) => {
+            if (err && err.NoSuchBucket) {
+                return next(errors.NoSuchUpload);
+            }
+            if (err) {
+                log.error('error getting the shadow mpu bucket', {
+                    error: err,
+                    method: 'objectPutPart::metadata.getBucket',
+                });
+                return next(err);
+            }
+            // BACKWARD: Remove to remove the old splitter
+            if (mpuBucket.getMdBucketModelVersion() < 2) {
+                splitter = constants.oldSplitter;
+            }
+            return next();
+        }),
+        // Check authorization of the MPU shadow bucket.
+        next => {
+            const mpuOverviewKey = _getOverviewKey(splitter, objectKey,
+                uploadId);
+            return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, log,
+                (err, res) => {
+                    if (err) {
+                        log.error('error getting the object from mpu bucket', {
+                            error: err,
+                            method: 'objectPutPart::metadata.getObjectMD',
+                        });
+                        return next(err);
+                    }
+                    const initiatorID = res.initiator.ID;
+                    const requesterID = authInfo.isRequesterAnIAMUser() ?
+                        authInfo.getArn() : authInfo.getCanonicalID();
+                    if (initiatorID !== requesterID) {
+                        return next(errors.AccessDenied);
+                    }
+                    return next();
+                });
+        },
+        // Store in data backend.
+        next => {
+            const objectKeyContext = {
+                bucketName,
+                owner: canonicalID,
+                namespace: request.namespace,
+            };
+            return dataStore(objectKeyContext, cipherBundle, request, size,
+                streamingV4Params, log, next);
+        },
+        // Store data locations in metadata.
+        (dataGetInfo, hexDigest, next) => {
+            // Use an array to be consistent with objectPutCopyPart where there
+            // could be multiple locations.
+            const partLocations = [dataGetInfo];
+            if (cipherBundle) {
+                const { algorithm, masterKeyId, cryptoScheme,
+                    cipheredDataKey } = cipherBundle;
+                partLocations[0].sseAlgorithm = algorithm;
+                partLocations[0].sseMasterKeyId = masterKeyId;
+                partLocations[0].sseCryptoScheme = cryptoScheme;
+                partLocations[0].sseCipheredDataKey = cipheredDataKey;
+            }
+            const paddedPartNumber = _getPaddedPartNumber(partNumber);
+            const partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
+            const omVal = {
+                // Version 3 changes the format of partLocations from an object
+                // to an array
+                'md-model-version': 3,
+                partLocations,
+                'key': partKey,
+                'last-modified': new Date().toJSON(),
+                'content-md5': hexDigest,
+                'content-length': size,
+            };
+            return metadata.putObjectMD(mpuBucketName, partKey, omVal, log,
+                err => {
+                    if (err) {
+                        log.error('error putting object in mpu bucket', {
+                            error: err,
+                            method: 'objectPutPart::metadata.putObjectMD',
+                        });
+                        return next(err);
+                    }
+                    return next(null, hexDigest);
+                });
+        },
+    ], (err, hexDigest) => {
+        if (err) {
+            log.error('error in object put part (upload part)', {
+                error: err,
+                method: 'objectPutPart',
+            });
+            return cb(err);
+        }
+        return cb(null, hexDigest);
+    });
 }

--- a/lib/services.js
+++ b/lib/services.js
@@ -134,6 +134,9 @@ export default {
             return cb(null, bucket, obj);
         });
     },
+    // TODO: `dataStore` has been moved to apiUtils/object/storeObject during
+    // the refactor of objectPutPart API. Once references to this function are
+    // updated in all other APIs, it should be deleted.
 
     /**
      * Stores object and responds back with location and storage type


### PR DESCRIPTION
Fixes refactoring part of #153

* Call `metadata.getBucket` directly and perform validation checks in the API.
* Remove calls to `services.metadataValidateAuthorization`, `services.metadataValidateMultipart`, and `services.getMPUBucket`.
* Remove `doStore` function and instead call `services.dataStore` and `services.metadataStorePart` directly in API.
* Remove extraneous code after the above changes.