### PR TITLE
COMPAT: Return expected response for `MaxUpload` and `Delimiter` params

### DIFF
--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -196,7 +196,7 @@ export default function listMultipartUploads(authInfo,
             if (mpuBucket.getMdBucketModelVersion() < 2) {
                 splitter = constants.oldSplitter;
             }
-            let maxUploads = Number.parseInt(query['max-uploads'], 10) ?
+            let maxUploads = query['max-uploads'] !== undefined ?
                 Number.parseInt(query['max-uploads'], 10) : 1000;
             if (maxUploads < 0) {
                 return callback(errors.InvalidArgument);

--- a/lib/metadata/in_memory/getMultipartUploadListing.js
+++ b/lib/metadata/in_memory/getMultipartUploadListing.js
@@ -10,7 +10,7 @@ export default function getMultipartUploadListing(bucket, params, callback) {
     const { delimiter, keyMarker,
         uploadIdMarker, prefix, queryPrefixLength, splitter } = params;
     const splitterLen = splitter.length;
-    const maxKeys = Number.parseInt(params.maxKeys, 10) ?
+    const maxKeys = params.maxKeys !== undefined ?
         Number.parseInt(params.maxKeys, 10) : defaultMaxKeys;
     const response = new ListMultipartUploadsResult();
     const keyMap = metadata.keyMaps.get(bucket.getName());
@@ -137,5 +137,11 @@ export default function getMultipartUploadListing(bucket, params, callback) {
             response.addUpload(currentUpload);
         }
     }
+    // `response.MaxKeys` should be the value from the original `MaxUploads`
+    // parameter specified by the user (or else the default 1000). Redefine it
+    // here, so it does not equal the value of `uploads.length`.
+    response.MaxKeys = maxKeys;
+    // If `response.MaxKeys` is 0, `response.IsTruncated` should be `false`.
+    response.IsTruncated = maxKeys === 0 ? false : response.IsTruncated;
     return callback(null, response);
 }

--- a/tests/functional/aws-node-sdk/test/object/mpu.js
+++ b/tests/functional/aws-node-sdk/test/object/mpu.js
@@ -6,31 +6,80 @@ import BucketUtility from '../../lib/utility/bucket-util';
 const bucket = 'object-test-mpu';
 const objectKey = 'toAbort&<>"\'';
 
-const throwErr = (str, err) => {
-    process.stdout.write(`${str}: ${err}\n`);
-    throw err;
-};
+// Get the expected object of listMPU API.
+function getExpectedObj(res, data) {
+    // If `maxUploads` is not given as a parameter, it should default to 1000.
+    const maxUploads = data.maxUploads === undefined ? 1000 : data.maxUploads;
 
-const checkValues = (res, uploadId, displayName, cb) => {
-    const prefix = res.Prefix ? res.Prefix : undefined;
-    const delimeter = res.Delimiter ? res.Delimiter : undefined;
-    assert.deepStrictEqual(res.KeyMarker, '');
-    assert.deepStrictEqual(res.UploadIdMarker, '');
-    assert.deepStrictEqual(res.Prefix, prefix);
-    assert.deepStrictEqual(res.Delimiter, delimeter);
-    assert.deepStrictEqual(res.Uploads.length, 1);
-    assert.deepStrictEqual(res.Uploads[0].UploadId, uploadId);
-    assert.deepStrictEqual(res.Uploads[0].StorageClass, 'STANDARD');
-    assert.deepStrictEqual(res.Uploads[0].Owner.DisplayName, displayName);
-    cb();
-};
+    // If `MaxUploads` is defined as 0, `IsTruncated` is set to `false` despite
+    // the fact that there may be multipart uploads in the bucket.
+    if (maxUploads === 0) {
+        return {
+            Bucket: bucket,
+            KeyMarker: '',
+            UploadIdMarker: '',
+            MaxUploads: 0,
+            IsTruncated: false,
+            Uploads: [],
+            CommonPrefixes: [],
+        };
+    }
 
-describe('aws-node-sdk test suite of listMultipartUploads', () => {
+    const { prefixVal, delimiter, uploadId, displayName, userId } = data;
+    const initiated = new Date(res.Uploads[0].Initiated.toISOString());
+    const expectedObj = {
+        Bucket: bucket,
+        KeyMarker: '',
+        UploadIdMarker: '',
+        NextKeyMarker: objectKey,
+        Prefix: prefixVal,
+        Delimiter: delimiter,
+        NextUploadIdMarker: uploadId,
+        MaxUploads: maxUploads,
+        IsTruncated: false,
+        Uploads: [{
+            UploadId: uploadId,
+            Key: objectKey,
+            Initiated: initiated,
+            StorageClass: 'STANDARD',
+            Owner:
+            {
+                DisplayName: displayName,
+                ID: userId,
+            },
+            Initiator:
+            {
+                DisplayName: displayName,
+                ID: userId,
+            },
+        }],
+        CommonPrefixes: [],
+    };
+
+    // If no `prefixVal` is given, it should not be included in the response.
+    if (!prefixVal) {
+        delete expectedObj.Prefix;
+    }
+
+    // If no `delimiter` is given, it should not be included in the response.
+    if (!delimiter) {
+        delete expectedObj.Delimiter;
+    }
+
+    return expectedObj;
+}
+
+// Compare the response object with the expected object.
+function checkValues(res, data) {
+    const expectedObj = getExpectedObj(res, data);
+    assert.deepStrictEqual(res, expectedObj);
+}
+
+describe('aws-node-sdk test suite of listMultipartUploads', () =>
     withV4(sigCfg => {
         let bucketUtil;
         let s3;
-        let uploadId;
-        let displayName;
+        const data = {};
 
         beforeEach(() => {
             bucketUtil = new BucketUtility('default', sigCfg);
@@ -39,45 +88,56 @@ describe('aws-node-sdk test suite of listMultipartUploads', () => {
             return s3.createBucketAsync({ Bucket: bucket })
             .then(() => bucketUtil.getOwner())
             .then(res => {
-                // In this case, the owner of the bucket will also be the MPU
-                // upload owner. We need this value for testing comparison.
-                displayName = res.DisplayName;
+                // The owner of the bucket will also be the MPU upload owner.
+                data.displayName = res.DisplayName;
+                data.userId = res.ID;
             })
             .then(() => s3.createMultipartUploadAsync({
                 Bucket: bucket,
                 Key: objectKey,
             }))
             .then(res => {
-                uploadId = res.UploadId;
-            })
-            .catch(err => throwErr('Error in beforeEach', err));
+                data.uploadId = res.UploadId;
+            });
         });
 
         afterEach(() =>
             s3.abortMultipartUploadAsync({
                 Bucket: bucket,
                 Key: objectKey,
-                UploadId: uploadId,
+                UploadId: data.uploadId,
             })
             .then(() => bucketUtil.empty(bucket))
             .then(() => bucketUtil.deleteOne(bucket))
-            .catch(err => throwErr('Error in afterEach', err))
         );
 
-        it('should list ongoing multipart uploads', done => {
+        it('should list ongoing multipart uploads', () =>
             s3.listMultipartUploadsAsync({ Bucket: bucket })
-            .then(res => checkValues(res, uploadId, displayName, done))
-            .catch(done);
-        });
+            .then(res => checkValues(res, data))
+        );
 
-        it('should list ongoing multipart uploads with params', done => {
-            s3.listMultipartUploadsAsync({
+        it('should list ongoing multipart uploads with params', () => {
+            data.prefixVal = 'to';
+            data.delimiter = 'test-delimiter';
+            data.maxUploads = 1;
+
+            return s3.listMultipartUploadsAsync({
                 Bucket: bucket,
                 Prefix: 'to',
+                Delimiter: 'test-delimiter',
                 MaxUploads: 1,
             })
-            .then(res => checkValues(res, uploadId, displayName, done))
-            .catch(done);
+            .then(res => checkValues(res, data));
         });
-    });
-});
+
+        it('should list 0 multipart uploads when MaxUploads is 0', () => {
+            data.maxUploads = 0;
+
+            return s3.listMultipartUploadsAsync({
+                Bucket: bucket,
+                MaxUploads: 0,
+            })
+            .then(res => checkValues(res, data));
+        });
+    })
+);


### PR DESCRIPTION
Currently, the value of `MaxUploads` for listMultipartUpload API is
the number of MPU in a bucket. This is not the behavior of AWS. This
commit changes the API's behavior so the value of `MaxUploads` can be
specified by the user using the `MaxUploads` parameter. This commit also
returns the expected default of 1000 if no `MaxUploads` is defined.
If `MaxUploads` is defined as `0`, the behavior of AWS is to return an
empty `Uploads` array and set `IsTruncated` to `false`. This commit also
adds this expected behavior.

Currently, when using the file-backend, if a `Delimiter` parameter is
defined and it does not result in a `CommonPrefixes` array that is
greater than 0, `Delimiter` is set to `''`. This causes the XML response
to omit the `Delimeter` key. For compatibility with AWS, this commit
tests an associated change in Arsenal that fixes the `Delimiter` response:
https://github.com/scality/Arsenal/pull/197

A new test that directly compares the expected object has been added to 
verify these behaviors.