### PR TITLE
FT: Add account level list metrics

### DIFF
--- a/bin/list_metrics.js
+++ b/bin/list_metrics.js
@@ -2,4 +2,4 @@
 'use strict'; // eslint-disable-line strict
 
 require('babel-core/register');
-require('../lib/utapi/utilities.js').listMetrics('buckets');
+require('../lib/utapi/utilities.js').listMetrics();

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -8,19 +8,24 @@ import _config from '../Config';
 // setup utapi client
 const utapi = new UtapiClient(_config.utapi);
 
-function _listBucketMetrics(host,
-                            port,
-                            buckets,
-                            timeRange,
-                            accessKey,
-                            secretKey,
-                            verbose,
-                            ssl) {
+function _listMetrics(host,
+                      port,
+                      metric,
+                      metricType,
+                      timeRange,
+                      accessKey,
+                      secretKey,
+                      verbose,
+                      ssl) {
+    const metricRoutes = {
+        buckets: '/buckets?Action=ListMetrics',
+        accounts: '/accounts?Action=ListMetrics',
+    };
     const options = {
         host,
         port,
         method: 'POST',
-        path: '/buckets?Action=ListMetrics',
+        path: metricRoutes[metric],
         headers: {
             'content-type': 'application/json',
             'cache-control': 'no-cache',
@@ -41,8 +46,8 @@ function _listBucketMetrics(host,
         response.on('end', () => {
             const responseBody = JSON.parse(body.join(''));
             if (response.statusCode >= 200 && response.statusCode < 300) {
-                // eslint-disable-next-line no-console
-                console.log(responseBody);
+                process.stdout.write(JSON.stringify(responseBody, null, 2));
+                process.stdout.write('\n');
                 process.exit(0);
             } else {
                 logger.error('request failed with HTTP Status ', {
@@ -57,23 +62,41 @@ function _listBucketMetrics(host,
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }
-    request.write(JSON.stringify({ buckets, timeRange }));
+    const requestObj = { timeRange };
+    requestObj[metric] = metricType;
+    request.write(JSON.stringify(requestObj));
     request.end();
 }
 
 /**
  * This function is used as a binary to send a request to utapi server
- * to list bucket metrics
- *
+ * to list metrics for buckets or accounts
+ * @param {string} [metricType] - (optional) Defined as 'buckets' if old style
+ * bucket metrics listing
  * @return {undefined}
  */
-export function listBucketMetrics() {
+export function listMetrics(metricType) {
     commander
         .version('0.0.1')
         .option('-a, --access-key <accessKey>', 'Access key id')
-        .option('-k, --secret-key <secretKey>', 'Secret access key')
-        .option('-b, --buckets <buckets>', 'Name of bucket(s)' +
-        'with a comma separator if more than one')
+        .option('-k, --secret-key <secretKey>', 'Secret access key');
+    // We want to continue support of previous bucket listing. Hence the ability
+    // to specify `metricType`. Remove `if` statement and
+    // bin/list_bucket_metrics.js when prior method of listing bucket metrics is
+    // no longer supported.
+    if (metricType === 'buckets') {
+        commander
+            .option('-b, --buckets <buckets>', 'Name of bucket(s) with ' +
+            'a comma separator if more than one');
+    } else {
+        commander
+            .option('-m, --metric <metric>', 'Metric type')
+            .option('--buckets <buckets>', 'Name of bucket(s) with a comma ' +
+                'separator if more than one')
+            .option('--accounts <accounts>', 'Name of account(s) with a ' +
+                'comma separator if more than one');
+    }
+    commander
         .option('-s, --start <start>', 'Start of time range')
         .option('-e --end <end>', 'End of time range')
         .option('-h, --host <host>', 'Host of the server')
@@ -82,11 +105,26 @@ export function listBucketMetrics() {
         .option('-v, --verbose')
         .parse(process.argv);
 
-    const { host, port, accessKey, secretKey, start, end,
-        buckets, verbose, ssl } =
+    const { host, port, accessKey, secretKey, start, end, verbose,
+        ssl } =
         commander;
-    const requiredOptions = { host, port, accessKey, secretKey, buckets,
-        start };
+    const requiredOptions = { host, port, accessKey, secretKey };
+    // If not old style bucket metrics, we require usage of the metric option
+    if (metricType !== 'buckets') {
+        requiredOptions.metric = commander.metric;
+        // Only allow 'buckets' or 'accounts' as the metric
+        if (commander.metric !== 'buckets' && commander.metric !== 'accounts') {
+            logger.error('metric must be buckets or accounts');
+            commander.outputHelp();
+            process.exit(1);
+            return;
+        }
+    }
+    // If old style bucket metrics, `metricType` will be 'buckets'. Otherwise,
+    // `commander.metric` should be defined.
+    const metric = metricType === 'buckets' ? 'buckets' : commander.metric;
+    requiredOptions[metric] = commander[metric];
+
     Object.keys(requiredOptions).forEach(option => {
         if (!requiredOptions[option]) {
             logger.error(`missing required option: ${option}`);
@@ -114,10 +152,11 @@ export function listBucketMetrics() {
         }
         timeRange.push(numEnd);
     }
-
-    const bucketArr = buckets.split(',');
-    _listBucketMetrics(host, port, bucketArr, timeRange,
-        accessKey, secretKey, verbose, ssl);
+    // The string `commander[metric]` is a comma-separated list of buckets or
+    // accounts given by the user.
+    const resources = commander[metric].split(',');
+    _listMetrics(host, port, metric, resources, timeRange, accessKey, secretKey,
+        verbose, ssl);
 }
 
 /**


### PR DESCRIPTION
Refactors listing metrics to allow for account-level Utapi listing. We are accommodating the refactored methods to maintain support for the current way of listing bucket metrics. Hence we keep bin/list_bucket_metrics.js.

Depends on https://github.com/scality/utapi/pull/75.