### PR TITLE
FT: Add OPTIONS route for CORS response

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -16,6 +16,7 @@ import bucketPutACL from './bucketPutACL';
 import bucketPutCors from './bucketPutCors';
 import bucketPutVersioning from './bucketPutVersioning';
 import bucketPutWebsite from './bucketPutWebsite';
+import corsPreflight from './corsPreflight';
 import completeMultipartUpload from './completeMultipartUpload';
 import initiateMultipartUpload from './initiateMultipartUpload';
 import listMultipartUploads from './listMultipartUploads';
@@ -42,8 +43,9 @@ auth.setHandler(vault);
 
 const api = {
     callApiMethod(apiMethod, request, log, callback, locationConstraint) {
-        // no need to check auth on website requests
-        if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead') {
+        // no need to check auth on website or cors preflight requests
+        if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
+        apiMethod === 'corsPreflight') {
             return this[apiMethod](request, log, callback);
         }
         let sourceBucket;
@@ -110,6 +112,7 @@ const api = {
     bucketPutCors,
     bucketPutVersioning,
     bucketPutWebsite,
+    corsPreflight,
     completeMultipartUpload,
     initiateMultipartUpload,
     listMultipartUploads,

--- a/lib/api/apiUtils/object/corsResponse.js
+++ b/lib/api/apiUtils/object/corsResponse.js
@@ -1,0 +1,127 @@
+/** _matchesValue - compare two values to determine if they match
+* @param {string} allowedValue - an allowed value in a CORS rule;
+*    may contain wildcards
+* @param {string} value - value from CORS request
+* @return {boolean} - true/false
+*/
+function _matchesValue(allowedValue, value) {
+    const wildcardIndex = allowedValue.indexOf('*');
+    // If no wildcards, simply return whether strings are equal
+    if (wildcardIndex === -1) {
+        return allowedValue === value;
+    }
+    // Otherwise make sure substrings match expected substrings before
+    // and after the wildcard
+    const beginValue = allowedValue.substring(0, wildcardIndex);
+    const endValue = allowedValue.substring(wildcardIndex + 1);
+    return (value.startsWith(beginValue) && value.endsWith(endValue));
+}
+
+/** _matchesOneOf - check if header matches any AllowedHeaders of a rule
+* @param {string[]} allowedHeaders - headers allowed in CORS rule
+* @param {string} header - header from CORS request
+* @return {boolean} - true/false
+*/
+function _matchesOneOf(allowedHeaders, header) {
+    return allowedHeaders.some(allowedHeader =>
+        // AllowedHeaders may have been stored with uppercase letters
+        // during putBucketCors; ignore case when searching for match
+        _matchesValue(allowedHeader.toLowerCase(), header));
+}
+
+/** _headersMatchRule - check if headers match AllowedHeaders of rule
+* @param {string[]} headers - the value of the 'Access-Control-Allow-Headers'
+*   in an OPTIONS request and actual request header keys in any other request
+* @param {string[]} allowedHeaders - AllowedHeaders of a CORS rule
+* @return {boolean} - true/false
+*/
+function _headersMatchRule(headers, allowedHeaders) {
+    if (!allowedHeaders) {
+        return false;
+    }
+    if (!headers.every(header => _matchesOneOf(allowedHeaders, header))) {
+        return false;
+    }
+    return true;
+}
+
+/** _findCorsRule - Return first matching rule in cors rules that permits
+*   CORS request
+* @param {object[]} rules - array of rules
+* @param {string} [rules.id] - optional id to identify rule
+* @param {string[]} rules[].allowedMethods - methods allowed for CORS
+* @param {string[]} rules[].allowedOrigins - origins allowed for CORS
+* @param {string[]} [rules[].allowedHeaders] - headers allowed in an
+*   OPTIONS request via the Access-Control-Request-Headers header
+* @param {number} [rules[].maxAgeSeconds] - seconds browsers should cache
+*   OPTIONS response
+* @param {string[]} [rules[].exposeHeaders] - headers to expose to external
+*   applications
+* @param {string} origin - origin of CORS request
+* @param {string} method - 'Access-Control-Request-Method' header value in
+*   an OPTIONS request and the actual method in any other request
+* @param {string[]} [headers] - the value of the 'Access-Control-Allow-Headers'
+*   in an OPTIONS request and actual request header keys in any other request
+* @return {(null|object)} - matching rule if found; null if no match
+*/
+export function findCorsRule(rules, origin, method, headers) {
+    return rules.find(rule => {
+        if (rule.allowedMethods.indexOf(method) === -1) {
+            return false;
+        } else if (!rule.allowedOrigins.some(allowedOrigin =>
+            _matchesValue(allowedOrigin, origin))) {
+            return false;
+        } else if (headers &&
+            !_headersMatchRule(headers, rule.allowedHeaders)) {
+            return false;
+        }
+        return true;
+    });
+}
+
+/** _gatherResHeaders - Collect headers to return in response
+* @param {object} rule - array of rules
+* @param {string} [rule.id] - optional id to identify rule
+* @param {string[]} rule[].allowedMethods - methods allowed for CORS
+* @param {string[]} rule[].allowedOrigins - origins allowed for CORS
+* @param {string[]} [rule[].allowedHeaders] - headers allowed in an
+*   OPTIONS request via the Access-Control-Request-Headers header
+* @param {number} [rule[].maxAgeSeconds] - seconds browsers should cache
+*   OPTIONS response
+* @param {string[]} [rule[].exposeHeaders] - headers to expose to external
+*   applications
+* @param {string} origin - origin of CORS request
+* @param {string} method - 'Access-Control-Request-Method' header value in
+*   an OPTIONS request and the actual method in any other request
+* @param {string[]} [headers] - the value of the 'Access-Control-Allow-Headers'
+*   in an OPTIONS request and actual request header keys in any other request
+* @return {object} resHeaders - headers to include in response
+*/
+export function gatherCorsResHeaders(rule, origin, method, headers) {
+    const resHeaders = {
+        'access-control-max-age': rule.maxAgeSeconds,
+        'access-control-allow-methods': rule.allowedMethods.join(', '),
+        'content-length': '0',
+        'date': new Date().toUTCString(),
+        'vary':
+        'Origin, Access-Control-Request-Headers, Access-Control-Request-Method',
+    };
+    // send back '*' if any origin allowed; otherwise send back
+    // request Origin value
+    if (rule.allowedOrigins.indexOf('*') > -1) {
+        resHeaders['access-control-allow-origin'] = '*';
+    } else {
+        resHeaders['access-control-allow-origin'] = origin;
+        // can only set allow credentials to true if not returning wildcard
+        // for 'access-control-allow-origin'
+        resHeaders['access-control-allow-credentials'] = true;
+    }
+    if (headers) {
+        resHeaders['access-control-allow-headers'] = headers.join(', ');
+    }
+    if (rule.exposeHeaders) {
+        resHeaders['access-control-expose-headers'] =
+            rule.exposeHeaders.join(', ');
+    }
+    return resHeaders;
+}

--- a/lib/api/corsPreflight.js
+++ b/lib/api/corsPreflight.js
@@ -1,0 +1,82 @@
+import { errors } from 'arsenal';
+
+import metadata from '../metadata/wrapper';
+import bucketShield from './apiUtils/bucket/bucketShield';
+import { findCorsRule,
+gatherCorsResHeaders } from './apiUtils/object/corsResponse';
+// import { pushMetric } from '../utapi/utilities';
+
+const requestType = 'objectGet';
+
+const customizedErrs = {
+    corsNotEnabled: 'CORSResponse: CORS is not enabled for this bucket.',
+    notAllowed: 'CORSResponse: This CORS request is not allowed. ' +
+    'This is usually because the evalution of Origin, request method / ' +
+    'Access-Control-Request-Method or Access-Control-Request-Headers ' +
+    'are not whitelisted by the resource\'s CORS spec.',
+};
+
+/** corsPreflight - handle preflight CORS requests
+* @param  {object} request - http request object
+* @param  {function} log - Werelogs request logger
+* @param  {function} callback - callback to respond to http request
+*  with either error code or 200 response
+* @return {undefined}
+*/
+export default function corsPreflight(request, log, callback) {
+    log.debug('processing request', { method: 'corsPreflight' });
+
+    const bucketName = request.bucketName;
+    const corsOrigin = request.headers.origin;
+    const corsMethod = request.headers['access-control-request-method'];
+    const corsHeaders = request.headers['access-control-request-headers'] ?
+        request.headers['access-control-request-headers'].replace(/ /g, '')
+            .split(',').reduce((resultArr, value) => {
+                // remove empty values and convert values to lowercase
+                if (value !== '') {
+                    resultArr.push(value.toLowerCase());
+                }
+                return resultArr;
+            }, []) : null;
+
+    return metadata.getBucket(bucketName, log, (err, bucket) => {
+        if (err) {
+            log.debug('metadata getbucket failed', { error: err });
+            return callback(err);
+        }
+        if (bucketShield(bucket, requestType)) {
+            return callback(errors.NoSuchBucket);
+        }
+        log.trace('found bucket in metadata');
+
+        const corsRules = bucket.getCors();
+        if (!corsRules) {
+            const err = errors.AccessForbidden
+                .customizeDescription(customizedErrs.corsNotEnabled);
+            log.trace('no existing cors configuration', {
+                error: err,
+                method: 'corsPreflight',
+            });
+            return callback(err);
+        }
+
+        log.trace('finding cors rule');
+        const corsRule = findCorsRule(corsRules, corsOrigin, corsMethod,
+            corsHeaders);
+
+        if (!corsRule) {
+            const err = errors.AccessForbidden
+                .customizeDescription(customizedErrs.notAllowed);
+            log.trace('no matching cors rule', {
+                error: err,
+                method: 'corsPreflight',
+            });
+            return callback(err);
+        }
+
+        const resHeaders = gatherCorsResHeaders(corsRule, corsOrigin,
+            corsMethod, corsHeaders);
+        // TODO: pushMetric('corsPreflight', log, { bucket: bucketName });
+        return callback(null, resHeaders);
+    });
+}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -4,6 +4,7 @@ import routePUT from './routes/routePUT';
 import routeDELETE from './routes/routeDELETE';
 import routeHEAD from './routes/routeHEAD';
 import routePOST from './routes/routePOST';
+import routeOPTIONS from './routes/routeOPTIONS';
 import routesUtils from './routes/routesUtils';
 import routeWebsite from './routes/routeWebsite';
 import utils from './utils';
@@ -18,6 +19,7 @@ const routeMap = {
     POST: routePOST,
     DELETE: routeDELETE,
     HEAD: routeHEAD,
+    OPTIONS: routeOPTIONS,
 };
 
 // redis client
@@ -83,8 +85,10 @@ export default function routes(req, res, logger) {
     if (!req.bucketName &&
       !(req.method.toUpperCase() === 'GET' && !req.objectKey)) {
         log.warn('empty bucket name', { method: 'routes' });
-        return routesUtils.responseXMLBody(errors.MethodNotAllowed,
-            undefined, res, log);
+        const err = (req.method.toUpperCase() !== 'OPTIONS') ?
+        errors.MethodNotAllowed : errors.AccessForbidden
+                .customizeDescription('CORSResponse: Bucket not found');
+        return routesUtils.responseXMLBody(err, undefined, res, log);
     }
 
     if (req.bucketName !== undefined &&

--- a/lib/routes/routeOPTIONS.js
+++ b/lib/routes/routeOPTIONS.js
@@ -1,0 +1,32 @@
+import { errors } from 'arsenal';
+
+import api from '../api/api';
+import routesUtils from './routesUtils';
+import statsReport500 from '../utilities/statsReport500';
+
+export default function routeOPTIONS(request, response, log, statsClient) {
+    log.debug('routing request', { method: 'routeOPTION' });
+
+    const corsMethod = request.headers['access-control-request-method'] || null;
+
+    if (!request.headers.origin) {
+        const msg = 'Insufficient information. Origin request header needed.';
+        const err = errors.BadRequest.customizeDescription(msg);
+        log.debug('missing origin', { method: 'routeOPTIONS', error: err });
+        return routesUtils.responseXMLBody(err, undefined, response, log);
+    }
+    if (['GET', 'PUT', 'HEAD', 'POST', 'DELETE'].indexOf(corsMethod) < 0) {
+        const msg = `Invalid Access-Control-Request-Method: ${corsMethod}`;
+        const err = errors.BadRequest.customizeDescription(msg);
+        log.debug('invalid Access-Control-Request-Method',
+            { method: 'routeOPTIONS', error: err });
+        return routesUtils.responseXMLBody(err, undefined, response, log);
+    }
+
+    return api.callApiMethod('corsPreflight', request, log,
+    (err, resHeaders) => {
+        statsReport500(err, statsClient);
+        return routesUtils.responseNoBody(err, resHeaders, response, 200,
+            log);
+    });
+}

--- a/tests/functional/aws-node-sdk/lib/utility/cors-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/cors-util.js
@@ -1,0 +1,74 @@
+import assert from 'assert';
+import http from 'http';
+import https from 'https';
+
+import conf from '../../../../../lib/Config';
+
+const transport = conf.https ? https : http;
+const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
+const hostname = process.env.AWS_ON_AIR ? 's3.amazonaws.com' :
+    ipAddress;
+const port = process.env.AWS_ON_AIR ? 80 : 8000;
+
+
+const statusCode = {
+    200: 200,
+    NoSuchBucket: 404,
+    BadRequest: 400,
+    AccessForbidden: 403,
+};
+
+export default function methodRequest(params, callback) {
+    const { method, bucket, objectKey, headers, code, headersResponse } =
+        params;
+    const options = {
+        hostname,
+        port,
+        method,
+        headers,
+        path: objectKey ? `/${bucket}/${objectKey}` : `/${bucket}`,
+        rejectUnauthorized: false,
+    };
+    const req = transport.request(options, res => {
+        const body = [];
+        res.on('data', chunk => {
+            body.push(chunk);
+        });
+        res.on('error', err => {
+            process.stdout.write('err receiving response');
+            return callback(err);
+        });
+        res.on('end', () => {
+            const total = body.join('');
+            if (code) {
+                const message = code === 200 ? '' : `<Code>${code}</Code>`;
+                assert(total.indexOf(message) > -1, `Expected ${message}`);
+                assert.deepEqual(res.statusCode, statusCode[code],
+                `status code expected: ${statusCode[code]}`);
+            }
+            if (headersResponse) {
+                Object.keys(headersResponse).forEach(key => {
+                    assert.deepEqual(res.headers[key], headersResponse[key],
+                      `error header: ${key}`);
+                });
+            } else {
+            // if no headersResponse provided, should not have these headers
+            // in the request
+                ['access-control-allow-origin',
+                'access-control-allow-methods',
+                'access-control-allow-credentials',
+                'vary'].forEach(key => {
+                    assert.strictEqual(res.headers[key], undefined,
+                        `Error: ${key} should not have value`);
+                });
+            }
+            return callback();
+        });
+    });
+
+    req.on('error', err => {
+        process.stdout.write('err sending request');
+        return callback(err);
+    });
+    req.end();
+}

--- a/tests/functional/aws-node-sdk/test/object/corsPreflight.js
+++ b/tests/functional/aws-node-sdk/test/object/corsPreflight.js
@@ -1,0 +1,855 @@
+import { S3 } from 'aws-sdk';
+
+import getConfig from '../support/config';
+import methodRequest from '../../lib/utility/cors-util';
+
+const config = getConfig('default', { signatureVersion: 'v4' });
+const s3 = new S3(config);
+
+const bucket = 'bucketcorstester';
+
+const methods = ['PUT', 'POST', 'DELETE', 'GET'];
+const originsWithWildcards = [
+    '*.allowedorigin.com',
+    'http://*.allowedorigin.com',
+    'http://www.allowedorigin.*',
+];
+const allowedOrigin = 'http://www.allowedwebsite.com';
+const vary = 'Origin, Access-Control-Request-Headers, ' +
+    'Access-Control-Request-Method';
+
+// AWS seems to take a bit long so sometimes by the time we send the request
+// the bucket has not yet been created or the bucket has been deleted.
+function _waitForAWS(callback, err) {
+    if (process.env.AWS_ON_AIR) {
+        setTimeout(() => callback(err), 5000);
+    } else {
+        callback(err);
+    }
+}
+
+describe('Preflight CORS request on non-existing bucket', () => {
+    it('should respond no such bucket if bucket does not exist', done => {
+        const headers = {
+            Origin: allowedOrigin,
+        };
+        methodRequest({ method: 'GET', bucket, headers, code: 'NoSuchBucket',
+        headersResponse: null }, done);
+    });
+    it('should return BadRequest for OPTIONS request without origin', done => {
+        const headers = {};
+        methodRequest({ method: 'OPTIONS', bucket, headers, code: 'BadRequest',
+        headersResponse: null }, done);
+    });
+    it('should return BadRequest for OPTIONS request without ' +
+    'Access-Control-Request-Method', done => {
+        const headers = {
+            Origin: allowedOrigin,
+        };
+        methodRequest({ method: 'OPTIONS', bucket, headers, code: 'BadRequest',
+        headersResponse: null }, done);
+    });
+});
+
+describe('Preflight CORS request with existing bucket', () => {
+    beforeEach(done => {
+        s3.createBucket({ Bucket: bucket, ACL: 'public-read' }, err => {
+            _waitForAWS(done, err);
+        });
+    });
+    afterEach(done => {
+        s3.deleteBucket({ Bucket: bucket }, err => {
+            _waitForAWS(done, err);
+        });
+    });
+
+    it('should allow GET on bucket without cors configuration even if ' +
+    'Origin header sent', done => {
+        const headers = {
+            Origin: allowedOrigin,
+        };
+        methodRequest({ method: 'GET', bucket, headers, code: 200,
+        headersResponse: null }, done);
+    });
+    it('should allow HEAD on bucket without cors configuration even if ' +
+    'Origin header sent', done => {
+        const headers = {
+            Origin: allowedOrigin,
+        };
+        methodRequest({ method: 'HEAD', bucket, headers, code: 200,
+        headersResponse: null }, done);
+    });
+    it('should respond AccessForbidden for OPTIONS request on bucket without ' +
+    'CORSConfiguration', done => {
+        const headers = {
+            'Origin': allowedOrigin,
+            'Access-Control-Request-Method': 'GET',
+        };
+        methodRequest({ method: 'OPTIONS', bucket, headers,
+        code: 'AccessForbidden', headersResponse: null }, done);
+    });
+
+    describe('allow PUT, POST, DELETE, GET methods and allow only ' +
+    'one origin', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'PUT', 'POST', 'DELETE', 'GET',
+                        ],
+                        AllowedOrigins: [
+                            allowedOrigin,
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        methods.forEach(method => {
+            it('should respond with 200 and access control headers to ' +
+            'OPTIONS request from allowed origin and allowed method ' +
+            `"${method}"`, done => {
+                const headers = {
+                    'Origin': allowedOrigin,
+                    'Access-Control-Request-Method': method,
+                };
+                const headersResponse = {
+                    'access-control-allow-origin': allowedOrigin,
+                    'access-control-allow-methods': 'PUT, POST, DELETE, GET',
+                    'access-control-allow-credentials': 'true',
+                    vary,
+                };
+                methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+                headersResponse }, done);
+            });
+        });
+        it('should respond AccessForbidden to OPTIONS request from ' +
+        'not allowed origin', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'Origin, Accept, ' +
+                'Content-Type',
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers,
+            code: 'AccessForbidden', headersResponse: null }, done);
+        });
+        it('should respond AccessForbidden to OPTIONS request with ' +
+        'not allowed Access-Control-Request-Headers', done => {
+            const headers = {
+                'Origin': 'http://www.forbiddenwebsite.com',
+                'Access-Control-Request-Method': 'GET',
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers,
+            code: 'AccessForbidden', headersResponse: null }, done);
+        });
+    });
+
+    describe('CORS allows method GET and allows one origin', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            allowedOrigin,
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('should respond with 200 and access control headers to OPTIONS ' +
+        'request from allowed origin and method "GET"', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': allowedOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should respond AccessForbidden to OPTIONS request with allowed ' +
+        'method but not from allowed origin', done => {
+            const headers = {
+                'Origin': 'http://www.forbiddenwebsite.com',
+                'Access-Control-Request-Method': 'GET',
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers,
+            code: 'AccessForbidden', headersResponse: null }, done);
+        });
+        it('should respond AccessForbidden to OPTIONS request from allowed ' +
+        'origin and method but with not allowed Access-Control-Request-Headers',
+        done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'Origin, Accept, ' +
+                'Content-Type',
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers,
+            code: 'AccessForbidden', headersResponse: null }, done);
+        });
+        ['PUT', 'POST', 'DELETE'].forEach(method => {
+            it('should respond AccessForbidden to OPTIONS request from ' +
+            `allowed origin but not allowed method "${method}"`, done => {
+                const headers = {
+                    'Origin': allowedOrigin,
+                    'Access-Control-Request-Method': method,
+                };
+                methodRequest({ method: 'OPTIONS', bucket, headers,
+                code: 'AccessForbidden', headersResponse: null }, done);
+            });
+        });
+    });
+
+    methods.forEach(allowedMethod => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [allowedMethod],
+                        AllowedOrigins: ['*'],
+                    },
+                ],
+            },
+        };
+        describe(`CORS allows method "${allowedMethod}" and allows all origins`,
+        () => {
+            beforeEach(done => {
+                s3.putBucketCors(corsParams, done);
+            });
+
+            afterEach(done => {
+                s3.deleteBucketCors({ Bucket: bucket }, done);
+            });
+
+            it('should respond with 200 and access control headers to ' +
+            `OPTIONS request from allowed origin and method "${allowedMethod}"`,
+            done => {
+                const headers = {
+                    'Origin': allowedOrigin,
+                    'Access-Control-Request-Method': allowedMethod,
+                };
+                const headersResponse = {
+                    'access-control-allow-origin': '*',
+                    'access-control-allow-methods': allowedMethod,
+                    vary,
+                };
+                methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+                headersResponse }, done);
+            });
+            it('should respond AccessForbidden to OPTIONS request from ' +
+            'allowed origin and method but with not allowed Access-Control-' +
+            'Request-Headers', done => {
+                const headers = {
+                    'Origin': allowedOrigin,
+                    'Access-Control-Request-Method': allowedMethod,
+                    'Access-Control-Request-Headers': 'Origin, Accept, ' +
+                    'Content-Type',
+                };
+                methodRequest({ method: 'OPTIONS', bucket, headers,
+                code: 'AccessForbidden', headersResponse: null }, done);
+            });
+            methods.filter(method => method !== allowedMethod)
+            .forEach(method => {
+                it('should respond AccessForbidden to OPTIONS request from ' +
+                `allowed origin but not allowed method "${method}"`, done => {
+                    const headers = {
+                        'Origin': allowedOrigin,
+                        'Access-Control-Request-Method': method,
+                    };
+                    methodRequest({ method: 'OPTIONS', bucket, headers,
+                    code: 'AccessForbidden', headersResponse: null }, done);
+                });
+            });
+        });
+    });
+
+    originsWithWildcards.forEach(origin => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: ['GET'],
+                        AllowedOrigins: [origin],
+                    },
+                ],
+            },
+        };
+        const originWithoutWildcard = origin.replace('*', '');
+        const originReplaceWildcard = origin.replace('*', 'test');
+
+        describe(`CORS allows method GET and origin "${origin}"`, () => {
+            beforeEach(done => {
+                s3.putBucketCors(corsParams, done);
+            });
+
+            afterEach(done => {
+                s3.deleteBucketCors({ Bucket: bucket }, done);
+            });
+
+            [originWithoutWildcard, originReplaceWildcard]
+            .forEach(acceptableOrigin => {
+                it('should return 200 and CORS header to OPTIONS request ' +
+                `from allowed method and origin "${acceptableOrigin}"`,
+                done => {
+                    const headers = {
+                        'Origin': acceptableOrigin,
+                        'Access-Control-Request-Method': 'GET',
+                    };
+                    const headersResponse = {
+                        'access-control-allow-origin': acceptableOrigin,
+                        'access-control-allow-methods': 'GET',
+                        'access-control-allow-credentials': 'true',
+                        vary,
+                    };
+                    methodRequest({ method: 'OPTIONS', bucket, headers,
+                    code: 200, headersResponse }, done);
+                });
+            });
+            if (!origin.endsWith('*')) {
+                it('should respond AccessForbidden to OPTIONS request from ' +
+                `allowed method and origin "${originWithoutWildcard}test"`,
+                done => {
+                    const headers = {
+                        'Origin': `${originWithoutWildcard}test`,
+                        'Access-Control-Request-Method': 'GET',
+                    };
+                    methodRequest({ method: 'OPTIONS', bucket, headers,
+                    code: 'AccessForbidden', headersResponse: null }, done);
+                });
+            }
+            if (!origin.startsWith('*')) {
+                it('should respond AccessForbidden to OPTIONS request from ' +
+                `allowed method and origin "test${originWithoutWildcard}"`,
+                done => {
+                    const headers = {
+                        'Origin': `test${originWithoutWildcard}`,
+                        'Access-Control-Request-Method': 'GET',
+                    };
+                    methodRequest({ method: 'OPTIONS', bucket, headers,
+                    code: 'AccessForbidden', headersResponse: null }, done);
+                });
+            }
+        });
+    });
+
+    describe('CORS response access-control-allow-origin header value',
+    () => {
+        const anotherOrigin = 'http://www.anotherorigin.com';
+        const originContainingWildcard = 'http://www.originwith*.com';
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            allowedOrigin,
+                            originContainingWildcard,
+                        ],
+                    },
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('if OPTIONS request matches rule with multiple origins, response ' +
+        'access-control-request-origin header value should be request Origin ' +
+        '(not list of AllowedOrigins)', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': allowedOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('if OPTIONS request matches rule with origin containing wildcard, ' +
+        'response access-control-request-origin header value should be ' +
+        'request Origin (not value containing wildcard)', done => {
+            const requestOrigin = originContainingWildcard.replace('*', 'test');
+            const headers = {
+                'Origin': requestOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': requestOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('if OPTIONS request matches rule that allows all origins, ' +
+        'e.g. "*", response access-control-request-origin header should ' +
+        'return "*"', done => {
+            const headers = {
+                'Origin': anotherOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+    });
+
+    describe('CORS allows method GET, allows all origins and allows ' +
+    'header Content-Type', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                        AllowedHeaders: [
+                            'content-type',
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('should respond with 200 and access control headers to OPTIONS ' +
+        'request from allowed origin and method, even without request ' +
+        'Access-Control-Request-Headers header value', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should respond with 200 and access control headers to OPTIONS ' +
+        'request from allowed origin and method with Access-Control-' +
+        'Request-Headers \'Content-Type\'', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'content-type',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-headers': 'content-type',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should respond AccessForbidden to OPTIONS request from allowed ' +
+        'origin and method but not allowed Access-Control-Request-Headers ' +
+        'in addition to Content-Type',
+        done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': 'Origin, Accept, ' +
+                'content-type',
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers,
+            code: 'AccessForbidden', headersResponse: null }, done);
+        });
+    });
+
+    describe('CORS response Access-Control-Allow-Headers header value',
+    () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                        AllowedHeaders: [
+                            'Content-Type', 'amz-*', 'Expires',
+                        ],
+                    },
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                        AllowedHeaders: [
+                            '*',
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('should return request access-control-request-headers value, ' +
+        'not list of AllowedHeaders from rule or corresponding AllowedHeader ' +
+        'value containing wildcard',
+        done => {
+            const requestHeaderValue = 'amz-meta-header-test, content-type';
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': requestHeaderValue,
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-headers': requestHeaderValue,
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should return lowercase version of request Access-Control-' +
+        'Request-Method header value if it contains any upper-case values',
+        done => {
+            const requestHeaderValue = 'Content-Type';
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': requestHeaderValue,
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-headers':
+                requestHeaderValue.toLowerCase(),
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should remove empty comma-separated values derived from request ' +
+        'Access-Control-Request-Method header and separate values with ' +
+        'spaces when responding with Access-Control-Allow-Headers header',
+        done => {
+            const requestHeaderValue = 'content-type,,expires';
+            const expectedValue = 'content-type, expires';
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': requestHeaderValue,
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-headers': expectedValue,
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+        it('should return request Access-Control-Request-Headers value ' +
+        'even if rule allows all headers (e.g. "*"), unlike access-control-' +
+        'allow-origin value', done => {
+            const requestHeaderValue = 'puppies';
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Access-Control-Request-Headers': requestHeaderValue,
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-headers': requestHeaderValue,
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+    });
+
+    describe('CORS and OPTIONS request with object keys', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            allowedOrigin,
+                        ],
+                    },
+                ],
+            },
+        };
+        const objectKey = 'testobject';
+        beforeEach(done => {
+            s3.putObject({ Key: objectKey, Bucket: bucket }, err => {
+                if (err) {
+                    process.stdout.write(`err in beforeEach ${err}`);
+                    done(err);
+                }
+                s3.putBucketCors(corsParams, done);
+            });
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, err => {
+                if (err) {
+                    process.stdout.write(`err in afterEach ${err}`);
+                    done(err);
+                }
+                s3.deleteObject({ Key: objectKey, Bucket: bucket }, done);
+            });
+        });
+
+        it('should respond with 200 and access control headers to OPTIONS ' +
+        'request from allowed origin, allowed method and existing object key',
+        done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': allowedOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', objectKey, bucket, headers,
+            code: 200, headersResponse }, done);
+        });
+        it('should respond with 200 and access control headers to OPTIONS ' +
+        'request from allowed origin, allowed method, even with non-existing ' +
+        'object key', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': allowedOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, objectKey:
+            'anotherObjectKey', headers, code: 200, headersResponse }, done);
+        });
+    });
+
+    describe('CORS and OPTIONS request', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: ['GET'],
+                        AllowedOrigins: ['*'],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('with fake auth credentials: should respond with 200 and access ' +
+        'control headers even if request has fake auth credentials', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Authorization': 'AWS fakeKey:fakesignature',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+
+        it('with cookies: should send identical response as to request ' +
+        'without cookies (200 and access control headers)', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+                'Cookie': 'testcookie=1',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+    });
+
+    describe('CORS exposes headers', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                        ExposeHeaders: [
+                            'x-amz-server-side-encryption',
+                            'x-amz-request-id',
+                            'x-amz-id-2',
+                        ],
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('if OPTIONS request matches CORS rule with ExposeHeader\'s, ' +
+        'response should include Access-Control-Expose-Headers header',
+        done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-expose-headers':
+                'x-amz-server-side-encryption, x-amz-request-id, x-amz-id-2',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+    });
+
+    describe('CORS max age seconds', () => {
+        const corsParams = {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [
+                    {
+                        AllowedMethods: [
+                            'GET',
+                        ],
+                        AllowedOrigins: [
+                            '*',
+                        ],
+                        MaxAgeSeconds: 86400,
+                    },
+                ],
+            },
+        };
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('if OPTIONS request matches CORS rule with max age seconds, ' +
+        'response should include Access-Control-Max-Age header', done => {
+            const headers = {
+                'Origin': allowedOrigin,
+                'Access-Control-Request-Method': 'GET',
+            };
+            const headersResponse = {
+                'access-control-allow-origin': '*',
+                'access-control-allow-methods': 'GET',
+                'access-control-max-age': '86400',
+                vary,
+            };
+            methodRequest({ method: 'OPTIONS', bucket, headers, code: 200,
+            headersResponse }, done);
+        });
+    });
+});


### PR DESCRIPTION
Depends on scality/S3#507 (deleteBucketCors and its prerequisite putBucketCors)

Reference: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTOPTIONSobject.html

Thanks @nicolas2bert for the bulk of the tests!