### PR TITLE
Handle bad headers

### DIFF
--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -115,6 +115,24 @@ function errorXMLResponse(errCode, response, log) {
 function okContentHeadersResponse(overrideHeaders, resHeaders,
     response, range, log) {
     const addHeaders = {};
+    if (process.env.ALLOW_INVALID_META_HEADERS) {
+        const headersArr = Object.keys(resHeaders);
+        const length = headersArr.length;
+        for (let i = 0; i < length; i++) {
+            const headerName = headersArr[i];
+            if (headerName.startsWith('x-amz-')) {
+                const translatedHeaderName = headerName.replace(/\//g, '|+2f');
+                // eslint-disable-next-line no-param-reassign
+                resHeaders[translatedHeaderName] =
+                    resHeaders[headerName];
+                if (translatedHeaderName !== headerName) {
+                    // eslint-disable-next-line no-param-reassign
+                    delete resHeaders[headerName];
+                }
+            }
+        }
+    }
+
     Object.assign(addHeaders, resHeaders);
 
     if (overrideHeaders['response-content-type']) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -232,6 +232,25 @@ utils.normalizeRequest = function normalizeRequest(request) {
         request.headers['content-length'];
     request.parsedContentLength =
         Number.parseInt(contentLength, 10);
+
+    if (process.env.ALLOW_INVALID_META_HEADERS) {
+        const headersArr = Object.keys(request.headers);
+        const length = headersArr.length;
+        if (headersArr.indexOf('x-invalid-metadata') > 1) {
+            for (let i = 0; i < length; i++) {
+                const headerName = headersArr[i];
+                if (headerName.startsWith('x-amz-')) {
+                    const translatedHeaderName =
+                        headerName.replace(/\|\+2f/g, '/');
+                    request.headers[translatedHeaderName] =
+                        request.headers[headerName];
+                    if (translatedHeaderName !== headerName) {
+                        delete request.headers[headerName];
+                    }
+                }
+            }
+        }
+    }
     return request;
 };
 


### PR DESCRIPTION
Translate x-amz headers on receipt and before sending out to handle translated characters.