### PR TITLE
fix: escape xml characters

### DIFF
--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -44,10 +44,10 @@ import { errors } from 'arsenal';
   </ListPartsResult>
    */
 
-function buildXML(xmlParams, xml) {
+function buildXML(xmlParams, xml, encodingFn) {
     xmlParams.forEach(param => {
         if (param.value !== undefined) {
-            xml.push(`<${param.tag}>${param.value}</${param.tag}>`);
+            xml.push(`<${param.tag}>${encodingFn(param.value)}</${param.tag}>`);
         } else {
             if (param.tag !== 'NextPartNumberMarker' &&
                 param.tag !== 'PartNumberMarker') {
@@ -69,7 +69,7 @@ export default function listParts(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'listParts' });
 
     const bucketName = request.bucketName;
-    let objectKey = request.objectKey;
+    const objectKey = request.objectKey;
     const uploadId = request.query.uploadId;
     const encoding = request.query['encoding-type'];
     let maxParts = Number.parseInt(request.query['max-parts'], 10) ?
@@ -145,11 +145,8 @@ export default function listParts(authInfo, request, log, callback) {
                 return next(null, mpuBucket, storedParts, mpuOverviewArray);
             });
         }, function waterfall4(mpuBucket, storedParts, mpuOverviewArray, next) {
-            if (encoding === 'url') {
-                objectKey = querystring.escape(objectKey);
-            } else {
-                objectKey = escapeForXML(objectKey);
-            }
+            const encodingFn = encoding === 'url'
+                ? querystring.escape : escapeForXML;
             const isTruncated = storedParts.IsTruncated;
             const splitterLen = splitter.length;
             const partListing = storedParts.Contents.map(item => {
@@ -178,18 +175,18 @@ export default function listParts(authInfo, request, log, callback) {
                 { tag: 'Bucket', value: bucketName },
                 { tag: 'Key', value: objectKey },
                 { tag: 'UploadId', value: uploadId },
-            ], xml);
+            ], xml, encodingFn);
             xml.push('<Initiator>');
             buildXML([
                 { tag: 'ID', value: mpuOverviewArray[4] },
                 { tag: 'DisplayName', value: mpuOverviewArray[5] },
-            ], xml);
+            ], xml, encodingFn);
             xml.push('</Initiator>');
             xml.push('<Owner>');
             buildXML([
                 { tag: 'ID', value: mpuOverviewArray[6] },
                 { tag: 'DisplayName', value: mpuOverviewArray[7] },
-            ], xml);
+            ], xml, encodingFn);
             xml.push('</Owner>');
             buildXML([
                 { tag: 'StorageClass', value: mpuOverviewArray[8] },
@@ -200,7 +197,7 @@ export default function listParts(authInfo, request, log, callback) {
                     parseInt(lastPartShown, 10) : undefined },
                 { tag: 'MaxParts', value: maxParts },
                 { tag: 'IsTruncated', value: isTruncated ? 'true' : 'false' },
-            ], xml);
+            ], xml, encodingFn);
 
             partListing.forEach(part => {
                 xml.push('<Part>');
@@ -209,7 +206,7 @@ export default function listParts(authInfo, request, log, callback) {
                     { tag: 'LastModified', value: part.lastModified },
                     { tag: 'ETag', value: part.ETag },
                     { tag: 'Size', value: part.size },
-                ], xml);
+                ], xml, encodingFn);
                 xml.push('</Part>');
             });
             xml.push('</ListPartsResult>');

--- a/tests/functional/aws-node-sdk/test/object/listParts.js
+++ b/tests/functional/aws-node-sdk/test/object/listParts.js
@@ -75,3 +75,154 @@ describe('List parts', () => {
         });
     });
 });
+
+/** Tests for special characters in XML **/
+
+/* eslint-disable no-param-reassign */
+function createPart(sigCfg, bucketUtil, s3, key) {
+    let uploadId;
+    return s3.createBucketAsync({ Bucket: bucket })
+    .then(() => s3.createMultipartUploadAsync({
+        Bucket: bucket, Key: key }))
+    .then(res => {
+        uploadId = res.UploadId;
+        return s3.uploadPartAsync({ Bucket: bucket, Key: key,
+          PartNumber: 1, UploadId: uploadId, Body: bodyFirstPart });
+    })
+    .then(() => Promise.resolve(uploadId));
+}
+/* eslint-enable no-param-reassign */
+function deletePart(s3, bucketUtil, key, uploadId) {
+    process.stdout.write('Emptying bucket');
+
+    return s3.abortMultipartUploadAsync({
+        Bucket: bucket, Key: key, UploadId: uploadId,
+    })
+    .then(() => bucketUtil.empty(bucket))
+    .then(() => {
+        process.stdout.write('Deleting bucket');
+        return bucketUtil.deleteOne(bucket);
+    });
+}
+
+function test(s3, bucket, key, uploadId, cb) {
+    s3.listParts({
+        Bucket: bucket,
+        Key: key,
+        UploadId: uploadId },
+    (err, data) => {
+        checkNoError(err);
+        assert.strictEqual(data.Key, key);
+        cb();
+    });
+}
+
+describe('List parts - object keys with special characters: `&`', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
+        const key = '&amp';
+
+        beforeEach(() =>
+            createPart(sigCfg, bucketUtil, s3, key)
+            .then(res => {
+                uploadId = res;
+                return Promise.resolve();
+            })
+        );
+
+        afterEach(() => deletePart(s3, bucketUtil, key, uploadId));
+
+        it('should list parts of an object with `&` in its key',
+            done => test(s3, bucket, key, uploadId, done));
+    });
+});
+
+describe('List parts - object keys with special characters: `"`', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
+        const key = '"quot';
+
+        beforeEach(() =>
+            createPart(sigCfg, bucketUtil, s3, key)
+            .then(res => {
+                uploadId = res;
+                return Promise.resolve();
+            })
+        );
+
+        afterEach(() => deletePart(s3, bucketUtil, key, uploadId));
+
+        it('should list parts of an object with `"` in its key',
+            done => test(s3, bucket, key, uploadId, done));
+    });
+});
+
+describe('List parts - object keys with special characters: `\'`', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
+        const key = '\'apos';
+
+        beforeEach(() =>
+            createPart(sigCfg, bucketUtil, s3, key)
+            .then(res => {
+                uploadId = res;
+                return Promise.resolve();
+            })
+        );
+
+        afterEach(() => deletePart(s3, bucketUtil, key, uploadId));
+
+        it('should list parts of an object with `\'` in its key',
+            done => test(s3, bucket, key, uploadId, done));
+    });
+});
+
+describe('List parts - object keys with special characters: `<`', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
+        const key = '<lt';
+
+        beforeEach(() =>
+            createPart(sigCfg, bucketUtil, s3, key)
+            .then(res => {
+                uploadId = res;
+                return Promise.resolve();
+            })
+        );
+
+        afterEach(() => deletePart(s3, bucketUtil, key, uploadId));
+
+        it('should list parts of an object with `<` in its key',
+            done => test(s3, bucket, key, uploadId, done));
+    });
+});
+
+describe('List parts - object keys with special characters: `>`', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
+        const key = '>gt';
+
+        beforeEach(() =>
+            createPart(sigCfg, bucketUtil, s3, key)
+            .then(res => {
+                uploadId = res;
+                return Promise.resolve();
+            })
+        );
+
+        afterEach(() => deletePart(s3, bucketUtil, key, uploadId));
+
+        it('should list parts of an object with `>` in its key',
+            done => test(s3, bucket, key, uploadId, done));
+    });
+});


### PR DESCRIPTION
List parts does not need tests for prefix, marker, next marker as they are string
hashes and not object keys which may have invalid xml characters.

fixes #519