### PR TITLE
FT: Add component to Utapi config

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -141,7 +141,7 @@ class Config {
             }
         }
 
-        this.utapi = {};
+        this.utapi = { component: 's3' };
         if (config.utapi) {
             if (config.utapi.port) {
                 assert(Number.isInteger(config.utapi.port)
@@ -186,6 +186,9 @@ class Config {
             }
             if (config.utapi.metrics) {
                 this.utapi.metrics = config.utapi.metrics;
+            }
+            if (config.utapi.component) {
+                this.utapi.component = config.utapi.component;
             }
         }
 


### PR DESCRIPTION
Adds a `component` property to the Utapi configuration. 

When introducing service-level metrics, including this property will allow the Utapi client to determine which service is pushing the metrics (the configuration is passed in the instantiation of `UtapiClient`).