### PR TITLE
FIX: Handle `objectPutPart` overwrites

### DIFF
--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -3,11 +3,13 @@ import async from 'async';
 import { errors } from 'arsenal';
 
 import constants from '../../constants';
+import data from '../data/wrapper';
 import kms from '../kms/wrapper';
 import { dataStore } from './apiUtils/object/storeObject';
 import metadata from '../metadata/wrapper';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import { pushMetric } from '../utapi/utilities';
+import { logger } from '../utilities/logger';
 
 
 // We pad the partNumbers so that the parts will be sorted in numerical order.
@@ -77,11 +79,6 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
     const uploadId = request.query.uploadId;
     const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
     const objectKey = request.objectKey;
-    // If bucket has no server-side encryption, `cipherBundle` remains `null`.
-    let cipherBundle = null;
-    let splitter = constants.splitter;
-    let prevObjectSize = null;
-    let partKey;
     return async.waterfall([
         // Get the destination bucket.
         next => metadata.getBucket(bucketName, log, (err, bucket) => {
@@ -111,6 +108,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
         // Get bucket server-side encryption, if it exists.
         (bucket, next) => {
             const encryption = bucket.getServerSideEncryption();
+            // If bucket has server-side encryption, pass the `res` value
             if (encryption) {
                 return kms.createCipherBundle(encryption, log, (err, res) => {
                     if (err) {
@@ -118,33 +116,36 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             'the destination bucket', {
                                 error: err,
                             });
+                        return next(err);
                     }
-                    cipherBundle = res;
-                    return next(err);
+                    return next(null, res);
                 });
             }
-            return next();
+            // The bucket does not have server-side encryption, so pass `null`
+            return next(null, null);
         },
         // Get the MPU shadow bucket.
-        next => metadata.getBucket(mpuBucketName, log, (err, mpuBucket) => {
-            if (err && err.NoSuchBucket) {
-                return next(errors.NoSuchUpload);
-            }
-            if (err) {
-                log.error('error getting the shadow mpu bucket', {
-                    error: err,
-                    method: 'objectPutPart::metadata.getBucket',
-                });
-                return next(err);
-            }
-            // BACKWARD: Remove to remove the old splitter
-            if (mpuBucket.getMdBucketModelVersion() < 2) {
-                splitter = constants.oldSplitter;
-            }
-            return next();
-        }),
+        (cipherBundle, next) => metadata.getBucket(mpuBucketName, log,
+            (err, mpuBucket) => {
+                if (err && err.NoSuchBucket) {
+                    return next(errors.NoSuchUpload);
+                }
+                if (err) {
+                    log.error('error getting the shadow mpu bucket', {
+                        error: err,
+                        method: 'objectPutPart::metadata.getBucket',
+                    });
+                    return next(err);
+                }
+                let splitter = constants.splitter;
+                // BACKWARD: Remove to remove the old splitter
+                if (mpuBucket.getMdBucketModelVersion() < 2) {
+                    splitter = constants.oldSplitter;
+                }
+                return next(null, cipherBundle, splitter);
+            }),
         // Check authorization of the MPU shadow bucket.
-        next => {
+        (cipherBundle, splitter, next) => {
             const mpuOverviewKey = _getOverviewKey(splitter, objectKey,
                 uploadId);
             return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, log,
@@ -162,13 +163,13 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                     if (initiatorID !== requesterID) {
                         return next(errors.AccessDenied);
                     }
-                    return next();
+                    return next(null, cipherBundle, splitter);
                 });
         },
         // Get any pre-existing part.
-        next => {
+        (cipherBundle, splitter, next) => {
             const paddedPartNumber = _getPaddedPartNumber(partNumber);
-            partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
+            const partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
             return metadata.getObjectMD(mpuBucketName, partKey, log,
                 (err, res) => {
                     // If there is no object with the same key, continue.
@@ -179,26 +180,41 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                         });
                         return next(err);
                     }
+                    let prevObjectSize = null;
+                    let oldLocations = null;
                     // If there is a pre-existing part, update utapi metrics and
                     // get the locations of data to be overwritten.
                     if (res) {
                         prevObjectSize = res['content-length'];
+                        // Pull locations to clean up any potential orphans in
+                        // data if object put is an overwrite of a pre-existing
+                        // object with the same key and part number.
+                        oldLocations = Array.isArray(res.partLocations) ?
+                            res.partLocations : [res.partLocations];
                     }
-                    return next();
+                    return next(null, cipherBundle, partKey, prevObjectSize,
+                        oldLocations);
                 });
         },
         // Store in data backend.
-        next => {
+        (cipherBundle, partKey, prevObjectSize, oldLocations, next) => {
             const objectKeyContext = {
                 bucketName,
                 owner: canonicalID,
                 namespace: request.namespace,
             };
             return dataStore(objectKeyContext, cipherBundle, request, size,
-                streamingV4Params, log, next);
+                streamingV4Params, log, (err, dataGetInfo, hexDigest) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    return next(null, dataGetInfo, hexDigest, cipherBundle,
+                        partKey, prevObjectSize, oldLocations);
+                });
         },
-        // Store data locations in metadata.
-        (dataGetInfo, hexDigest, next) => {
+        // Store data locations in metadata and delete any overwritten data.
+        (dataGetInfo, hexDigest, cipherBundle, partKey, prevObjectSize,
+            oldLocations, next) => {
             // Use an array to be consistent with objectPutCopyPart where there
             // could be multiple locations.
             const partLocations = [dataGetInfo];
@@ -229,10 +245,18 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                         });
                         return next(err);
                     }
-                    return next(null, hexDigest);
+                    // Clean up any old data now that new metadata (with new
+                    // data locations) has been stored.
+                    if (oldLocations) {
+                        log.trace('Overwriting MPU part, deleting data');
+                        data.batchDelete(oldLocations, logger
+                            .newRequestLoggerFromSerializedUids(log
+                            .getSerializedUids()));
+                    }
+                    return next(null, hexDigest, prevObjectSize);
                 });
         },
-    ], (err, hexDigest) => {
+    ], (err, hexDigest, prevObjectSize) => {
         if (err) {
             log.error('error in object put part (upload part)', {
                 error: err,

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -77,10 +77,11 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
     const uploadId = request.query.uploadId;
     const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
     const objectKey = request.objectKey;
-
     // If bucket has no server-side encryption, `cipherBundle` remains `null`.
     let cipherBundle = null;
     let splitter = constants.splitter;
+    let prevObjectSize = null;
+    let partKey;
     return async.waterfall([
         // Get the destination bucket.
         next => metadata.getBucket(bucketName, log, (err, bucket) => {
@@ -164,6 +165,28 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                     return next();
                 });
         },
+        // Get any pre-existing part.
+        next => {
+            const paddedPartNumber = _getPaddedPartNumber(partNumber);
+            partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
+            return metadata.getObjectMD(mpuBucketName, partKey, log,
+                (err, res) => {
+                    // If there is no object with the same key, continue.
+                    if (err && !err.NoSuchKey) {
+                        log.error('error getting current part (if any)', {
+                            error: err,
+                            method: 'objectPutPart::metadata.getObjectMD',
+                        });
+                        return next(err);
+                    }
+                    // If there is a pre-existing part, update utapi metrics and
+                    // get the locations of data to be overwritten.
+                    if (res) {
+                        prevObjectSize = res['content-length'];
+                    }
+                    return next();
+                });
+        },
         // Store in data backend.
         next => {
             const objectKeyContext = {
@@ -187,8 +210,6 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                 partLocations[0].sseCryptoScheme = cryptoScheme;
                 partLocations[0].sseCipheredDataKey = cipheredDataKey;
             }
-            const paddedPartNumber = _getPaddedPartNumber(partNumber);
-            const partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
             const omVal = {
                 // Version 3 changes the format of partLocations from an object
                 // to an array
@@ -223,6 +244,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
             authInfo,
             bucket: bucketName,
             newByteLength: size,
+            oldByteLength: prevObjectSize,
         });
         return cb(null, hexDigest);
     });


### PR DESCRIPTION
Fix #153

Update Utapi metrics on `objectPutPart` overwrites and remove orphaned data on overwrite.

See associated PRs: 
https://github.com/scality/Integration/pull/384
https://github.com/scality/utapi/pull/71