### PR TITLE
FT: Add recent metrics listing option

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -16,12 +16,14 @@ function _listMetrics(host,
                       accessKey,
                       secretKey,
                       verbose,
+                      recent,
                       ssl) {
+    const listAction = recent ? 'ListRecentMetrics' : 'ListMetrics';
     const options = {
         host,
         port,
         method: 'POST',
-        path: `/${metric}?Action=ListMetrics`,
+        path: `/${metric}?Action=${listAction}`,
         headers: {
             'content-type': 'application/json',
             'cache-control': 'no-cache',
@@ -56,13 +58,14 @@ function _listMetrics(host,
     });
     // TODO: cleanup with refactor of generateV4Headers
     request.path = `/${metric}`;
-    auth.client.generateV4Headers(request, { Action: 'ListMetrics' },
+    auth.client.generateV4Headers(request, { Action: listAction },
         accessKey, secretKey, 's3');
-    request.path = `/${metric}?Action=ListMetrics`;
+    request.path = `/${metric}?Action=${listAction}`;
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }
-    const requestObj = { timeRange };
+    // If recent listing, we do not provide `timeRange` in the request
+    const requestObj = recent ? {} : { timeRange };
     requestObj[metric] = metricType;
     request.write(JSON.stringify(requestObj));
     request.end();
@@ -101,6 +104,8 @@ export function listMetrics(metricType) {
     }
     commander
         .option('-s, --start <start>', 'Start of time range')
+        .option('-r, --recent', 'List metrics including the previous and ' +
+            'current 15 minute interval')
         .option('-e --end <end>', 'End of time range')
         .option('-h, --host <host>', 'Host of the server')
         .option('-p, --port <port>', 'Port of the server')
@@ -108,7 +113,8 @@ export function listMetrics(metricType) {
         .option('-v, --verbose')
         .parse(process.argv);
 
-    const { host, port, accessKey, secretKey, start, end, verbose, ssl } =
+    const { host, port, accessKey, secretKey, start, end, verbose, recent,
+        ssl } =
         commander;
     const requiredOptions = { host, port, accessKey, secretKey };
     // If not old style bucket metrics, we require usage of the metric option
@@ -127,7 +133,10 @@ export function listMetrics(metricType) {
     // `commander.metric` should be defined.
     const metric = metricType === 'buckets' ? 'buckets' : commander.metric;
     requiredOptions[metric] = commander[metric];
-
+    // If not recent listing, the start option must be provided
+    if (!recent) {
+        requiredOptions.start = commander.start;
+    }
     Object.keys(requiredOptions).forEach(option => {
         if (!requiredOptions[option]) {
             logger.error(`missing required option: ${option}`);
@@ -137,29 +146,33 @@ export function listMetrics(metricType) {
         }
     });
 
-    const numStart = Number.parseInt(start, 10);
-    if (!numStart) {
-        logger.error('start must be a number');
-        commander.outputHelp();
-        process.exit(1);
-    }
-
-    const timeRange = [numStart];
-
-    if (end) {
-        const numEnd = Number.parseInt(end, 10);
-        if (!numEnd) {
-            logger.error('if provide end, end must be a number');
+    const timeRange = [];
+    // If recent listing, we disregard any start or end option given
+    if (!recent) {
+        const numStart = Number.parseInt(start, 10);
+        if (!numStart) {
+            logger.error('start must be a number');
             commander.outputHelp();
             process.exit(1);
+            return;
         }
-        timeRange.push(numEnd);
+        timeRange.push(numStart);
+        if (end) {
+            const numEnd = Number.parseInt(end, 10);
+            if (!numEnd) {
+                logger.error('end must be a number');
+                commander.outputHelp();
+                process.exit(1);
+                return;
+            }
+            timeRange.push(numEnd);
+        }
     }
     // The string `commander[metric]` is a comma-separated list of resources
     // given by the user.
     const resources = commander[metric].split(',');
     _listMetrics(host, port, metric, resources, timeRange, accessKey, secretKey,
-        verbose, ssl);
+        verbose, recent, ssl);
 }
 
 /**


### PR DESCRIPTION
Adds the option to list recent metrics using the Utapi route with action `ListRecentMetrics`. This will return the latest metrics of between `Date.now()` and the second most recent fifteen minute interval (e.g., if it is 6:31 when the request is made, then list metrics starting from 6:15). 

If `start` or `end` options are provided along with the `recent` option, they will be ignored and metrics of the "recent" time range will be returned.

Depends on https://github.com/scality/utapi/pull/114.