### PR TITLE
Add listenOn field to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "port": 8000,
+    "listenOn": [],
     "regions": {
         "ap-northeast-1": ["s3.ap-northeast-1.amazonaws.com"],
         "ap-southeast-1": ["s3.ap-southeast-1.amazonaws.com"],

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
+import { ipCheck } from 'arsenal';
 
 import authDataChecker from './auth/in_memory/checker';
 
@@ -41,6 +42,29 @@ class Config {
             assert(Number.isInteger(config.port) && config.port > 0,
                 'bad config: port must be a positive integer');
             this.port = config.port;
+        }
+
+        this.listenOn = [];
+        if (config.listenOn !== undefined) {
+            assert(Array.isArray(config.listenOn)
+                && config.listenOn.every(e => typeof e === 'string'),
+                'bad config: listenOn must be a list of strings');
+            config.listenOn.forEach(item => {
+                const lastColon = item.lastIndexOf(':');
+                // if address is IPv6 format, it includes brackets
+                // that have to be removed from the final IP address
+                const ipAddress = item.indexOf(']') > 0 ?
+                    item.substr(1, lastColon - 2) :
+                    item.substr(0, lastColon);
+                // the port should not include the colon
+                const port = item.substr(lastColon + 1);
+                // parseIp returns as empty object if the address is invalid
+                assert(Object.keys(ipCheck.parseIp(ipAddress)).length !== 0,
+                    'bad config: listenOn IP address must be valid');
+                assert(parseInt(port, 10),
+                    'bad config: listenOn port must be a positive integer');
+                this.listenOn.push({ ip: ipAddress, port });
+            });
         }
 
         assert(typeof config.regions === 'object',

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,7 @@ class S3Server {
     /*
      * This starts the http server.
      */
-    startup(port) {
+    startup(port, ipAddress) {
         // Todo: http.globalAgent.maxSockets, http.globalAgent.maxFreeSockets
         if (_config.https) {
             this.server = https.createServer({
@@ -69,13 +69,17 @@ class S3Server {
         });
         this.server.on('listening', () => {
             const addr = this.server.address() || {
-                address: '[::]',
+                address: ipAddress || '[::]',
                 port,
             };
             logger.info('server started', { address: addr.address,
                 port: addr.port, pid: process.pid });
         });
-        this.server.listen(port);
+        if (ipAddress !== undefined) {
+            this.server.listen(port, ipAddress);
+        } else {
+            this.server.listen(port);
+        }
     }
 
     /*
@@ -112,7 +116,13 @@ class S3Server {
                 log.info('initial health check succeeded', {
                     healthStatus: results,
                 });
-                this.startup(_config.port);
+                if (_config.listenOn.length > 0) {
+                    _config.listenOn.forEach(item => {
+                        this.startup(item.port, item.ip);
+                    });
+                } else {
+                    this.startup(_config.port);
+                }
             }
         });
     }


### PR DESCRIPTION
Adds a new field to the config file that allows users to explicitly set a host:port for the s3 server to listen on.