### PR TITLE
Restore max limit on listing

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -54,12 +54,10 @@ export default {
 
     // Number of sub-directories for file backend
     folderHash: 3511, // Prime number
-    // AWS does not set a hard limit on the listing maxKeys.
-    // Nonetheless, we should not consume the whole memory when
-    // listing some large buckets
+    // AWS only returns 1000 on a listing
     // http://docs.aws.amazon.com/AmazonS3/latest/API/
     //      RESTBucketGET.html#RESTBucketGET-requests
-    listingHardLimit: 20000,
+    listingHardLimit: 1000,
 
     // AWS sets a minimum size limit for parts except for the last part.
     // http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -48,14 +48,16 @@ export default function bucketGet(authInfo, request, log, callback) {
         return callback(errors.InvalidArgument.customizeDescription('Invalid ' +
             'Encoding Method specified in Request'));
     }
-    let maxKeys = params['max-keys'] ?
+    const requestMaxKeys = params['max-keys'] ?
         Number.parseInt(params['max-keys'], 10) : 1000;
-    if (Number.isNaN(maxKeys) || maxKeys < 0) {
+    if (Number.isNaN(requestMaxKeys) || requestMaxKeys < 0) {
         return callback(errors.InvalidArgument);
     }
-    if (maxKeys > constants.listingHardLimit) {
-        maxKeys = constants.listingHardLimit;
-    }
+    // AWS only returns 1000 keys even if max keys are greater.
+    // Max keys stated in response xml can be greater than actual
+    // keys returned.
+    const actualMaxKeys = Math.min(constants.listingHardLimit, requestMaxKeys);
+
     const metadataValParams = {
         authInfo,
         bucketName,
@@ -63,7 +65,7 @@ export default function bucketGet(authInfo, request, log, callback) {
         log,
     };
     const listParams = {
-        maxKeys,
+        maxKeys: actualMaxKeys,
         delimiter: params.delimiter,
         marker: params.marker,
         prefix: params.prefix,
@@ -92,7 +94,7 @@ export default function bucketGet(authInfo, request, log, callback) {
                 { tag: 'Prefix', value: listParams.prefix },
                 { tag: 'NextMarker', value: list.NextMarker },
                 { tag: 'Marker', value: listParams.marker },
-                { tag: 'MaxKeys', value: listParams.maxKeys },
+                { tag: 'MaxKeys', value: requestMaxKeys },
                 { tag: 'Delimiter', value: listParams.delimiter },
                 { tag: 'EncodingType', value: encoding },
                 { tag: 'IsTruncated', value: isTruncated },

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -164,7 +164,8 @@ describe('bucketGet API', () => {
         });
     });
 
-    it('should return max-keys: 20000 if max-keys > 20000', done => {
+    it('should return max-keys number from request even if greater than ' +
+        'actual keys returned', done => {
         const testGetRequest = {
             bucketName,
             namespace,
@@ -185,7 +186,7 @@ describe('bucketGet API', () => {
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.MaxKeys[0],
-                               '20000');
+                               '99999');
             done();
         });
     });


### PR DESCRIPTION
Allow a bucket listing to return a max keys number
greater than actual keys returned to mirror AWS.