### PR TITLE
fix: allow bucket names with IP addresses in them

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,7 @@ utils.getNamesFromReq = function getNamesFromReq(request, bucketNameFromHost) {
  * bucket name against validation rules
  */
 utils.isValidBucketName = function isValidBucketName(bucketname) {
-    const ipAddressRegex = new RegExp(/(\d+\.){3}\d+/);
+    const ipAddressRegex = new RegExp(/^(\d+\.){3}\d+$/);
     const dnsRegex = new RegExp(/^[a-z0-9]+([\.\-]{1}[a-z0-9]+)*$/);
     // Must be at least 3 and no more than 63 characters long.
     if (bucketname.length < 3 || bucketname.length > 63) {

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -113,27 +113,26 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
         });
 
         describe('bucket creation success', () => {
-            it('should create bucket if name is valid', done => {
-                const validName = 'scality-very-valid-bucket-name';
+            function _test(name, done) {
+                bucketUtil.s3.createBucket({ Bucket: name }, (err, res) => {
+                    assert.ifError(err);
+                    if (process.env.AWS_ON_AIR) {
+                        assert(res.Location, 'No Location in response');
+                        assert(res.Location.indexOf(name) > -1,
+                            'Does not include bucket name in Location');
+                    }
 
-                bucketUtil.s3
-                    .createBucket({ Bucket: validName }, (error, data) => {
-                        assert.ifError(error);
+                    bucketUtil.deleteOne(name).then(() => done()).catch(done);
+                });
+            }
+            it('should create bucket if name is valid', done =>
+                _test('scality-very-valid-bucket-name', done));
 
-                        if (process.env.AWS_ON_AIR) {
-                            assert(data.Location, 'No Location in response');
-                            assert(data.Location.indexOf(validName) > -1,
-                                'Does not include bucket name in Location');
-                        }
+            it('should create bucket if name is some prefix and an IP address',
+                done => _test('prefix-192.168.5.4', done));
 
-                        bucketUtil
-                            .deleteOne(validName)
-                            .then(() => {
-                                done();
-                            })
-                            .catch(done);
-                    });
-            });
+            it('should create bucket if name is an IP address with some suffix',
+                done => _test('192.168.5.4-suffix', done));
         });
     });
 });


### PR DESCRIPTION
The bucketname check loosely checked if it matches an IP address, this
failed bucketnames which includes IP with prefixes. The commit adds a strict
check so that regex matches exactly an IP address.

fix #464