### PR TITLE
Make func check handling consistent across backends

### DIFF
--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -108,11 +108,6 @@ export const backend = {
             return callback();
         });
     },
-
-    healthcheck: (log, callback) => {
-        process.nextTick(() =>
-            callback(null, { statusCode: 200, statusMessage: 'OK' }));
-    },
 };
 
 export default backend;

--- a/lib/data/in_memory/backend.js
+++ b/lib/data/in_memory/backend.js
@@ -86,11 +86,6 @@ export const backend = {
             return callback(null);
         });
     },
-
-    healthcheck: (log, callback) => {
-        process.nextTick(() =>
-            callback(null, { statusCode: 200, statusMessage: 'OK' }));
-    },
 };
 
 export default backend;

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -155,7 +155,12 @@ const data = {
     },
 
     checkHealth: (log, cb) => {
-        client.healthcheck(log, (err, result) => {
+        if (!client.healthcheck) {
+            const defResp = {};
+            defResp[implName] = { code: 200, message: 'OK' };
+            return cb(null, defResp);
+        }
+        return client.healthcheck(log, (err, result) => {
             const respBody = {};
             if (err) {
                 log.error(`error from ${implName}`, { error: err });


### PR DESCRIPTION
The handling to check if the backend healthcheck function exists was done differently in vaultclient and bucketclient from sproxyd. This makes sproxyd follow the same format.