### PR TITLE
REFACTOR: Add & use bucketOwnerAction requestType

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -6,6 +6,9 @@ export function isBucketAuthorized(bucket, requestType, canonicalID) {
     // TODO: Add IAM checks and bucket policy checks.
     if (bucket.getOwner() === canonicalID) {
         return true;
+    } else if (requestType === 'bucketOwnerAction') {
+        // only bucket owner can modify or retrieve this property of a bucket
+        return false;
     }
     const bucketAcl = bucket.getAcl();
     if (requestType === 'bucketGet' || requestType === 'bucketHead') {
@@ -34,12 +37,6 @@ export function isBucketAuthorized(bucket, requestType, canonicalID) {
             || bucketAcl.WRITE_ACP.indexOf(canonicalID) > -1) {
             return true;
         }
-    }
-
-    // only bucket owner can modify or retrieve this property of a bucket
-    if (requestType === 'bucketGetVersioning' ||
-            requestType === 'bucketPutVersioning') {
-        return false;
     }
 
     if (requestType === 'bucketDelete' && bucket.getOwner() === canonicalID) {

--- a/lib/api/apiUtils/bucket/bucketShield.js
+++ b/lib/api/apiUtils/bucket/bucketShield.js
@@ -9,7 +9,7 @@ import { invisiblyDelete } from './bucketDeletion';
  */
 export default function (bucket, requestType) {
     const invisiblyDeleteRequests = ['bucketGet', 'bucketHead',
-        'bucketGetACL', 'bucketPutWebsite', 'objectGet', 'objectGetACL',
+        'bucketGetACL', 'bucketOwnerAction', 'objectGet', 'objectGetACL',
         'objectHead', 'objectPutACL', 'objectDelete'];
     if (invisiblyDeleteRequests.indexOf(requestType) > -1 &&
         bucket.hasDeletedFlag()) {

--- a/lib/api/bucketGetVersioning.js
+++ b/lib/api/bucketGetVersioning.js
@@ -51,7 +51,7 @@ export default function bucketGetVersioning(authInfo, request, log, callback) {
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketGetVersioning',
+        requestType: 'bucketOwnerAction',
         log,
     };
 

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -31,7 +31,7 @@ export default function bucketPutVersioning(authInfo, request, log, callback) {
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketPutVersioning',
+        requestType: 'bucketOwnerAction',
         log,
     };
 

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -6,6 +6,8 @@ import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 import { parseWebsiteConfigXml } from './apiUtils/bucket/bucketWebsite';
 
+const requestType = 'bucketOwnerAction';
+
 /**
  * Bucket Put Website - Create bucket website configuration
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
@@ -17,7 +19,6 @@ import { parseWebsiteConfigXml } from './apiUtils/bucket/bucketWebsite';
 export default function bucketPutWebsite(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPutWebsite' });
     const bucketName = request.bucketName;
-    const requestType = 'bucketPutWebsite';
     const canonicalID = authInfo.getCanonicalID();
 
     if (!request.post) {
@@ -45,6 +46,7 @@ export default function bucketPutWebsite(authInfo, request, log, callback) {
             if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
                 log.debug('access denied for user on bucket', {
                     requestType,
+                    method: 'bucketPutWebsite',
                 });
                 return next(errors.AccessDenied);
             }


### PR DESCRIPTION
There is a similar group of bucket-level actions which are only permitted if user is the bucket owner or has granted permissions. This commit refactors acl checks to explicitly check whether an action belongs to this category and adds this requestType to bucketShield. For existing api actions, it affects bucketPutVersioning, bucketGetVersioning, and bucketPutWebsite.