### PR TITLE
CLEANUP: Update BucketInfo Model Version to 5

### DIFF
--- a/lib/metadata/BucketInfo.js
+++ b/lib/metadata/BucketInfo.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { WebsiteConfiguration } from './WebsiteConfiguration';
 
 // WHEN UPDATING THIS NUMBER, UPDATE MODELVERSION.MD CHANGELOG
-const modelVersion = 4;
+const modelVersion = 5;
 
 export default class BucketInfo {
     /**


### PR DESCRIPTION
This was omitted in forward port from 6.3, despite updating ModelVersion.md document to describe Model Version 5 for the `websiteConfiguration` property.