### PR TITLE
FIX: Fill buffer with zeros

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/listParts.js
+++ b/tests/functional/aws-node-sdk/test/object/listParts.js
@@ -5,8 +5,8 @@ import BucketUtility from '../../lib/utility/bucket-util';
 
 const bucket = 'bucketlistparts';
 const key = 'key';
-const bodyFirstPart = Buffer.allocUnsafe(10);
-const bodySecondPart = Buffer.allocUnsafe(20);
+const bodyFirstPart = Buffer.allocUnsafe(10).fill(0);
+const bodySecondPart = Buffer.allocUnsafe(20).fill(0);
 
 function checkNoError(err) {
     assert.equal(err, null,


### PR DESCRIPTION
Because using `allocUnsafe` the contents of the newly created Buffer are unknown and may contain sensitive data