### PR TITLE
FT: Add deleteBucketWebsite to API

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -3,6 +3,7 @@ import querystring from 'querystring';
 import { auth, errors } from 'arsenal';
 
 import bucketDelete from './bucketDelete';
+import bucketDeleteWebsite from './bucketDeleteWebsite';
 import bucketGet from './bucketGet';
 import bucketGetACL from './bucketGetACL';
 import bucketGetVersioning from './bucketGetVersioning';
@@ -87,6 +88,7 @@ const api = {
         }, 's3', requestContexts);
     },
     bucketDelete,
+    bucketDeleteWebsite,
     bucketGet,
     bucketGetACL,
     bucketGetVersioning,

--- a/lib/api/bucketDeleteWebsite.js
+++ b/lib/api/bucketDeleteWebsite.js
@@ -1,0 +1,43 @@
+import { errors } from 'arsenal';
+
+import bucketShield from './apiUtils/bucket/bucketShield';
+import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
+import metadata from '../metadata/wrapper';
+
+const requestType = 'bucketOwnerAction';
+
+export default function bucketDeleteWebsite(authInfo, request, log, callback) {
+    const bucketName = request.bucketName;
+    const canonicalID = authInfo.getCanonicalID();
+
+    return metadata.getBucket(bucketName, log, (err, bucket) => {
+        if (err) {
+            log.debug('metadata getbucket failed', { error: err });
+            return callback(err);
+        }
+        if (bucketShield(bucket, requestType)) {
+            return callback(errors.NoSuchBucket);
+        }
+        log.trace('found bucket in metadata');
+
+        if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
+            log.debug('access denied for user on bucket', {
+                requestType,
+                method: 'bucketDeleteWebsite',
+            });
+            return callback(errors.AccessDenied);
+        }
+
+        const websiteConfig = bucket.getWebsiteConfiguration();
+        if (!websiteConfig) {
+            log.trace('no existing website configuration', {
+                method: 'bucketDeleteWebsite',
+            });
+            return callback();
+        }
+
+        log.trace('deleting website configuration in metadata');
+        bucket.setWebsiteConfiguration(null);
+        return metadata.updateBucket(bucketName, bucket, log, callback);
+    });
+}

--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -8,6 +8,16 @@ export default function routeDELETE(request, response, log, utapi,
     log.debug('routing request', { method: 'routeDELETE' });
 
     if (request.objectKey === undefined) {
+        if (request.query.website !== undefined) {
+            return api.callApiMethod('bucketDeleteWebsite', request, log,
+            err => {
+                statsReport500(err, statsClient);
+                pushMetrics(err, log, utapi, 'bucketDeleteWebsite',
+                    request.bucketName);
+                return routesUtils.responseNoBody(err, null, response, 200,
+                    log);
+            });
+        }
         api.callApiMethod('bucketDelete', request, log, (err, resHeaders) => {
             statsReport500(err, statsClient);
             pushMetrics(err, log, utapi, 'bucketDelete', request.bucketName);
@@ -44,4 +54,5 @@ export default function routeDELETE(request, response, log, utapi,
               });
         }
     }
+    return undefined;
 }

--- a/lib/utilities/pushMetrics.js
+++ b/lib/utilities/pushMetrics.js
@@ -56,6 +56,9 @@ export default function pushMetrics(err, log, utapi, action, resource,
         case 'bucketDelete':
             utapi.pushMetricDeleteBucket(reqUid, resource);
             break;
+        case 'bucketDeleteWebsite':
+            utapi.pushMetricDeleteBucketWebsite(reqUid, resource);
+            break;
         case 'objectDelete':
             utapi.pushMetricDeleteObject(reqUid, resource, contentLength);
             break;

--- a/tests/functional/aws-node-sdk/test/bucket/deleteWebsite.js
+++ b/tests/functional/aws-node-sdk/test/bucket/deleteWebsite.js
@@ -1,0 +1,69 @@
+import assert from 'assert';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+import { WebsiteConfigTester } from '../../lib/utility/website-util';
+
+const bucketName = 'testdeletewebsitebucket';
+
+describe('DELETE bucket website', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        const otherAccountBucketUtility = new BucketUtility('lisa', {});
+        const otherAccountS3 = otherAccountBucketUtility.s3;
+
+        describe('without existing bucket', () => {
+            it('should return NoSuchBucket', done => {
+                s3.deleteBucketWebsite({ Bucket: bucketName }, err => {
+                    assert(err);
+                    assert.strictEqual(err.code, 'NoSuchBucket');
+                    assert.strictEqual(err.statusCode, 404);
+                    return done();
+                });
+            });
+        });
+
+        describe('with existing bucket', () => {
+            beforeEach(() => s3.createBucketAsync({ Bucket: bucketName }));
+            afterEach(() => bucketUtil.deleteOne(bucketName));
+
+            describe('without existing configuration', () => {
+                it('should return a 200 response', done => {
+                    s3.deleteBucketWebsite({ Bucket: bucketName }, err => {
+                        assert.strictEqual(err, null,
+                            `Found unexpected err ${err}`);
+                        return done();
+                    });
+                });
+            });
+
+            describe('with existing configuration', () => {
+                beforeEach(done => {
+                    const config = new WebsiteConfigTester('index.html');
+                    s3.putBucketWebsite({ Bucket: bucketName,
+                    WebsiteConfiguration: config }, done);
+                });
+
+                it('should delete bucket configuration successfully', done => {
+                    s3.deleteBucketWebsite({ Bucket: bucketName }, err => {
+                        assert.strictEqual(err, null,
+                            `Found unexpected err ${err}`);
+                        return done();
+                    });
+                });
+
+                it('should return AccessDenied if user is not bucket owner',
+                done => {
+                    otherAccountS3.deleteBucketWebsite({ Bucket: bucketName },
+                    err => {
+                        assert(err);
+                        assert.strictEqual(err.code, 'AccessDenied');
+                        assert.strictEqual(err.statusCode, 403);
+                        return done();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/api/bucketDeleteWebsite.js
+++ b/tests/unit/api/bucketDeleteWebsite.js
@@ -1,0 +1,64 @@
+import assert from 'assert';
+
+import bucketPut from '../../../lib/api/bucketPut';
+import bucketPutWebsite from '../../../lib/api/bucketPutWebsite';
+import bucketDeleteWebsite from '../../../lib/api/bucketDeleteWebsite';
+import { cleanup,
+    DummyRequestLogger,
+    makeAuthInfo,
+    WebsiteConfig }
+from '../helpers';
+import metadata from '../../../lib/metadata/wrapper';
+
+const log = new DummyRequestLogger();
+const authInfo = makeAuthInfo('accessKey1');
+const bucketName = 'bucketname';
+const locationConstraint = 'us-west-1';
+const config = new WebsiteConfig('index.html', 'error.html');
+config.addRoutingRule({ ReplaceKeyPrefixWith: 'documents/' },
+{ KeyPrefixEquals: 'docs/' });
+const testBucketPutRequest = {
+    bucketName,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+};
+const testBucketDeleteWebsiteRequest = {
+    bucketName,
+    headers: {
+        host: `${bucketName}.s3.amazonaws.com`,
+    },
+    url: '/?website',
+    query: { website: '' },
+};
+const testBucketPutWebsiteRequest = Object.assign({ post: config.getXml() },
+    testBucketDeleteWebsiteRequest);
+
+describe('deleteBucketWebsite API', () => {
+    beforeEach(done => {
+        cleanup();
+        bucketPut(authInfo, testBucketPutRequest,
+        locationConstraint, log, () => {
+            bucketPutWebsite(authInfo, testBucketPutWebsiteRequest, log, done);
+        });
+    });
+    afterEach(() => cleanup());
+
+    it('should delete a bucket\'s website configuration in metadata', done => {
+        bucketDeleteWebsite(authInfo, testBucketDeleteWebsiteRequest, log,
+        err => {
+            if (err) {
+                process.stdout.write(`Unexpected err ${err}`);
+                return done(err);
+            }
+            return metadata.getBucket(bucketName, log, (err, bucket) => {
+                if (err) {
+                    process.stdout.write(`Err retrieving bucket MD ${err}`);
+                    return done(err);
+                }
+                assert.strictEqual(bucket.getWebsiteConfiguration(),
+                    null);
+                return done();
+            });
+        });
+    });
+});

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -11,6 +11,7 @@ import bucketPut from '../../../lib/api/bucketPut';
 import bucketPutACL from '../../../lib/api/bucketPutACL';
 import bucketPutWebsite from '../../../lib/api/bucketPutWebsite';
 import bucketDelete from '../../../lib/api/bucketDelete';
+import bucketDeleteWebsite from '../../../lib/api/bucketDeleteWebsite';
 import completeMultipartUpload from
     '../../../lib/api/completeMultipartUpload';
 import constants from '../../../constants';
@@ -323,6 +324,15 @@ describe('deleted flag bucket handling', () => {
             log, err => {
                 assert.deepStrictEqual(err, errors.AccessDenied);
                 done();
+            });
+    });
+
+    it('bucketDeleteWebsite request on bucket with delete flag should return ' +
+        'NoSuchBucket error and complete deletion', done => {
+        bucketDeleteWebsite(authInfo, baseTestRequest,
+            log, err => {
+                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                confirmDeleted(done);
             });
     });
 

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -5,12 +5,13 @@ import { errors } from 'arsenal';
 import BucketInfo from '../../../lib/metadata/BucketInfo';
 import bucketGet from '../../../lib/api/bucketGet';
 import bucketGetACL from '../../../lib/api/bucketGetACL';
+import bucketGetWebsite from '../../../lib/api/bucketGetWebsite';
 import bucketHead from '../../../lib/api/bucketHead';
 import bucketPut from '../../../lib/api/bucketPut';
 import bucketPutACL from '../../../lib/api/bucketPutACL';
 import bucketPutWebsite from '../../../lib/api/bucketPutWebsite';
 import bucketDelete from '../../../lib/api/bucketDelete';
-import bucketGetWebsite from '../../../lib/api/bucketGetWebsite';
+import bucketDeleteWebsite from '../../../lib/api/bucketDeleteWebsite';
 import completeMultipartUpload from
     '../../../lib/api/completeMultipartUpload';
 import constants from '../../../constants';
@@ -289,6 +290,14 @@ describe('transient bucket handling', () => {
         '<IndexDocument><Suffix>index.html</Suffix></IndexDocument>' +
         '</WebsiteConfiguration>';
         bucketPutWebsite(authInfo, bucketPutWebsiteRequest, log, err => {
+            assert.deepStrictEqual(err, errors.NoSuchBucket);
+            done();
+        });
+    });
+
+    it('bucketDeleteWebsite request on transient bucket should return ' +
+        'NoSuchBucket error', done => {
+        bucketDeleteWebsite(authInfo, baseTestRequest, log, err => {
             assert.deepStrictEqual(err, errors.NoSuchBucket);
             done();
         });


### PR DESCRIPTION
Deletes a bucket's website configuration stored in metadata.

Depends on
scality/Arsenal#202,
scality/utapi#69,
scality/Integration#365, &
scality/S3#469