### PR TITLE
BF: ListPart - when PartNumberMarker > 0 return no part

### DIFF
--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -195,8 +195,9 @@ export default function listParts(authInfo, request, log, callback) {
                 { tag: 'StorageClass', value: mpuOverviewArray[8] },
                 { tag: 'PartNumberMarker', value: partNumberMarker ||
                     undefined },
+                // print only if it's truncated
                 { tag: 'NextPartNumberMarker', value: isTruncated ?
-                    lastPartShown : undefined }, // print only if it's truncated
+                    parseInt(lastPartShown, 10) : undefined },
                 { tag: 'MaxParts', value: maxParts },
                 { tag: 'IsTruncated', value: isTruncated ? 'true' : 'false' },
             ], xml);
@@ -204,7 +205,7 @@ export default function listParts(authInfo, request, log, callback) {
             partListing.forEach(part => {
                 xml.push('<Part>');
                 buildXML([
-                    { tag: 'PartNumber', value: part.partNumber },
+                    { tag: 'PartNumber', value: parseInt(part.partNumber, 10) },
                     { tag: 'LastModified', value: part.lastModified },
                     { tag: 'ETag', value: part.ETag },
                     { tag: 'Size', value: part.size },

--- a/lib/services.js
+++ b/lib/services.js
@@ -754,9 +754,10 @@ export default {
             params;
         assert.strictEqual(typeof mpuBucketName, 'string');
         assert.strictEqual(typeof params.splitter, 'string');
+        const paddedPartNumber = `000000${partNumberMarker}`.substr(-5);
         const searchArgs = {
             prefix: uploadId,
-            marker: `${uploadId}${params.splitter}${partNumberMarker}`,
+            marker: `${uploadId}${params.splitter}${paddedPartNumber}`,
             delimiter: undefined,
             maxKeys: maxParts,
         };

--- a/tests/functional/aws-node-sdk/test/object/listParts.js
+++ b/tests/functional/aws-node-sdk/test/object/listParts.js
@@ -1,0 +1,77 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+const bucket = 'bucketlistparts';
+const key = 'key';
+const bodyFirstPart = Buffer.allocUnsafe(10);
+const bodySecondPart = Buffer.allocUnsafe(20);
+
+function checkNoError(err) {
+    assert.equal(err, null,
+        `Expected success, got error ${JSON.stringify(err)}`);
+}
+
+describe('List parts', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+        let uploadId;
+        let secondEtag;
+
+        beforeEach(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            return s3.createBucketAsync({ Bucket: bucket })
+            .then(() => s3.createMultipartUploadAsync({
+                Bucket: bucket, Key: key }))
+            .then(res => {
+                uploadId = res.UploadId;
+                return s3.uploadPartAsync({ Bucket: bucket, Key: key,
+                  PartNumber: 1, UploadId: uploadId, Body: bodyFirstPart });
+            }).then(() => s3.uploadPartAsync({ Bucket: bucket, Key: key,
+                PartNumber: 2, UploadId: uploadId, Body: bodySecondPart })
+            ).then(res => {
+                secondEtag = res.ETag;
+                return secondEtag;
+            })
+            .catch(err => {
+                process.stdout.write(`Error in beforeEach: ${err}\n`);
+                throw err;
+            });
+        });
+
+        afterEach(() => {
+            process.stdout.write('Emptying bucket');
+            return s3.abortMultipartUploadAsync({
+                Bucket: bucket, Key: key, UploadId: uploadId,
+            })
+            .then(() => bucketUtil.empty(bucket))
+            .then(() => {
+                process.stdout.write('Deleting bucket');
+                return bucketUtil.deleteOne(bucket);
+            })
+            .catch(err => {
+                process.stdout.write('Error in afterEach');
+                throw err;
+            });
+        });
+
+        // remove the quote when forward porting to master
+        it('should only list the second part', done => {
+            s3.listParts({
+                Bucket: bucket,
+                Key: key,
+                PartNumberMarker: 1,
+                UploadId: uploadId },
+            (err, data) => {
+                checkNoError(err);
+                assert.strictEqual(data.Parts[0].PartNumber, 2);
+                assert.strictEqual(data.Parts[0].Size, 20);
+                assert.strictEqual(`"${data.Parts[0].ETag}"`, secondEtag);
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/api/listParts.js
+++ b/tests/unit/api/listParts.js
@@ -26,12 +26,12 @@ const sixMBObjectETag = 'f3a9fb2071d3503b703938a74eb99846';
 const lastPieceETag = '555e4cd2f9eff38109d7a3ab13995a32';
 const overviewKey = `overview${splitter}$makememulti${splitter}4db92ccc-` +
     'd89d-49d3-9fa6-e9c2c1eb31b0';
-const partOneKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}1`;
+const partOneKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}00001`;
 const partTwoKey = '4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0' +
-    `${splitter}2`;
-const partThreeKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}3`;
-const partFourKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}4`;
-const partFiveKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}5`;
+    `${splitter}00002`;
+const partThreeKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}00003`;
+const partFourKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}00004`;
+const partFiveKey = `4db92ccc-d89d-49d3-9fa6-e9c2c1eb31b0${splitter}00005`;
 
 describe('List Parts API', () => {
     beforeEach(done => {


### PR DESCRIPTION
FIXES #445

The issue is related with the fact that in the [MarkerFilter function ](https://github.com/scality/S3/blob/d3ba43b87ce07a640ade2413f5f915e178a73dff/lib/metadata/in_memory/bucket_utilities.js#L1), a marker was never equals to any keys.  This is for the in memory implementation.  For the file backend and other backends, LevelDB also needs a padded part number to sort correctly.