### PR TITLE
COMPAT: Mirror AWS err for bucketAlreadyOwned

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,5 +36,6 @@
     },
     "healthChecks": {
         "allowFrom": ["127.0.0.1/8", "::1"]
-    }
+    },
+    "usEastBehavior": false
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -58,6 +58,11 @@ class Config {
             this.clusters = config.clusters;
         }
 
+        this.usEastBehavior = false;
+        if (config.usEastBehavior !== undefined) {
+            assert(typeof config.usEastBehavior === 'boolean');
+            this.usEastBehavior = config.usEastBehavior;
+        }
         this.sproxyd = { bootstrap: [] };
         if (config.sproxyd !== undefined) {
             if (config.sproxyd.bootstrap !== undefined) {

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -152,12 +152,14 @@ function bucketLevelServerSideEncryption(bucketName, headers, log, cb) {
  * @param {object} headers - request headers
  * @param {string} locationConstraint - locationConstraint provided in
  *                                      request body xml (if provided)
+ * @param {boolean} usEastBehavior - whether s3 is set up with a usEastBehavior
+ * config option
  * @param {function} log - Werelogs logger
  * @param {function} cb - callback to bucketPut
  * @return {undefined}
  */
 export function createBucket(authInfo, bucketName, headers,
-    locationConstraint, log, cb) {
+    locationConstraint, usEastBehavior, log, cb) {
     log.trace('Creating bucket');
     assert.strictEqual(typeof bucketName, 'string');
     const canonicalID = authInfo.getCanonicalID();
@@ -170,6 +172,8 @@ export function createBucket(authInfo, bucketName, headers,
 
     if (locationConstraint !== undefined) {
         bucket.setLocationConstraint(locationConstraint);
+    } else if (usEastBehavior) {
+        bucket.setLocationConstraint('us-east-1');
     }
     const parseAclParams = {
         headers,
@@ -234,7 +238,19 @@ export function createBucket(authInfo, bucketName, headers,
             return cleanUpBucket(newBucketMD, canonicalID, log, cb);
         }
         // If bucket exists in non-transient and non-deleted
-        // state and owned by requester:
+        // state and owned by requester then return BucketAlreadyOwnedByYou
+        // error unless old AWS behavior (us-east-1)
+        // For old behavior:
+        // 1) new locationConstraint should either be undefined or not us-east-1
+        // 2) the existing locationConstraint must be us-east-1 or undefined
+        // 3) the s3 being hit must be set up to have usEastBehavior
+        if ((!locationConstraint || locationConstraint === 'us-east-1') &&
+            (!existingBucketMD.getLocationConstraint() ||
+            existingBucketMD.getLocationConstraint() === 'us-east-1') &&
+            usEastBehavior) {
+            log.trace('returning 200 instead of 409 to mirror us-east-1');
+            return cb();
+        }
         return cb(errors.BucketAlreadyOwnedByYou);
     });
 }

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import { createBucket } from './apiUtils/bucket/bucketCreation';
+import config from '../Config';
 import aclUtils from '../utilities/aclUtils';
 
 /*
@@ -37,5 +38,5 @@ export default function bucketPut(authInfo, request, locationConstraint, log,
     const bucketName = request.bucketName;
 
     return createBucket(authInfo, bucketName, request.headers,
-                                 locationConstraint, log, callback);
+        locationConstraint, config.usEastBehavior, log, callback);
 }

--- a/lib/metadata/BucketInfo.js
+++ b/lib/metadata/BucketInfo.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
-const modelVersion = 3;
+const modelVersion = 4;
 
 export default class BucketInfo {
     /**
@@ -30,10 +30,12 @@ export default class BucketInfo {
     * @param {object} versioningConfiguration - versioning configuration
     * @param {string} versioningConfiguration.Status - versioning status
     * @param {object} versioningConfiguration.MfaDelete - versioning mfa delete
+    * @param {string} locationConstraint - locationConstraint for bucket
     */
     constructor(name, owner, ownerDisplayName, creationDate,
                 mdBucketModelVersion, acl, transient, deleted,
-                serverSideEncryption, versioningConfiguration) {
+                serverSideEncryption, versioningConfiguration,
+                locationConstraint) {
         assert.strictEqual(typeof name, 'string');
         assert.strictEqual(typeof owner, 'string');
         assert.strictEqual(typeof ownerDisplayName, 'string');
@@ -68,6 +70,9 @@ export default class BucketInfo {
                 MfaDelete === 'Enabled' ||
                 MfaDelete === 'Disabled');
         }
+        if (locationConstraint) {
+            assert.strictEqual(typeof locationConstraint, 'string');
+        }
         const aclInstance = acl || {
             Canned: 'private',
             FULL_CONTROL: [],
@@ -88,6 +93,7 @@ export default class BucketInfo {
         this._deleted = deleted || false;
         this._serverSideEncryption = serverSideEncryption || null;
         this._versioningConfiguration = versioningConfiguration || null;
+        this._locationConstraint = locationConstraint || null;
         return this;
     }
     /**
@@ -106,6 +112,7 @@ export default class BucketInfo {
             deleted: this._deleted,
             serverSideEncryption: this._serverSideEncryption,
             versioningConfiguration: this._versioningConfiguration,
+            locationConstraint: this._locationConstraint,
         };
         return JSON.stringify(bucketInfos);
     }
@@ -119,7 +126,7 @@ export default class BucketInfo {
         return new BucketInfo(obj.name, obj.owner, obj.ownerDisplayName,
             obj.creationDate, obj.mdBucketModelVersion, obj.acl,
             obj.transient, obj.deleted, obj.serverSideEncryption,
-            obj.versioningConfiguration);
+            obj.versioningConfiguration, obj.locationConstraint);
     }
 
     /**
@@ -140,7 +147,7 @@ export default class BucketInfo {
         return new BucketInfo(data._name, data._owner, data._ownerDisplayName,
             data._creationDate, data._mdBucketModelVersion, data._acl,
             data._transient, data._deleted, data._serverSideEncryption,
-            data._versioningConfiguration);
+            data._versioningConfiguration, data._locationConstraint);
     }
 
     /**
@@ -291,9 +298,18 @@ export default class BucketInfo {
     * @return {BucketInfo} - bucket info instance
     */
     setLocationConstraint(location) {
-        this.locationConstraint = location;
+        this._locationConstraint = location;
         return this;
     }
+
+    /**
+    * Get location constraint.
+    * @return {string} - bucket location constraint
+    */
+    getLocationConstraint() {
+        return this._locationConstraint;
+    }
+
     /**
      * Set Bucket model version
      *

--- a/lib/metadata/ModelVersion.md
+++ b/lib/metadata/ModelVersion.md
@@ -42,3 +42,15 @@ this._serverSideEncryption = serverSideEncryption || null;
 ### Usage
 
 Used to store the server bucket encryption info
+
+## Model version 4
+
+### Properties Added
+
+```javascript
+this._locationConstraint = LocationConstraint || null;
+```
+
+### Usage
+
+Used to store the location constraint of the bucket

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -188,6 +188,8 @@ describe('s3curl put delete buckets', () => {
                 });
         });
 
+        // note that if the config is changed to usEastBehavior, this call
+        // will return a 200 in conformance with AWS behavior
         it('should not be able to put a bucket with a name ' +
             'already being used', done => {
             provideRawOutput(

--- a/tests/unit/bucket/BucketInfo.js
+++ b/tests/unit/bucket/BucketInfo.js
@@ -27,6 +27,7 @@ const acl = { undefined, emptyAcl, filledAcl };
 const testDate = new Date().toJSON();
 
 const testVersioningConfiguration = { Status: 'Enabled' };
+const testLocationConstraint = 'us-west-1';
 // create a dummy bucket to test getters and setters
 
 Object.keys(acl).forEach(
@@ -39,7 +40,7 @@ Object.keys(acl).forEach(
                 algorithm: 'sha1',
                 masterKeyId: 'somekey',
                 mandatory: true,
-            }, testVersioningConfiguration);
+            }, testVersioningConfiguration, testLocationConstraint);
 
         describe('serialize/deSerialize on BucketInfo class', () => {
             let serialized;
@@ -58,6 +59,7 @@ Object.keys(acl).forEach(
                     serverSideEncryption: dummyBucket._serverSideEncryption,
                     versioningConfiguration:
                         dummyBucket._versioningConfiguration,
+                    locationConstraint: dummyBucket._locationConstraint,
                 };
                 assert.strictEqual(serialized, JSON.stringify(bucketInfos));
                 done();
@@ -120,6 +122,10 @@ Object.keys(acl).forEach(
                 assert.deepStrictEqual(dummyBucket.getVersioningConfiguration(),
                         testVersioningConfiguration);
             });
+            it('getLocationConstraint should return locationConstraint', () => {
+                assert.deepStrictEqual(dummyBucket.getLocationConstraint(),
+                testLocationConstraint);
+            });
         });
 
         describe('setters on BucketInfo class', () => {
@@ -174,7 +180,7 @@ Object.keys(acl).forEach(
                    const newLocation = 'newLocation';
                    dummyBucket.setLocationConstraint(newLocation);
                    assert.deepStrictEqual(
-                       dummyBucket.locationConstraint, newLocation);
+                       dummyBucket.getLocationConstraint(), newLocation);
                });
             it('setVersioningConfiguration should set configuration', () => {
                 const newVersioningConfiguration =

--- a/tests/unit/bucket/bucketCreation.js
+++ b/tests/unit/bucket/bucketCreation.js
@@ -1,0 +1,101 @@
+import assert from 'assert';
+
+import { errors } from 'arsenal';
+
+import { cleanup, DummyRequestLogger } from '../helpers';
+import { createBucket } from '../../../lib/api/apiUtils/bucket/bucketCreation';
+import { makeAuthInfo } from '../helpers';
+
+const bucketName = 'creationbucket';
+const log = new DummyRequestLogger();
+const normalBehaviorLocationConstraint = 'us-west-1';
+const specialBehaviorLocationConstraint = 'us-east-1';
+const usEastBehavior = true;
+const headers = {};
+const authInfo = makeAuthInfo('accessKey1');
+
+describe('bucket creation', () => {
+    it('should create a bucket', done => {
+        createBucket(authInfo, bucketName, headers,
+            normalBehaviorLocationConstraint, !usEastBehavior, log, err => {
+                assert.ifError(err);
+                done();
+            });
+    });
+
+    describe('when you already created the bucket in us-east', () => {
+        beforeEach(done => {
+            cleanup();
+            createBucket(authInfo, bucketName, headers,
+                specialBehaviorLocationConstraint, usEastBehavior, log, err => {
+                    assert.ifError(err);
+                    done();
+                });
+        });
+
+        it('should return 200 if try to recreate in us-east and ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            specialBehaviorLocationConstraint, usEastBehavior, log, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
+
+        it('should return 409 if try to recreate in non-us-east-1 even if ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            normalBehaviorLocationConstraint, usEastBehavior, log, err => {
+                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                done();
+            });
+        });
+
+        it('should return 409 if try to recreate in us-east-1 but without ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            specialBehaviorLocationConstraint, !usEastBehavior, log, err => {
+                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                done();
+            });
+        });
+    });
+
+    describe('when you already created the bucket in non-us-east-1', () => {
+        beforeEach(done => {
+            cleanup();
+            createBucket(authInfo, bucketName, headers,
+                normalBehaviorLocationConstraint, usEastBehavior, log, err => {
+                    assert.ifError(err);
+                    done();
+                });
+        });
+
+        it('should return 409 even if try to recreate in us-east and ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            specialBehaviorLocationConstraint, usEastBehavior, log, err => {
+                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                done();
+            });
+        });
+
+        it('should return 409 if try to recreate in non-us-east-1 even if ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            normalBehaviorLocationConstraint, usEastBehavior, log, err => {
+                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                done();
+            });
+        });
+
+        it('should return 409 if try to recreate in us-east-1 but without ' +
+            'usEastBehavior config set', done => {
+            createBucket(authInfo, bucketName, headers,
+            specialBehaviorLocationConstraint, !usEastBehavior, log, err => {
+                assert.strictEqual(err, errors.BucketAlreadyOwnedByYou);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
AWS does not return 409 for bucketAlreadyOwned
if bucket is in us-east-1 and request is to us-east-1.

This fixes https://github.com/scality/S3/issues/475