### PR TITLE
fix: flaky healthcheck test

### DIFF
--- a/tests/functional/healthchecks/test/checkRoutes.js
+++ b/tests/functional/healthchecks/test/checkRoutes.js
@@ -116,14 +116,17 @@ describe('Healthcheck stats', () => {
     afterEach(() => redis.flushdb());
 
     it('should respond back with total requests', done =>
-        makeStatsRequest((err, res) => {
-            if (err) {
-                return done(err);
-            }
-            const expectedStatsRes = { 'requests': totalReqs, '500s': 0,
-                'sampleDuration': 30 };
-            assert.deepStrictEqual(JSON.parse(res), expectedStatsRes);
-            return done();
-        })
+        // interm fix to avoid race condition with Redis
+        setTimeout(() => {
+            makeStatsRequest((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                const expectedStatsRes = { 'requests': totalReqs, '500s': 0,
+                    'sampleDuration': 30 };
+                assert.deepStrictEqual(JSON.parse(res), expectedStatsRes);
+                return done();
+            });
+        }, 500)
     );
 });


### PR DESCRIPTION
This commit adds a delay of 100ms to ensure that stats request is made
after the Redis calls are complete, otherwise it will result in a race
condition making the test fail.