### PR TITLE
FT: Implement CORS headers in API responses

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -214,7 +214,8 @@ export function createBucket(authInfo, bucketName, headers,
         const existingBucketMD = results.getAnyExistingBucketInfo;
         if (existingBucketMD instanceof BucketInfo &&
             existingBucketMD.getOwner() !== canonicalID) {
-            return cb(errors.BucketAlreadyExists);
+            // return existingBucketMD to collect cors headers
+            return cb(errors.BucketAlreadyExists, existingBucketMD);
         }
         const newBucketMD = results.prepareNewBucketMD;
         if (existingBucketMD === 'NoBucketYet') {
@@ -249,8 +250,8 @@ export function createBucket(authInfo, bucketName, headers,
             existingBucketMD.getLocationConstraint() === 'us-east-1') &&
             usEastBehavior) {
             log.trace('returning 200 instead of 409 to mirror us-east-1');
-            return cb();
+            return cb(null, existingBucketMD);
         }
-        return cb(errors.BucketAlreadyOwnedByYou);
+        return cb(errors.BucketAlreadyOwnedByYou, existingBucketMD);
     });
 }

--- a/lib/api/apiUtils/object/corsResponse.js
+++ b/lib/api/apiUtils/object/corsResponse.js
@@ -30,8 +30,8 @@ function _matchesOneOf(allowedHeaders, header) {
 }
 
 /** _headersMatchRule - check if headers match AllowedHeaders of rule
-* @param {string[]} headers - the value of the 'Access-Control-Allow-Headers'
-*   in an OPTIONS request and actual request header keys in any other request
+* @param {string[]} headers - the value of the 'Access-Control-Request-Headers'
+*   in an OPTIONS request
 * @param {string[]} allowedHeaders - AllowedHeaders of a CORS rule
 * @return {boolean} - true/false
 */
@@ -58,10 +58,10 @@ function _headersMatchRule(headers, allowedHeaders) {
 * @param {string[]} [rules[].exposeHeaders] - headers to expose to external
 *   applications
 * @param {string} origin - origin of CORS request
-* @param {string} method - 'Access-Control-Request-Method' header value in
+* @param {string} method - Access-Control-Request-Method header value in
 *   an OPTIONS request and the actual method in any other request
-* @param {string[]} [headers] - the value of the 'Access-Control-Allow-Headers'
-*   in an OPTIONS request and actual request header keys in any other request
+* @param {string[]} [headers] - Access-Control-Request-Headers header value
+*   in a preflight CORS request
 * @return {(null|object)} - matching rule if found; null if no match
 */
 export function findCorsRule(rules, origin, method, headers) {
@@ -91,18 +91,19 @@ export function findCorsRule(rules, origin, method, headers) {
 * @param {string[]} [rule[].exposeHeaders] - headers to expose to external
 *   applications
 * @param {string} origin - origin of CORS request
-* @param {string} method - 'Access-Control-Request-Method' header value in
+* @param {string} method - Access-Control-Request-Method header value in
 *   an OPTIONS request and the actual method in any other request
-* @param {string[]} [headers] - the value of the 'Access-Control-Allow-Headers'
-*   in an OPTIONS request and actual request header keys in any other request
+* @param {string[]} [headers] - Access-Control-Request-Headers header value
+*   in a preflight CORS request
+* @param {boolean} [isPreflight] - indicates if cors headers are being gathered
+*   for a CORS preflight request
 * @return {object} resHeaders - headers to include in response
 */
-export function gatherCorsResHeaders(rule, origin, method, headers) {
+export function generateCorsResHeaders(rule, origin, method, headers,
+isPreflight) {
     const resHeaders = {
         'access-control-max-age': rule.maxAgeSeconds,
         'access-control-allow-methods': rule.allowedMethods.join(', '),
-        'content-length': '0',
-        'date': new Date().toUTCString(),
         'vary':
         'Origin, Access-Control-Request-Headers, Access-Control-Request-Method',
     };
@@ -122,6 +123,10 @@ export function gatherCorsResHeaders(rule, origin, method, headers) {
     if (rule.exposeHeaders) {
         resHeaders['access-control-expose-headers'] =
             rule.exposeHeaders.join(', ');
+    }
+    if (isPreflight) {
+        resHeaders['content-length'] = '0';
+        resHeaders.date = new Date().toUTCString();
     }
     return resHeaders;
 }

--- a/lib/api/bucketDelete.js
+++ b/lib/api/bucketDelete.js
@@ -1,5 +1,6 @@
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { deleteBucket } from './apiUtils/bucket/bucketDeletion';
 import services from '../services';
 import { pushMetric } from '../utapi/utilities';
@@ -32,23 +33,25 @@ export default function bucketDelete(authInfo, request, log, cb) {
 
     return services.metadataValidateAuthorization(metadataValParams,
         (err, bucketMD) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, bucketMD);
             if (err) {
                 log.debug('error processing request',
                     { method: 'metadataValidateAuthorization', error: err });
-                return cb(err);
+                return cb(err, corsHeaders);
             }
             log.trace('passed checks',
                 { method: 'metadataValidateAuthorization' });
             return deleteBucket(bucketMD, bucketName, authInfo.getCanonicalID(),
                 log, err => {
                     if (err) {
-                        return cb(err);
+                        return cb(err, corsHeaders);
                     }
                     pushMetric('deleteBucket', log, {
                         authInfo,
                         bucket: bucketName,
                     });
-                    return cb();
+                    return cb(null, corsHeaders);
                 });
         });
 }

--- a/lib/api/bucketDeleteCors.js
+++ b/lib/api/bucketDeleteCors.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 // TODO: import { pushMetric } from '../utapi/utilities';
@@ -20,6 +21,8 @@ export default function bucketDeleteCors(authInfo, request, log, callback) {
     const canonicalID = authInfo.getCanonicalID();
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
             return callback(err);
@@ -34,7 +37,7 @@ export default function bucketDeleteCors(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketDeleteCors',
             });
-            return callback(errors.AccessDenied);
+            return callback(errors.AccessDenied, corsHeaders);
         }
 
         const cors = bucket.getCors();
@@ -44,18 +47,18 @@ export default function bucketDeleteCors(authInfo, request, log, callback) {
             });
             // TODO: add 'deleteBucketCors' to Utapi Client action map
             // pushMetric('deleteBucketCors', log, { bucket: bucketName });
-            return callback();
+            return callback(null, corsHeaders);
         }
 
         log.trace('deleting cors configuration in metadata');
         bucket.setCors(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
-                return callback(err);
+                return callback(err, corsHeaders);
             }
             // TODO: pushMetric('deleteBucketCors', log,
             // { bucket: bucketName });
-            return callback();
+            return callback(err, corsHeaders);
         });
     });
 }

--- a/lib/api/bucketDeleteWebsite.js
+++ b/lib/api/bucketDeleteWebsite.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 import { pushMetric } from '../utapi/utilities';
@@ -12,6 +13,8 @@ export default function bucketDeleteWebsite(authInfo, request, log, callback) {
     const canonicalID = authInfo.getCanonicalID();
 
     return metadata.getBucket(bucketName, log, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('metadata getbucket failed', { error: err });
             return callback(err);
@@ -26,7 +29,7 @@ export default function bucketDeleteWebsite(authInfo, request, log, callback) {
                 requestType,
                 method: 'bucketDeleteWebsite',
             });
-            return callback(errors.AccessDenied);
+            return callback(errors.AccessDenied, corsHeaders);
         }
 
         const websiteConfig = bucket.getWebsiteConfiguration();
@@ -38,20 +41,20 @@ export default function bucketDeleteWebsite(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback();
+            return callback(null, corsHeaders);
         }
 
         log.trace('deleting website configuration in metadata');
         bucket.setWebsiteConfiguration(null);
         return metadata.updateBucket(bucketName, bucket, log, err => {
             if (err) {
-                return callback(err);
+                return callback(err, corsHeaders);
             }
             pushMetric('deleteBucketWebsite', log, {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback();
+            return callback(null, corsHeaders);
         });
     });
 }

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -2,6 +2,7 @@ import querystring from 'querystring';
 import constants from '../../constants';
 
 import services from '../services';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
 import { errors } from 'arsenal';
@@ -73,16 +74,18 @@ export default function bucketGet(authInfo, request, log, callback) {
         prefix: params.prefix,
     };
 
-    services.metadataValidateAuthorization(metadataValParams, err => {
+    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('error processing request', { error: err });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         return services.getObjectListing(bucketName, listParams, log,
         (err, list) => {
             if (err) {
                 log.debug('error processing request', { error: err });
-                return callback(err);
+                return callback(err, null, corsHeaders);
             }
             const xml = [];
             xml.push(
@@ -141,7 +144,7 @@ export default function bucketGet(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback(null, xml.join(''));
+            return callback(null, xml.join(''), corsHeaders);
         });
     });
     return undefined;

--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -2,6 +2,7 @@ import aclUtils from '../utilities/aclUtils';
 import constants from '../../constants';
 import services from '../services';
 import vault from '../auth/vault';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { pushMetric } from '../utapi/utilities';
 
 //	Sample XML response:
@@ -60,10 +61,12 @@ export default function bucketGetACL(authInfo, request, log, callback) {
     ];
 
     services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('error processing request',
                 { method: 'bucketGetACL', error: err });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const bucketACL = bucket.getAcl();
         const allSpecificGrants = [].concat(
@@ -90,7 +93,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback(null, xml);
+            return callback(null, xml, corsHeaders);
         }
         /**
         * Build array of all canonicalIDs used in ACLs so duplicates
@@ -124,7 +127,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback(null, xml);
+            return callback(null, xml, corsHeaders);
         }
         /**
 	    * If acl's set by account canonicalID, get emails from Vault to serve
@@ -134,7 +137,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
             if (err) {
                 log.debug('error processing request',
                     { method: 'vault.getEmailAddresses', error: err });
-                return callback(err);
+                return callback(err, null, corsHeaders);
             }
             const individualGrants = canonicalIDs.map(canonicalID => {
                 /**
@@ -164,7 +167,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback(null, xml);
+            return callback(null, xml, corsHeaders);
         });
     });
 }

--- a/lib/api/bucketGetCors.js
+++ b/lib/api/bucketGetCors.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { convertToXml } from './apiUtils/bucket/bucketCors';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
@@ -29,13 +30,15 @@ export default function bucketGetCors(authInfo, request, log, callback) {
             return callback(errors.NoSuchBucket);
         }
         log.trace('found bucket in metadata');
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
 
         if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
             log.debug('access denied for user on bucket', {
                 requestType,
                 method: 'bucketGetCors',
             });
-            return callback(errors.AccessDenied);
+            return callback(errors.AccessDenied, null, corsHeaders);
         }
 
         const cors = bucket.getCors();
@@ -43,13 +46,13 @@ export default function bucketGetCors(authInfo, request, log, callback) {
             log.debug('cors configuration does not exist', {
                 method: 'bucketGetCors',
             });
-            return callback(errors.NoSuchCORSConfiguration);
+            return callback(errors.NoSuchCORSConfiguration, null, corsHeaders);
         }
         log.trace('converting cors configuration to xml');
         const xml = convertToXml(cors);
 
         // TODO: Add getBucketCors to Utapi Client action map
         // pushMetric('getBucketCors', log, { bucket: bucketName });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetVersioning.js
+++ b/lib/api/bucketGetVersioning.js
@@ -1,4 +1,5 @@
 import services from '../services';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 
 //	Sample XML response:
 /*
@@ -56,10 +57,12 @@ export default function bucketGetVersioning(authInfo, request, log, callback) {
     };
 
     services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('error processing request',
                 { method: 'bucketGetVersioning', error: err });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const versioningConfiguration = bucket.getVersioningConfiguration();
         const xml = convertToXml(versioningConfiguration);
@@ -68,6 +71,6 @@ export default function bucketGetVersioning(authInfo, request, log, callback) {
         //      authInfo,
         //      bucket: bucketName,
         // });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketGetWebsite.js
+++ b/lib/api/bucketGetWebsite.js
@@ -2,6 +2,7 @@ import { errors } from 'arsenal';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
 import { convertToXml } from './apiUtils/bucket/bucketWebsite';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 import { pushMetric } from '../utapi/utilities';
@@ -30,12 +31,14 @@ export default function bucketGetWebsite(authInfo, request, log, callback) {
         }
         log.trace('found bucket in metadata');
 
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
             log.debug('access denied for user on bucket', {
                 requestType,
                 method: 'bucketGetWebsite',
             });
-            return callback(errors.AccessDenied);
+            return callback(errors.AccessDenied, null, corsHeaders);
         }
 
         const websiteConfig = bucket.getWebsiteConfiguration();
@@ -43,7 +46,8 @@ export default function bucketGetWebsite(authInfo, request, log, callback) {
             log.debug('bucket website configuration does not exist', {
                 method: 'bucketGetWebsite',
             });
-            return callback(errors.NoSuchWebsiteConfiguration);
+            return callback(errors.NoSuchWebsiteConfiguration, null,
+                corsHeaders);
         }
         log.trace('converting website configuration to xml');
         const xml = convertToXml(websiteConfig);
@@ -52,6 +56,6 @@ export default function bucketGetWebsite(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -1,4 +1,6 @@
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
+
 import { pushMetric } from '../utapi/utilities';
 
 /**
@@ -19,14 +21,16 @@ export default function bucketHead(authInfo, request, log, callback) {
         requestType: 'bucketHead',
         log,
     };
-    services.metadataValidateAuthorization(metadataValParams, err => {
+    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
-            return callback(err);
+            return callback(err, corsHeaders);
         }
         pushMetric('headBucket', log, {
             authInfo,
             bucket: bucketName,
         });
-        return callback(null, 'Bucket exists and user authorized -- 200');
+        return callback(null, corsHeaders);
     });
 }

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import { createBucket } from './apiUtils/bucket/bucketCreation';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import config from '../Config';
 import aclUtils from '../utilities/aclUtils';
 import { pushMetric } from '../utapi/utilities';
@@ -39,14 +40,18 @@ export default function bucketPut(authInfo, request, locationConstraint, log,
     const bucketName = request.bucketName;
 
     return createBucket(authInfo, bucketName, request.headers,
-        locationConstraint, config.usEastBehavior, log, err => {
+        locationConstraint, config.usEastBehavior, log,
+        (err, previousBucket) => {
+            // if bucket already existed, gather any relevant cors headers
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, previousBucket);
             if (err) {
-                return callback(err);
+                return callback(err, corsHeaders);
             }
             pushMetric('createBucket', log, {
                 authInfo,
                 bucket: bucketName,
             });
-            return callback();
+            return callback(null, corsHeaders);
         });
 }

--- a/lib/api/bucketPutACL.js
+++ b/lib/api/bucketPutACL.js
@@ -4,6 +4,7 @@ import async from 'async';
 import acl from '../metadata/acl';
 import aclUtils from '../utilities/aclUtils';
 import { cleanUpBucket } from './apiUtils/bucket/bucketCreation';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import services from '../services';
 import vault from '../auth/vault';
@@ -103,16 +104,16 @@ export default function bucketPutACL(authInfo, request, log, callback) {
     return async.waterfall([
         function waterfall1(next) {
             services.metadataValidateAuthorization(metadataValParams,
-                (err, bucket) => {
-                    if (err) {
-                        log.trace('request authorization failed', {
-                            error: err,
-                            method: 'services.metadataValidateAuthorization',
-                        });
-                        return next(err);
-                    }
-                    return next(null, bucket);
-                });
+            (err, bucket) => {
+                if (err) {
+                    log.trace('request authorization failed', {
+                        error: err,
+                        method: 'services.metadataValidateAuthorization',
+                    });
+                    return next(err, bucket);
+                }
+                return next(null, bucket);
+            });
         },
         function waterfall2(bucket, next) {
             // If not setting acl through headers, parse body
@@ -128,7 +129,7 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                         (err, jsonGrants) => next(err, bucket, jsonGrants));
                 }
                 // If no ACLs sent with request at all
-                return next(errors.MalformedXML);
+                return next(errors.MalformedXML, bucket);
             }
             /**
             * If acl set in headers (including canned acl) pass bucket and
@@ -180,7 +181,7 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                         if (possibleGroups.indexOf(grantee.URI[0]) < 0) {
                             log.trace('invalid user group',
                                  { userGroup: grantee.URI[0] });
-                            return next(errors.InvalidArgument);
+                            return next(errors.InvalidArgument, bucket);
                         }
                         return usersIdentifiedByGroup.push({
                             identifier: grantee.URI[0],
@@ -209,7 +210,7 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                     if (possibleGroups.indexOf(userGroup) < 0) {
                         log.trace('invalid user group', { userGroup,
                             method: 'bucketPutACL' });
-                        return next(errors.InvalidArgument);
+                        return next(errors.InvalidArgument, bucket);
                     }
                 }
                 /** TODO: Consider whether want to verify with Vault
@@ -230,7 +231,7 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                         id,
                         method: 'bucketPutACL',
                     });
-                    return callback(errors.InvalidArgument);
+                    return callback(errors.InvalidArgument, bucket);
                 }
             }
 
@@ -243,7 +244,7 @@ export default function bucketPutACL(authInfo, request, log, callback) {
                         if (err) {
                             log.trace('error looking up canonical ids', {
                                 error: err, method: 'vault.getCanonicalIDs' });
-                            return next(err);
+                            return next(err, bucket);
                         }
                         const reconstructedUsersIdentifiedByEmail = aclUtils
                             .reconstructUsersIdentifiedByEmail(results,
@@ -272,21 +273,25 @@ export default function bucketPutACL(authInfo, request, log, callback) {
             if (bucket.hasTransientFlag() || bucket.hasDeletedFlag()) {
                 log.trace('transient or deleted flag so cleaning up bucket');
                 bucket.setFullAcl(addACLParams);
-                return cleanUpBucket(bucket, canonicalID, log, next);
+                return cleanUpBucket(bucket, canonicalID, log, err =>
+                    next(err, bucket));
             }
             // If no bucket flags, just add acl's to bucket metadata
-            return acl.addACL(bucket, addACLParams, log, next);
+            return acl.addACL(bucket, addACLParams, log, err =>
+                next(err, bucket));
         },
-    ], err => {
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutACL' });
-            return callback(err);
+        } else {
+            pushMetric('putBucketAcl', log, {
+                authInfo,
+                bucket: bucketName,
+            });
         }
-        pushMetric('putBucketAcl', log, {
-            authInfo,
-            bucket: bucketName,
-        });
-        return callback(err, 'ACL Set');
+        return callback(err, corsHeaders);
     });
 }

--- a/lib/api/bucketPutCors.js
+++ b/lib/api/bucketPutCors.js
@@ -4,6 +4,7 @@ import async from 'async';
 import { errors } from 'arsenal';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 import { parseCorsXml } from './apiUtils/bucket/bucketCors';
@@ -58,30 +59,34 @@ export default function bucketPutCors(authInfo, request, log, callback) {
                     return next(errors.NoSuchBucket);
                 }
                 log.trace('found bucket in metadata');
-                return next(null, bucket, rules);
+                // get corsHeaders before CORSConfiguration is updated
+                const corsHeaders = collectCorsHeaders(request.headers.origin,
+                    request.method, bucket);
+                return next(null, bucket, rules, corsHeaders);
             });
         },
-        function validateBucketAuthorization(bucket, rules, next) {
+        function validateBucketAuthorization(bucket, rules, corsHeaders, next) {
             if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
                 log.debug('access denied for account on bucket', {
                     requestType,
                 });
-                return next(errors.AccessDenied);
+                return next(errors.AccessDenied, corsHeaders);
             }
-            return next(null, bucket, rules);
+            return next(null, bucket, rules, corsHeaders);
         },
-        function updateBucketMetadata(bucket, rules, next) {
+        function updateBucketMetadata(bucket, rules, corsHeaders, next) {
             log.trace('updating bucket cors rules in metadata');
             bucket.setCors(rules);
-            metadata.updateBucket(bucketName, bucket, log, next);
+            metadata.updateBucket(bucketName, bucket, log, err =>
+                next(err, corsHeaders));
         },
-    ], err => {
+    ], (err, corsHeaders) => {
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutCors' });
         }
         // TODO: Add this action to Utapi Client for pushMetrics
         // pushMetric('putBucketCors', log, { bucket: bucketName });
-        return callback(err);
+        return callback(err, corsHeaders);
     });
 }

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -1,6 +1,7 @@
 import { waterfall } from 'async';
 import { parseString } from 'xml2js';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import metadata from '../metadata/wrapper';
 import services from '../services';
 
@@ -37,11 +38,11 @@ export default function bucketPutVersioning(authInfo, request, log, callback) {
 
     return waterfall([
         next => services.metadataValidateAuthorization(metadataValParams,
-            (err, bucket) => next(err, bucket)), // to ignore null object
+            (err, bucket) => next(err, bucket)), // ignore extra null object,
         (bucket, next) => parseString(request.post, (err, result) => {
             // just for linting; there should not be any parsing error here
             if (err) {
-                return next(err);
+                return next(err, bucket);
             }
             const versioningConfiguration = {};
             if (result.VersioningConfiguration.Status) {
@@ -58,19 +59,23 @@ export default function bucketPutVersioning(authInfo, request, log, callback) {
         (bucket, versioningConfiguration, next) => {
             bucket.setVersioningConfiguration(versioningConfiguration);
             // TODO all metadata updates of bucket should be using CAS
-            metadata.updateBucket(bucket.getName(), bucket, log, next);
+            metadata.updateBucket(bucket.getName(), bucket, log, err =>
+                next(err, bucket));
         },
-    ], err => {
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutVersioning' });
-            return callback(err);
         }
         // TODO push metrics for bucketPutVersioning
-        // pushMetric('bucketPutVersioning', log, {
+        // else {
+        //  pushMetric('bucketPutVersioning', log, {
         //      authInfo,
         //      bucket: bucketName,
+        //   }
         // }
-        return callback(err, 'Versioning Set');
+        return callback(err, corsHeaders);
     });
 }

--- a/lib/api/bucketPutWebsite.js
+++ b/lib/api/bucketPutWebsite.js
@@ -2,6 +2,7 @@ import { errors } from 'arsenal';
 import async from 'async';
 
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
 import metadata from '../metadata/wrapper';
 import { parseWebsiteConfigXml } from './apiUtils/bucket/bucketWebsite';
@@ -49,25 +50,29 @@ export default function bucketPutWebsite(authInfo, request, log, callback) {
                     requestType,
                     method: 'bucketPutWebsite',
                 });
-                return next(errors.AccessDenied);
+                return next(errors.AccessDenied, bucket);
             }
             return next(null, bucket, config);
         },
         function updateBucketMetadata(bucket, config, next) {
             log.trace('updating bucket website configuration in metadata');
             bucket.setWebsiteConfiguration(config);
-            metadata.updateBucket(bucketName, bucket, log, next);
+            metadata.updateBucket(bucketName, bucket, log, err => {
+                next(err, bucket);
+            });
         },
-    ], err => {
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.trace('error processing request', { error: err,
                 method: 'bucketPutWebsite' });
-            return callback(err);
+        } else {
+            pushMetric('putBucketWebsite', log, {
+                authInfo,
+                bucket: bucketName,
+            });
         }
-        pushMetric('putBucketWebsite', log, {
-            authInfo,
-            bucket: bucketName,
-        });
-        return callback();
+        return callback(err, corsHeaders);
     });
 }

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -6,6 +6,7 @@ import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
 
 import data from '../data/wrapper';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import metadata from '../metadata/wrapper';
 import services from '../services';
@@ -114,29 +115,50 @@ function completeMultipartUpload(authInfo, request, log, callback) {
 
     async.waterfall([
         function waterfall1(next) {
+            const metadataValParams = {
+                objectKey,
+                authInfo,
+                bucketName,
+                // Required permissions for this action
+                // at the destinationBucket level are same as objectPut
+                requestType: 'objectPut',
+                log,
+            };
+            services.metadataValidateAuthorization(metadataValParams, next);
+        },
+        function waterfall2(destBucket, objMD, next) {
             services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket) => {
                     if (err) {
-                        return next(err);
+                        return next(err, destBucket);
                     }
-                    return next(null, mpuBucket);
+                    return next(null, destBucket, objMD, mpuBucket);
                 });
         },
-        function waterfall2(mpuBucket, next) {
+        function waterfall3(destBucket, objMD, mpuBucket, next) {
             if (request.post) {
-                return parseXml(request.post, (err, jsonList) =>
-                    next(err, mpuBucket, jsonList));
+                return parseXml(request.post, (err, jsonList) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
+                    return next(err, destBucket, objMD, mpuBucket, jsonList);
+                });
             }
-            return next(errors.MalformedXML);
+            return next(errors.MalformedXML, destBucket);
         },
-        function waterfall3(mpuBucket, jsonList, next) {
+        function waterfall4(destBucket, objMD, mpuBucket, jsonList, next) {
             services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
                     const storedParts = result.Contents;
-                    return next(err, mpuBucket, storedParts, jsonList);
+                    return next(null, destBucket, objMD, mpuBucket,
+                        storedParts, jsonList);
                 });
         },
-        function waterfall4(mpuBucket, storedParts, jsonList, next) {
+        function waterfall5(destBucket, objMD, mpuBucket, storedParts, jsonList,
+        next) {
             const storedPartsAsObjects = storedParts.map(item => ({
                 // In order to delete the part listing in the shadow
                 // bucket, need the full key
@@ -176,7 +198,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             // in the completed MPU but there cannot be more
             // parts in the complete message than were already put
             if (partLength > storedPartsAsObjects.length) {
-                return next(errors.InvalidPart);
+                return next(errors.InvalidPart, destBucket);
             }
             // if extra parts, need to delete the data when done with completing
             // mpu so extract the info to delete here
@@ -204,10 +226,10 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 if (partNumber !== i + 1) {
                     // If not in order return InvalidPartOrder
                     if (partNumber <= partLength) {
-                        return next(errors.InvalidPartOrder);
+                        return next(errors.InvalidPartOrder, destBucket);
                     }
                     // If missing part return InvalidPart
-                    return next(errors.InvalidPart);
+                    return next(errors.InvalidPart, destBucket);
                 }
 
                 // some clients send base64, convert to hex
@@ -224,7 +246,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // a part ETag that does not match
                 // the ETag for the part already sent, return an error
                 if (partETag !== storedPartsAsObjects[i].ETag) {
-                    return next(errors.InvalidPart);
+                    return next(errors.InvalidPart, destBucket);
                 }
                 // If any part other than the last part is less than 5MB,
                 // return an error
@@ -240,7 +262,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     i < jsonList.Part.length - 1 &&
                     partSize < constants.minimumAllowedPartSize) {
                     log.debug('part too small on complete mpu');
-                    return next(errors.EntityTooSmall);
+                    return next(errors.EntityTooSmall, destBucket);
                 }
                 // Assemble array of part locations, aggregate size and build
                 // string to create aggregate ETag
@@ -303,16 +325,16 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             return metadata.getObjectMD(mpuBucket.getName(), mpuOverviewKey,
                 log, (err, storedMetadata) => {
                     if (err) {
-                        return next(err);
+                        return next(err, destBucket);
                     }
-                    return next(null, mpuBucket, storedMetadata,
-                        aggregateETag, calculatedSize,
+                    return next(null, destBucket, objMD, mpuBucket,
+                        storedMetadata, aggregateETag, calculatedSize,
                         dataLocations, mpuOverviewKey,
                         storedPartsAsObjects, extraPartLocations);
                 });
         },
-        function waterfall5(mpuBucket, storedMetadata, aggregateETag,
-            calculatedSize, dataLocations, mpuOverviewKey,
+        function waterfall6(destBucket, objMD, mpuBucket, storedMetadata,
+            aggregateETag, calculatedSize, dataLocations, mpuOverviewKey,
             storedPartsAsObjects, extraPartLocations, next) {
             const metaHeaders = {};
             const keysNotNeeded =
@@ -341,22 +363,11 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 multipart: true,
                 log,
             };
-            const metadataValParams = {
-                objectKey,
-                authInfo,
-                bucketName,
-                // Required permissions for this action
-                // at the destinationBucket level are same as objectPut
-                requestType: 'objectPut',
-                log,
-            };
-            services.metadataValidateAuthorization(metadataValParams,
-                (err, destinationBucket, objMD) =>
-                    next(err, destinationBucket, dataLocations, metaStoreParams,
-                        mpuBucket, mpuOverviewKey, aggregateETag,
-                        storedPartsAsObjects, objMD, extraPartLocations));
+            next(null, destBucket, dataLocations, metaStoreParams,
+                mpuBucket, mpuOverviewKey, aggregateETag,
+                storedPartsAsObjects, objMD, extraPartLocations);
         },
-        function waterfall6(destinationBucket, dataLocations,
+        function waterfall7(destinationBucket, dataLocations,
                             metaStoreParams, mpuBucket, mpuOverviewKey,
                             aggregateETag, storedPartsAsObjects, objMD,
                             extraPartLocations, next) {
@@ -369,19 +380,10 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     masterKeyId: destinationBucket.getSseMasterKeyId(),
                 };
             }
-            next(null, destinationBucket, pseudoCipherBundle, dataLocations,
-                 metaStoreParams, mpuBucket, mpuOverviewKey, aggregateETag,
-                 storedPartsAsObjects, objMD, extraPartLocations);
-        },
-        function waterfall7(destinationBucket, pseudoCipherBundle,
-                            dataLocations, metaStoreParams, mpuBucket,
-                            mpuOverviewKey, aggregateETag,
-                            storedPartsAsObjects, objMD,
-                            extraPartLocations, next) {
             services.metadataStoreObject(destinationBucket.getName(),
                 dataLocations, pseudoCipherBundle, metaStoreParams, err => {
                     if (err) {
-                        return next(err);
+                        return next(err, destinationBucket);
                     }
                     if (objMD && objMD.location) {
                         const dataToDelete = Array.isArray(objMD.location) ?
@@ -392,24 +394,28 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     }
                     return next(null, mpuBucket, mpuOverviewKey,
                         aggregateETag, storedPartsAsObjects,
-                        extraPartLocations);
+                        extraPartLocations, destinationBucket);
                 });
         },
         function waterfall8(mpuBucket, mpuOverviewKey, aggregateETag,
-            storedPartsAsObjects, extraPartLocations, next) {
+            storedPartsAsObjects, extraPartLocations, destinationBucket, next) {
             const keysToDelete = storedPartsAsObjects.map(item => item.key);
             keysToDelete.push(mpuOverviewKey);
             services.batchDeleteObjectMetadata(mpuBucket.getName(),
-                keysToDelete, log, err => next(err, aggregateETag));
+                keysToDelete, log, err => next(err, destinationBucket,
+                    aggregateETag));
             if (extraPartLocations.length > 0) {
                 data.batchDelete(extraPartLocations, logger
                     .newRequestLoggerFromSerializedUids(log
                     .getSerializedUids()));
             }
         },
-    ], (err, aggregateETag) => {
+    ], (err, destinationBucket, aggregateETag) => {
+        const corsHeaders =
+            collectCorsHeaders(request.headers.origin, request.method,
+                destinationBucket);
         if (err) {
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         xmlParams.ETag = `"${aggregateETag}"`;
         const xml = _convertToXml(xmlParams);
@@ -417,6 +423,6 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             authInfo,
             bucket: bucketName,
         });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/corsPreflight.js
+++ b/lib/api/corsPreflight.js
@@ -3,7 +3,7 @@ import { errors } from 'arsenal';
 import metadata from '../metadata/wrapper';
 import bucketShield from './apiUtils/bucket/bucketShield';
 import { findCorsRule,
-gatherCorsResHeaders } from './apiUtils/object/corsResponse';
+generateCorsResHeaders } from './apiUtils/object/corsResponse';
 // import { pushMetric } from '../utapi/utilities';
 
 const requestType = 'objectGet';
@@ -74,8 +74,8 @@ export default function corsPreflight(request, log, callback) {
             return callback(err);
         }
 
-        const resHeaders = gatherCorsResHeaders(corsRule, corsOrigin,
-            corsMethod, corsHeaders);
+        const resHeaders = generateCorsResHeaders(corsRule, corsOrigin,
+            corsMethod, corsHeaders, true);
         // TODO: pushMetric('corsPreflight', log, { bucket: bucketName });
         return callback(null, resHeaders);
     });

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -2,6 +2,7 @@ import UUID from 'node-uuid';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
 import { errors } from 'arsenal';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { cleanUpBucket } from './apiUtils/bucket/bucketCreation';
 import constants from '../../constants';
 import services from '../services';
@@ -125,7 +126,7 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
     };
     const xml = _convertToXml(xmlParams);
 
-    function _storetheMPObject(destinationBucket) {
+    function _storetheMPObject(destinationBucket, corsHeaders) {
         const serverSideEncryption =
             destinationBucket.getServerSideEncryption();
         let cipherBundle = null;
@@ -144,25 +145,27 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                 services.metadataStoreMPObject(MPUbucket.getName(),
                     cipherBundle, metadataStoreParams, log, err => {
                         if (err) {
-                            return callback(err);
+                            return callback(err, null, corsHeaders);
                         }
                         pushMetric('initiateMultipartUpload', log, {
                             authInfo,
                             bucket: bucketName,
                         });
-                        return callback(err, xml);
+                        return callback(err, xml, corsHeaders);
                     });
             });
     }
 
     services.metadataValidateAuthorization(metadataValParams,
         (err, destinationBucket) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, destinationBucket);
             if (err) {
                 log.debug('error processing request', {
                     error: err,
                     method: 'services.metadataValidateAuthorization',
                 });
-                return callback(err);
+                return callback(err, null, corsHeaders);
             }
             if (destinationBucket.hasDeletedFlag() &&
                 accountCanonicalID !== destinationBucket.getOwner()) {
@@ -186,12 +189,14 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                                 // To avoid confusing user with error
                                 // from cleaning up
                                 // bucket return InternalError
-                                return callback(errors.InternalError);
+                                return callback(errors.InternalError,
+                                    null, corsHeaders);
                             }
-                            return _storetheMPObject(destinationBucket);
+                            return _storetheMPObject(destinationBucket,
+                                corsHeaders);
                         });
             }
-            return _storetheMPObject(destinationBucket);
+            return _storetheMPObject(destinationBucket, corsHeaders);
         });
     return undefined;
 }

--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -3,6 +3,7 @@ import escapeForXML from '../utilities/escapeForXML';
 import querystring from 'querystring';
 
 import constants from '../../constants';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
 import { pushMetric } from '../utapi/utilities';
 import { errors } from 'arsenal';
@@ -189,9 +190,9 @@ export default function listMultipartUploads(authInfo,
         },
         function getMPUBucket(bucket, next) {
             services.getMPUBucket(bucket, bucketName, log,
-                (err, mpuBucket) => next(err, mpuBucket));
+                (err, mpuBucket) => next(err, bucket, mpuBucket));
         },
-        function waterfall2(mpuBucket, next) {
+        function waterfall2(bucket, mpuBucket, next) {
             let splitter = constants.splitter;
             // BACKWARD: Remove to remove the old splitter
             if (mpuBucket.getMdBucketModelVersion() < 2) {
@@ -200,7 +201,7 @@ export default function listMultipartUploads(authInfo,
             let maxUploads = query['max-uploads'] !== undefined ?
                 Number.parseInt(query['max-uploads'], 10) : 1000;
             if (maxUploads < 0) {
-                return callback(errors.InvalidArgument);
+                return callback(errors.InvalidArgument, bucket);
             }
             if (maxUploads > constants.listingHardLimit) {
                 maxUploads = constants.listingHardLimit;
@@ -216,12 +217,14 @@ export default function listMultipartUploads(authInfo,
                 splitter,
             };
             services.getMultipartUploadListing(mpuBucketName, listingParams,
-                log, next);
+                log, (err, list) => next(err, bucket, list));
             return undefined;
         },
-    ], (err, list) => {
+    ], (err, bucket, list) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const xmlParams = {
             bucketName,
@@ -236,6 +239,6 @@ export default function listMultipartUploads(authInfo,
             authInfo,
             bucket: bucketName,
         });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -2,6 +2,7 @@ import async from 'async';
 import querystring from 'querystring';
 
 import constants from '../../constants';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
@@ -108,7 +109,7 @@ export default function listParts(authInfo, request, log, callback) {
             services.metadataValidateAuthorization(metadataValParams,
                 (err, destinationBucket) => {
                     if (err) {
-                        return next(err);
+                        return next(err, destinationBucket, null);
                     }
                     if (destinationBucket.policies) {
                         // TODO: Check bucket policies to see if user is granted
@@ -120,13 +121,19 @@ export default function listParts(authInfo, request, log, callback) {
                         metadataValMPUparams.requestType =
                             'bucketPolicyGoAhead';
                     }
-                    return next();
+                    return next(null, destinationBucket);
                 });
         },
-        function waterfall2(next) {
-            services.metadataValidateMultipart(metadataValMPUparams, next);
+        function waterfall2(destBucket, next) {
+            services.metadataValidateMultipart(metadataValMPUparams,
+                (err, mpuBucket, mpuOverview) => {
+                    if (err) {
+                        return next(err, destBucket, null);
+                    }
+                    return next(null, destBucket, mpuBucket, mpuOverview);
+                });
         },
-        function waterfall3(mpuBucket, mpuOverviewArray, next) {
+        function waterfall3(destBucket, mpuBucket, mpuOverviewArray, next) {
             // BACKWARD: Remove to remove the old splitter
             if (mpuBucket.getMdBucketModelVersion() < 2) {
                 splitter = constants.oldSplitter;
@@ -141,11 +148,13 @@ export default function listParts(authInfo, request, log, callback) {
             };
             services.getSomeMPUparts(getPartsParams, (err, storedParts) => {
                 if (err) {
-                    return next(err);
+                    return next(err, destBucket, null);
                 }
-                return next(null, mpuBucket, storedParts, mpuOverviewArray);
+                return next(null, destBucket, mpuBucket, storedParts,
+                    mpuOverviewArray);
             });
-        }, function waterfall4(mpuBucket, storedParts, mpuOverviewArray, next) {
+        }, function waterfall4(destBucket, mpuBucket, storedParts,
+            mpuOverviewArray, next) {
             const encodingFn = encoding === 'url'
                 ? querystring.escape : escapeForXML;
             const isTruncated = storedParts.IsTruncated;
@@ -215,8 +224,12 @@ export default function listParts(authInfo, request, log, callback) {
                 authInfo,
                 bucket: bucketName,
             });
-            next(null, xml.join(''));
+            next(null, destBucket, xml.join(''));
         },
-    ], callback);
+    ], (err, destinationBucket, xml) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, destinationBucket);
+        return callback(err, xml, corsHeaders);
+    });
     return undefined;
 }

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -7,6 +7,7 @@ import { parseString } from 'xml2js';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
 import bucketShield from './apiUtils/bucket/bucketShield';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import metadata from '../metadata/wrapper';
 import services from '../services';
 import vault from '../auth/vault';
@@ -300,10 +301,11 @@ function multiObjectDelete(authInfo, request, log, callback) {
                 });
         },
         function checkBucketMetadata(quietSetting, errorResults, inPlay, next) {
-            // if no objects in play, no need to check ACLs,
-            // just move on
-            if (inPlay.length === 0) {
-                return next(null, quietSetting, errorResults, inPlay);
+            // if no objects in play, no need to check ACLs / get metadata,
+            // just move on if there is no Origin header
+            if (inPlay.length === 0 && !request.headers.origin) {
+                return next(null, quietSetting, errorResults, inPlay,
+                    undefined);
             }
             return metadata.getBucket(bucketName, log, (err, bucketMD) => {
                 if (err) {
@@ -314,6 +316,11 @@ function multiObjectDelete(authInfo, request, log, callback) {
                 // check whether bucket has transient or deleted flag
                 if (bucketShield(bucketMD, 'objectDelete')) {
                     return next(errors.NoSuchBucket);
+                }
+                // if no objects in play, no need to check ACLs
+                if (inPlay.length === 0) {
+                    return next(null, quietSetting, errorResults, inPlay,
+                        bucketMD);
                 }
                 if (!isBucketAuthorized(bucketMD, 'objectDelete',
                     canonicalID)) {
@@ -330,20 +337,28 @@ function multiObjectDelete(authInfo, request, log, callback) {
                     // async.forEachLimit below will not actually
                     // make any calls to metadata or data but will continue on
                     // to the next step to build xml
-                    return next(null, quietSetting, errorResults, []);
+                    return next(null, quietSetting, errorResults, [], bucketMD);
                 }
-                return next(null, quietSetting, errorResults, inPlay);
+                return next(null, quietSetting, errorResults, inPlay, bucketMD);
             });
         },
         function getObjMetadataAndDeleteStep(quietSetting, errorResults, inPlay,
-            next) {
+            bucket, next) {
             return getObjMetadataAndDelete(bucketName, quietSetting,
-                errorResults, inPlay, log, next);
+                errorResults, inPlay, log, (err, quietSetting, errorResults,
+                numOfObjects, successfullyDeleted,
+                totalContentLengthDeleted) => {
+                    next(err, quietSetting, errorResults,
+                    numOfObjects, successfullyDeleted,
+                    totalContentLengthDeleted, bucket);
+                });
         },
-    ], (err, quietSetting, errorResults, numOfObjects, successfullyDeleted,
-            totalContentLengthDeleted) => {
+    ], (err, quietSetting, errorResults, numOfObjects,
+        successfullyDeleted, totalContentLengthDeleted, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const xml = _formatXML(quietSetting, errorResults,
             successfullyDeleted);
@@ -353,6 +368,6 @@ function multiObjectDelete(authInfo, request, log, callback) {
             byteLength: totalContentLengthDeleted,
             numberOfObjects: numOfObjects,
         });
-        return callback(null, xml);
+        return callback(null, xml, corsHeaders);
     });
 }

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -1,5 +1,6 @@
 import async from 'async';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import data from '../data/wrapper';
 import services from '../services';
@@ -42,7 +43,7 @@ function multipartDelete(authInfo, request, log, callback) {
             services.metadataValidateAuthorization(metadataValParams,
                 (err, destinationBucket) => {
                     if (err) {
-                        return next(err);
+                        return next(err, destinationBucket);
                     }
                     if (destinationBucket.policies) {
                         // TODO: Check bucket policies to see if user is granted
@@ -54,28 +55,35 @@ function multipartDelete(authInfo, request, log, callback) {
                         metadataValMPUparams.requestType =
                             'bucketPolicyGoAhead';
                     }
-                    return next();
+                    return next(null, destinationBucket);
                 });
         },
-        function checkMPUval(next) {
-            services.metadataValidateMultipart(metadataValParams, next);
+        function checkMPUval(destBucket, next) {
+            services.metadataValidateMultipart(metadataValParams,
+                (err, mpuBucket, mpuOverviewArray) => {
+                    if (err) {
+                        return next(err, destBucket);
+                    }
+                    return next(err, mpuBucket, mpuOverviewArray, destBucket);
+                });
         },
-        function getPartLocations(mpuBucket, mpuOverviewArray, next) {
+        function getPartLocations(mpuBucket, mpuOverviewArray, destBucket,
+            next) {
             services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
                     if (err) {
-                        return next(err);
+                        return next(err, destBucket);
                     }
                     const storedParts = result.Contents;
-                    return next(null, mpuBucket, storedParts);
+                    return next(null, mpuBucket, storedParts, destBucket);
                 });
         },
-        function deleteData(mpuBucket, storedParts, next) {
+        function deleteData(mpuBucket, storedParts, destBucket, next) {
             // The locations were sent to metadata as an array
             // under partLocations.  Pull the partLocations.
             let locations = storedParts.map(item => item.value.partLocations);
             if (locations.length === 0) {
-                return next(null, mpuBucket, storedParts);
+                return next(null, mpuBucket, storedParts, destBucket);
             }
             // flatten the array
             locations = [].concat.apply([], locations);
@@ -86,9 +94,9 @@ function multipartDelete(authInfo, request, log, callback) {
                     }
                     cb();
                 });
-            }, () => next(null, mpuBucket, storedParts));
+            }, () => next(null, mpuBucket, storedParts, destBucket));
         },
-        function deleteMetadata(mpuBucket, storedParts, next) {
+        function deleteMetadata(mpuBucket, storedParts, destBucket, next) {
             let splitter = constants.splitter;
             // BACKWARD: Remove to remove the old splitter
             if (mpuBucket.getMdBucketModelVersion() < 2) {
@@ -102,14 +110,18 @@ function multipartDelete(authInfo, request, log, callback) {
             services.batchDeleteObjectMetadata(mpuBucket.getName(),
                 keysToDelete, log, err => {
                     if (err) {
-                        return next(err);
+                        return next(err, destBucket);
                     }
                     pushMetric('abortMultipartUpload', log, {
                         authInfo,
                         bucket: bucketName,
                     });
-                    return next(null);
+                    return next(null, destBucket);
                 });
         },
-    ], callback);
+    ], (err, destinationBucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, destinationBucket);
+        return callback(err, corsHeaders);
+    });
 }

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -1,6 +1,7 @@
 import async from 'async';
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import data from '../data/wrapper';
 import kms from '../kms/wrapper';
 import { logger } from '../utilities/logger';
@@ -140,28 +141,46 @@ function objectCopy(authInfo, request, sourceBucket,
     }
 
     return async.waterfall([
-        function checkSourceAuthorization(next) {
+        function checkDestAuth(next) {
+            return services.metadataValidateAuthorization(valPutParams,
+                (err, destBucketMD, destObjMD) => {
+                    if (err) {
+                        log.debug('error validating put part of request',
+                        { error: err });
+                        return next(err, destBucketMD);
+                    }
+                    const flag = destBucketMD.hasDeletedFlag()
+                        || destBucketMD.hasTransientFlag();
+                    if (flag) {
+                        log.trace('deleted flag or transient flag ' +
+                        'on destination bucket', { flag });
+                        return next(errors.NoSuchBucket);
+                    }
+                    return next(null, destBucketMD, destObjMD);
+                });
+        },
+        function checkSourceAuthorization(destBucketMD, destObjMD, next) {
             return services.metadataValidateAuthorization(valGetParams,
                 (err, sourceBucketMD, sourceObjMD) => {
                     if (err) {
                         log.debug('error validating get part of request',
                         { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     if (!sourceObjMD) {
                         log.debug('no source object', { sourceObject });
-                        return next(errors.NoSuchKey);
+                        return next(errors.NoSuchKey, destBucketMD);
                     }
                     const headerValResult =
                         validateHeaders(sourceObjMD, request.headers);
                     if (headerValResult.error) {
-                        return next(errors.PreconditionFailed);
+                        return next(errors.PreconditionFailed, destBucketMD);
                     }
                     const storeMetadataParams =
                         _prepMetadata(sourceObjMD, request.headers,
                             sourceIsDestination, authInfo, destObjectKey, log);
                     if (storeMetadataParams.error) {
-                        return next(storeMetadataParams.error);
+                        return next(storeMetadataParams.error, destBucketMD);
                     }
                     let dataLocator;
                     // If 0 byte object just set dataLocator to empty array
@@ -183,24 +202,6 @@ function objectCopy(authInfo, request, sourceBucket,
                                 sourceObjMD['x-amz-server-side-encryption'];
                         }
                     }
-                    return next(null, storeMetadataParams, dataLocator);
-                });
-        },
-        function checkDestAuth(storeMetadataParams, dataLocator, next) {
-            return services.metadataValidateAuthorization(valPutParams,
-                (err, destBucketMD, destObjMD) => {
-                    if (err) {
-                        log.debug('error validating put part of request',
-                        { error: err });
-                        return next(err);
-                    }
-                    const flag = destBucketMD.hasDeletedFlag()
-                        || destBucketMD.hasTransientFlag();
-                    if (flag) {
-                        log.trace('deleted flag or transient flag ' +
-                        'on destination bucket', { flag });
-                        return next(errors.NoSuchBucket);
-                    }
                     return next(null, storeMetadataParams,
                         dataLocator, destBucketMD, destObjMD);
                 });
@@ -214,7 +215,7 @@ function objectCopy(authInfo, request, sourceBucket,
             // and masterKeyId stored properly in metadata
             if (sourceIsDestination || dataLocator.length === 0) {
                 return next(null, storeMetadataParams, dataLocator, destObjMD,
-                    serverSideEncryption);
+                    serverSideEncryption, destBucketMD);
             }
              // dataLocator is an array.  need to get and put all parts
              // For now, copy 1 part at a time. Could increase the second
@@ -276,20 +277,20 @@ function objectCopy(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error transferring data from source',
                         { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     return next(null, storeMetadataParams, results,
-                        destObjMD, serverSideEncryption);
+                        destObjMD, serverSideEncryption, destBucketMD);
                 });
         },
         function storeNewMetadata(storeMetadataParams, destDataGetInfoArr,
-            destObjMD, serverSideEncryption, next) {
+            destObjMD, serverSideEncryption, destBucketMD, next) {
             return services.metadataStoreObject(destBucketName,
                 destDataGetInfoArr,
                 serverSideEncryption, storeMetadataParams, err => {
                     if (err) {
                         log.debug('error storing new metadata', { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     // Clean up any potential orphans in data if object
                     // put is an overwrite of already existing
@@ -307,14 +308,17 @@ function objectCopy(authInfo, request, sourceBucket,
                     const sourceObjSize = storeMetadataParams.size;
                     const destObjPrevSize = destObjMD ?
                         destObjMD['content-length'] : null;
-                    return next(null, storeMetadataParams,
+                    return next(null, destBucketMD, storeMetadataParams,
                         serverSideEncryption, sourceObjSize, destObjPrevSize);
                 });
         },
-    ], (err, storeMetadataParams, serverSideEncryption, sourceObjSize,
-        destObjPrevSize) => {
+    ], (err, destBucketMD, storeMetadataParams, serverSideEncryption,
+        sourceObjSize, destObjPrevSize) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, destBucketMD);
+
         if (err) {
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const xml = [
             '<?xml version="1.0" encoding="UTF-8"?>',
@@ -324,7 +328,7 @@ function objectCopy(authInfo, request, sourceBucket,
             '<ETag>&quot;', storeMetadataParams.contentMD5, '&quot;</ETag>',
             '</CopyObjectResult>',
         ].join('');
-        const additionalHeaders = {};
+        const additionalHeaders = corsHeaders || {};
         if (serverSideEncryption) {
             additionalHeaders['x-amz-server-side-encryption'] =
                 serverSideEncryption.algorithm;

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -1,5 +1,6 @@
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
 import validateHeaders from '../utilities/validateHeaders';
 import { pushMetric } from '../utapi/utilities';
@@ -32,19 +33,21 @@ export default function objectDelete(authInfo, request, log, cb) {
     };
     return services.metadataValidateAuthorization(valParams,
         (err, bucket, objMD) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, bucket);
             if (err) {
                 log.debug('error processing request', {
                     error: err,
                     method: 'metadataValidateAuthorization',
                 });
-                return cb(err);
+                return cb(err, corsHeaders);
             }
             if (!objMD) {
-                return cb(errors.NoSuchKey);
+                return cb(errors.NoSuchKey, corsHeaders);
             }
             const headerValResult = validateHeaders(objMD, request.headers);
             if (headerValResult.error) {
-                return cb(headerValResult.error);
+                return cb(headerValResult.error, corsHeaders);
             }
             if (objMD['content-length']) {
                 log.end().addDefaultFields({
@@ -54,7 +57,7 @@ export default function objectDelete(authInfo, request, log, cb) {
             return services.deleteObject(bucketName, objMD, objectKey, log,
                 err => {
                     if (err) {
-                        return cb(err);
+                        return cb(err, corsHeaders);
                     }
                     pushMetric('deleteObject', log, {
                         authInfo,
@@ -62,7 +65,7 @@ export default function objectDelete(authInfo, request, log, cb) {
                         byteLength: objMD['content-length'],
                         numberOfObjects: 1,
                     });
-                    return cb();
+                    return cb(null, corsHeaders);
                 });
         });
 }

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -1,6 +1,7 @@
 import { errors } from 'arsenal';
 
 import { parseRange } from './apiUtils/object/parseRange';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import services from '../services';
 import validateHeaders from '../utilities/validateHeaders';
@@ -29,22 +30,24 @@ function objectGet(authInfo, request, log, callback) {
 
     services.metadataValidateAuthorization(mdValParams, (err, bucket,
         objMD) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.debug('error processing request', { error: err });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         if (!objMD) {
-            return callback(errors.NoSuchKey);
+            return callback(errors.NoSuchKey, null, corsHeaders);
         }
         const headerValResult = validateHeaders(objMD, request.headers);
         if (headerValResult.error) {
-            return callback(headerValResult.error);
+            return callback(headerValResult.error, null, corsHeaders);
         }
-        const responseMetaHeaders = collectResponseHeaders(objMD);
+        const responseMetaHeaders = collectResponseHeaders(objMD, corsHeaders);
         // 0 bytes file
         if (objMD.location === null) {
             if (request.headers.range) {
-                return callback(errors.InvalidRange);
+                return callback(errors.InvalidRange, null, corsHeaders);
             }
             pushMetric('getObject', log, {
                 authInfo,
@@ -64,7 +67,7 @@ function objectGet(authInfo, request, log, callback) {
             range = parseRangeRes.range;
             const error = parseRangeRes.error;
             if (error) {
-                return callback(error);
+                return callback(error, null, corsHeaders);
             }
             if (range) {
                 // End of range should be included so + 1
@@ -84,7 +87,7 @@ function objectGet(authInfo, request, log, callback) {
         // for objects with multiple parts
         if (range && dataLocator.length > 1 &&
             dataLocator[0].start === undefined) {
-            return callback(errors.NotImplemented);
+            return callback(errors.NotImplemented, null, corsHeaders);
         }
         if (objMD['x-amz-server-side-encryption']) {
             for (let i = 0; i < dataLocator.length; i++) {

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -1,8 +1,9 @@
 import { errors } from 'arsenal';
 
 import aclUtils from '../utilities/aclUtils';
-import { pushMetric } from '../utapi/utilities';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
+import { pushMetric } from '../utapi/utilities';
 import services from '../services';
 import vault from '../auth/vault';
 
@@ -61,15 +62,17 @@ export default function objectGetACL(authInfo, request, log, callback) {
 
     services.metadataValidateAuthorization(metadataValParams,
         (err, bucket, objectMD) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, bucket);
             if (err) {
                 log.trace('request authorization failed',
                     { method: 'objectGetACL', error: err });
-                return callback(err);
+                return callback(err, null, corsHeaders);
             }
             if (!objectMD) {
                 log.trace('error processing request',
                     { method: 'objectGetACL', error: err });
-                return callback(errors.NoSuchKey);
+                return callback(errors.NoSuchKey, null, corsHeaders);
             }
             const objectACL = objectMD.acl;
             const allSpecificGrants = [].concat(
@@ -106,7 +109,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                     authInfo,
                     bucket: bucketName,
                 });
-                return callback(null, xml);
+                return callback(null, xml, corsHeaders);
             }
             /**
             * Build array of all canonicalIDs used in ACLs so duplicates
@@ -140,7 +143,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                     authInfo,
                     bucket: bucketName,
                 });
-                return callback(null, xml);
+                return callback(null, xml, corsHeaders);
             }
             /**
             * If acl's set by account canonicalID,
@@ -151,7 +154,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                 if (err) {
                     log.trace('error processing request',
                         { method: 'objectGetACL', error: err });
-                    return callback(err);
+                    return callback(err, null, corsHeaders);
                 }
                 const individualGrants = canonicalIDs.map(canonicalID => {
                 /**
@@ -181,7 +184,7 @@ export default function objectGetACL(authInfo, request, log, callback) {
                     authInfo,
                     bucket: bucketName,
                 });
-                return callback(null, xml);
+                return callback(null, xml, corsHeaders);
             });
         });
 }

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,5 +1,6 @@
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import services from '../services';
 import validateHeaders from '../utilities/validateHeaders';
@@ -29,21 +30,24 @@ export default function objectHead(authInfo, request, log, callback) {
 
     return services.metadataValidateAuthorization(metadataValParams,
         (err, bucket, objMD) => {
+            const corsHeaders = collectCorsHeaders(request.headers.origin,
+                request.method, bucket);
             if (err) {
                 log.debug('error processing request', {
                     error: err,
                     method: 'metadataValidateAuthorization',
                 });
-                return callback(err);
+                return callback(err, corsHeaders);
             }
             if (!objMD) {
-                return callback(errors.NoSuchKey);
+                return callback(errors.NoSuchKey, corsHeaders);
             }
             const headerValResult = validateHeaders(objMD, request.headers);
             if (headerValResult.error) {
-                return callback(headerValResult.error);
+                return callback(headerValResult.error, corsHeaders);
             }
-            const responseMetaHeaders = collectResponseHeaders(objMD);
+            const responseMetaHeaders = collectResponseHeaders(objMD,
+                corsHeaders);
             pushMetric('headObject', log, {
                 authInfo,
                 bucket: bucketName,

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -5,6 +5,7 @@ import services from '../services';
 import aclUtils from '../utilities/aclUtils';
 import utils from '../utils';
 import { cleanUpBucket } from './apiUtils/bucket/bucketCreation';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { dataStore } from './apiUtils/object/storeObject';
 import constants from '../../constants';
 import { logger } from '../utilities/logger';
@@ -119,7 +120,7 @@ function _storeIt(bucketName, objectKey, objMD, authInfo, canonicalID,
                                 newByteLength: size,
                                 oldByteLength: prevContentLen,
                             });
-                            return callback(null, contentMD5, prevContentLen);
+                            return callback(null, contentMD5);
                         });
             });
     }
@@ -141,7 +142,7 @@ function _storeIt(bucketName, objectKey, objMD, authInfo, canonicalID,
                     newByteLength: size,
                     oldByteLength: prevContentLen,
                 });
-                return callback(null, contentMD5, prevContentLen);
+                return callback(null, contentMD5);
             });
 }
 
@@ -186,12 +187,14 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
 
     return services.metadataValidateAuthorization(valParams, (err, bucket,
         objMD) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.trace('error processing request', {
                 error: err,
                 method: 'services.metadataValidateAuthorization',
             });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         if (bucket.hasDeletedFlag() &&
             canonicalID !== bucket.getOwner()) {
@@ -216,24 +219,31 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                             // To avoid confusing user with error
                             // from cleaning up
                             // bucket return InternalError
-                            return callback(errors.InternalError);
+                            return callback(errors.InternalError, null,
+                                corsHeaders);
                         }
                         if (serverSideEncryption) {
                             return kms.createCipherBundle(
                                 serverSideEncryption,
                                 log, (err, cipherBundle) => {
                                     if (err) {
-                                        return callback(errors.InternalError);
+                                        return callback(errors.InternalError,
+                                            null, corsHeaders);
                                     }
                                     return _storeIt(bucketName, objectKey,
                                         objMD, authInfo, canonicalID,
                                         cipherBundle, request,
-                                        streamingV4Params, log, callback);
+                                        streamingV4Params, log,
+                                            (err, contentMD5) =>
+                                                callback(err, contentMD5,
+                                                    corsHeaders));
                                 });
                         }
                         return _storeIt(bucketName, objectKey, objMD,
                                         authInfo, canonicalID, null, request,
-                                        streamingV4Params, log, callback);
+                                        streamingV4Params, log,
+                                (err, contentMD5) =>
+                                    callback(err, contentMD5, corsHeaders));
                     });
         }
         if (serverSideEncryption) {
@@ -241,14 +251,19 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 serverSideEncryption,
                 log, (err, cipherBundle) => {
                     if (err) {
-                        return callback(errors.InternalError);
+                        return callback(errors.InternalError, null,
+                            corsHeaders);
                     }
                     return _storeIt(bucketName, objectKey, objMD,
                                     authInfo, canonicalID, cipherBundle,
-                                    request, streamingV4Params, log, callback);
+                                    request, streamingV4Params, log,
+                            (err, contentMD5) =>
+                                callback(err, contentMD5, corsHeaders));
                 });
         }
         return _storeIt(bucketName, objectKey, objMD, authInfo, canonicalID,
-                        null, request, streamingV4Params, log, callback);
+                        null, request, streamingV4Params, log,
+                        (err, contentMD5) =>
+                            callback(err, contentMD5, corsHeaders));
     });
 }

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -4,6 +4,7 @@ import async from 'async';
 import acl from '../metadata/acl';
 import aclUtils from '../utilities/aclUtils';
 import { pushMetric } from '../utapi/utilities';
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import services from '../services';
 import vault from '../auth/vault';
@@ -90,7 +91,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
         next => services.metadataValidateAuthorization(metadataValParams, next),
         (bucket, objectMD, next) => {
             if (!objectMD) {
-                return next(errors.NoSuchKey);
+                return next(errors.NoSuchKey, bucket);
             }
             // If not setting acl through headers, parse body
             let jsonGrants;
@@ -107,7 +108,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
                             objectMD, jsonGrants, aclOwnerID));
                 }
                 // If no ACLs sent with request at all
-                return next(errors.MalformedXML);
+                return next(errors.MalformedXML, bucket);
             }
             /**
             * If acl set in headers (including canned acl) pass bucket and
@@ -132,7 +133,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
                     ACL: request.post,
                     method: 'objectPutACL',
                 });
-                return next(errors.AccessDenied);
+                return next(errors.AccessDenied, bucket);
             }
 
             /**
@@ -168,7 +169,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
                         if (possibleGroups.indexOf(grantee.URI[0]) < 0) {
                             log.trace('invalid user group',
                                  { userGroup: grantee.URI[0] });
-                            return next(errors.InvalidArgument);
+                            return next(errors.InvalidArgument, bucket);
                         }
                         return usersIdentifiedByGroup.push({
                             identifier: grantee.URI[0],
@@ -197,7 +198,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
                         log.trace('invalid user group',
                              { userGroup: usersIdentifiedByGroup[i]
                                  .identifier });
-                        return next(errors.InvalidArgument);
+                        return next(errors.InvalidArgument, bucket);
                     }
                 }
                 /** TODO: Consider whether want to verify with Vault
@@ -216,7 +217,7 @@ export default function objectPutACL(authInfo, request, log, cb) {
                         if (err) {
                             log.trace('error looking up canonical ids',
                                 { error: err, method: 'getCanonicalIDs' });
-                            return next(err);
+                            return next(err, bucket);
                         }
                         const reconstructedUsersIdentifiedByEmail = aclUtils
                             .reconstructUsersIdentifiedByEmail(results,
@@ -242,19 +243,21 @@ export default function objectPutACL(authInfo, request, log, cb) {
             // Add acl's to object metadata
             acl.addObjectACL(bucket, objectKey, objectMD, ACLParams, log, next);
         },
-    ], err => {
+    ], (err, bucket) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.trace('error processing request', {
                 error: err,
                 method: 'objectPutACL',
             });
-            return cb(err);
+            return cb(err, corsHeaders);
         }
         log.trace('processed request successfully in object put acl api');
         pushMetric('putObjectAcl', log, {
             authInfo,
             bucket: bucketName,
         });
-        return cb();
+        return cb(null, corsHeaders);
     });
 }

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -1,6 +1,7 @@
 import async from 'async';
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import data from '../data/wrapper';
 import kms from '../kms/wrapper';
@@ -37,7 +38,6 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         requestType: 'objectGet',
         log,
     };
-
 
     const partNumber = Number.parseInt(request.query.partNumber, 10);
     // AWS caps partNumbers at 10,000
@@ -77,40 +77,14 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
     };
 
     return async.waterfall([
-        function checkSourceAuthorization(next) {
-            return services.metadataValidateAuthorization(valGetParams,
-                (err, sourceBucketMD, sourceObjMD) => {
-                    if (err) {
-                        log.debug('error validating get part of request',
-                        { error: err });
-                        return next(err);
-                    }
-                    if (!sourceObjMD) {
-                        log.debug('no source object', { sourceObject });
-                        return next(errors.NoSuchKey);
-                    }
-                    const headerValResult =
-                        validateHeaders(sourceObjMD, request.headers);
-                    if (headerValResult.error) {
-                        return next(errors.PreconditionFailed);
-                    }
-                    const copyLocator = setUpCopyLocator(sourceObjMD,
-                        request.headers['x-amz-copy-source-range'], log);
-                    if (copyLocator.error) {
-                        return next(copyLocator.error);
-                    }
-                    return next(null, copyLocator.dataLocator,
-                        copyLocator.copyObjectSize);
-                });
-        },
-        function checkDestAuth(dataLocator, copyObjectSize, next) {
+        function checkDestAuth(next) {
             return services.metadataValidateAuthorization(valPutParams,
                 (err, destBucketMD) => {
                     if (err) {
                         log.debug('error validating authorization for ' +
                         'destination bucket',
                         { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     const flag = destBucketMD.hasDeletedFlag()
                         || destBucketMD.hasTransientFlag();
@@ -119,8 +93,33 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                         'on destination bucket', { flag });
                         return next(errors.NoSuchBucket);
                     }
-                    return next(null, dataLocator, destBucketMD,
-                        copyObjectSize);
+                    return next(null, destBucketMD);
+                });
+        },
+        function checkSourceAuthorization(destBucketMD, next) {
+            return services.metadataValidateAuthorization(valGetParams,
+                (err, sourceBucketMD, sourceObjMD) => {
+                    if (err) {
+                        log.debug('error validating get part of request',
+                        { error: err });
+                        return next(err, destBucketMD);
+                    }
+                    if (!sourceObjMD) {
+                        log.debug('no source object', { sourceObject });
+                        return next(errors.NoSuchKey, destBucketMD);
+                    }
+                    const headerValResult =
+                        validateHeaders(sourceObjMD, request.headers);
+                    if (headerValResult.error) {
+                        return next(errors.PreconditionFailed, destBucketMD);
+                    }
+                    const copyLocator = setUpCopyLocator(sourceObjMD,
+                        request.headers['x-amz-copy-source-range'], log);
+                    if (copyLocator.error) {
+                        return next(copyLocator.error, destBucketMD);
+                    }
+                    return next(null, copyLocator.dataLocator, destBucketMD,
+                        copyLocator.copyObjectSize);
                 });
         },
         function checkMPUBucketAuth(dataLocator, destBucketMD,
@@ -130,7 +129,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err) {
                         log.trace('error authorizing based on mpu bucket',
                         { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     return next(null, dataLocator,
                         destBucketMD, mpuBucket, copyObjectSize);
@@ -144,7 +143,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             if (dataLocator.length === 0) {
                 return next(null, [], constants.emptyFileMd5,
                     copyObjectSize, mpuBucket,
-                    serverSideEncryption);
+                    serverSideEncryption, destBucketMD);
             }
             // totalHash will be sent through the RelayMD5Sum transform streams
             // to collect the md5 from multiple streams
@@ -229,17 +228,18 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error transferring data from source',
                         { error: err, method: 'goGetData' });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     // Digest the final combination of all of the part streams
                     totalHash = totalHash.digest('hex');
                     return next(null, locations, totalHash,
                         copyObjectSize, mpuBucket,
-                        serverSideEncryption);
+                        serverSideEncryption, destBucketMD);
                 });
         },
         function getExistingPartInfo(locations, totalHash,
-            copyObjectSize, mpuBucket, serverSideEncryption, next) {
+            copyObjectSize, mpuBucket, serverSideEncryption, destBucketMD,
+            next) {
             const partKey =
                 `${uploadId}${constants.splitter}${paddedPartNumber}`;
             metadata.getObjectMD(mpuBucket.getName(), partKey, log,
@@ -248,7 +248,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err && !err.NoSuchKey) {
                         log.debug('error getting current part (if any)',
                         { error: err });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     let oldLocations;
                     if (result) {
@@ -261,12 +261,12 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     }
                     return next(null, locations, totalHash,
                         copyObjectSize, mpuBucket, serverSideEncryption,
-                        oldLocations);
+                        oldLocations, destBucketMD);
                 });
         },
         function storeNewPartMetadata(locations, totalHash,
             copyObjectSize, mpuBucket, serverSideEncryption,
-            oldLocations, next) {
+            oldLocations, destBucketMD, next) {
             const lastModified = new Date().toJSON();
             const metaStoreParams = {
                 partNumber: paddedPartNumber,
@@ -281,7 +281,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                     if (err) {
                         log.debug('error storing new metadata',
                         { error: err, method: 'storeNewPartMetadata' });
-                        return next(err);
+                        return next(err, destBucketMD);
                     }
                     // Clean up the old data now that new metadata (with new
                     // data locations) has been stored
@@ -290,15 +290,17 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             logger.newRequestLoggerFromSerializedUids(
                                 log.getSerializedUids()));
                     }
-                    return next(null, totalHash, lastModified,
+                    return next(null, destBucketMD, totalHash, lastModified,
                         serverSideEncryption);
                 });
         },
-    ], (err, totalHash, lastModified, serverSideEncryption) => {
+    ], (err, destBucketMD, totalHash, lastModified, serverSideEncryption) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, destBucketMD);
         if (err) {
             log.trace('error from copy part waterfall',
             { error: err });
-            return callback(err);
+            return callback(err, null, corsHeaders);
         }
         const xml = [
             '<?xml version="1.0" encoding="UTF-8"?>',
@@ -310,7 +312,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         ].join('');
         // TODO: Add version headers for response
         // (if source is a version).
-        const additionalHeaders = {};
+        const additionalHeaders = corsHeaders || {};
         if (serverSideEncryption) {
             additionalHeaders['x-amz-server-side-encryption'] =
                 serverSideEncryption.algorithm;

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -2,12 +2,13 @@ import assert from 'assert';
 import async from 'async';
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import data from '../data/wrapper';
-import kms from '../kms/wrapper';
 import { dataStore } from './apiUtils/object/storeObject';
-import metadata from '../metadata/wrapper';
 import { isBucketAuthorized } from './apiUtils/authorization/aclChecks';
+import kms from '../kms/wrapper';
+import metadata from '../metadata/wrapper';
 import { pushMetric } from '../utapi/utilities';
 import { logger } from '../utilities/logger';
 
@@ -79,6 +80,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
     const uploadId = request.query.uploadId;
     const mpuBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
     const objectKey = request.objectKey;
+
     return async.waterfall([
         // Get the destination bucket.
         next => metadata.getBucket(bucketName, log, (err, bucket) => {
@@ -90,7 +92,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                     error: err,
                     method: 'objectPutPart::metadata.getBucket',
                 });
-                return next(err);
+                return next(err, bucket);
             }
             return next(null, bucket);
         }),
@@ -101,7 +103,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
             const requestType = 'objectPut';
             if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
                 log.debug('access denied for user on bucket', { requestType });
-                return next(errors.AccessDenied);
+                return next(errors.AccessDenied, bucket);
             }
             return next(null, bucket);
         },
@@ -116,36 +118,36 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             'the destination bucket', {
                                 error: err,
                             });
-                        return next(err);
+                        return next(err, bucket);
                     }
-                    return next(null, res);
+                    return next(null, res, bucket);
                 });
             }
             // The bucket does not have server-side encryption, so pass `null`
-            return next(null, null);
+            return next(null, null, bucket);
         },
         // Get the MPU shadow bucket.
-        (cipherBundle, next) => metadata.getBucket(mpuBucketName, log,
+        (cipherBundle, bucket, next) => metadata.getBucket(mpuBucketName, log,
             (err, mpuBucket) => {
                 if (err && err.NoSuchBucket) {
-                    return next(errors.NoSuchUpload);
+                    return next(errors.NoSuchUpload, bucket);
                 }
                 if (err) {
                     log.error('error getting the shadow mpu bucket', {
                         error: err,
                         method: 'objectPutPart::metadata.getBucket',
                     });
-                    return next(err);
+                    return next(err, bucket);
                 }
                 let splitter = constants.splitter;
                 // BACKWARD: Remove to remove the old splitter
                 if (mpuBucket.getMdBucketModelVersion() < 2) {
                     splitter = constants.oldSplitter;
                 }
-                return next(null, cipherBundle, splitter);
+                return next(null, cipherBundle, splitter, bucket);
             }),
         // Check authorization of the MPU shadow bucket.
-        (cipherBundle, splitter, next) => {
+        (cipherBundle, splitter, bucket, next) => {
             const mpuOverviewKey = _getOverviewKey(splitter, objectKey,
                 uploadId);
             return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, log,
@@ -155,19 +157,19 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             error: err,
                             method: 'objectPutPart::metadata.getObjectMD',
                         });
-                        return next(err);
+                        return next(err, bucket);
                     }
                     const initiatorID = res.initiator.ID;
                     const requesterID = authInfo.isRequesterAnIAMUser() ?
                         authInfo.getArn() : authInfo.getCanonicalID();
                     if (initiatorID !== requesterID) {
-                        return next(errors.AccessDenied);
+                        return next(errors.AccessDenied, bucket);
                     }
-                    return next(null, cipherBundle, splitter);
+                    return next(null, cipherBundle, splitter, bucket);
                 });
         },
         // Get any pre-existing part.
-        (cipherBundle, splitter, next) => {
+        (cipherBundle, splitter, bucket, next) => {
             const paddedPartNumber = _getPaddedPartNumber(partNumber);
             const partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
             return metadata.getObjectMD(mpuBucketName, partKey, log,
@@ -178,7 +180,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             error: err,
                             method: 'objectPutPart::metadata.getObjectMD',
                         });
-                        return next(err);
+                        return next(err, bucket);
                     }
                     let prevObjectSize = null;
                     let oldLocations = null;
@@ -193,11 +195,11 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             res.partLocations : [res.partLocations];
                     }
                     return next(null, cipherBundle, partKey, prevObjectSize,
-                        oldLocations);
+                        oldLocations, bucket);
                 });
         },
         // Store in data backend.
-        (cipherBundle, partKey, prevObjectSize, oldLocations, next) => {
+        (cipherBundle, partKey, prevObjectSize, oldLocations, bucket, next) => {
             const objectKeyContext = {
                 bucketName,
                 owner: canonicalID,
@@ -206,15 +208,15 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
             return dataStore(objectKeyContext, cipherBundle, request, size,
                 streamingV4Params, log, (err, dataGetInfo, hexDigest) => {
                     if (err) {
-                        return next(err);
+                        return next(err, bucket);
                     }
                     return next(null, dataGetInfo, hexDigest, cipherBundle,
-                        partKey, prevObjectSize, oldLocations);
+                        partKey, prevObjectSize, oldLocations, bucket);
                 });
         },
         // Store data locations in metadata and delete any overwritten data.
         (dataGetInfo, hexDigest, cipherBundle, partKey, prevObjectSize,
-            oldLocations, next) => {
+            oldLocations, bucket, next) => {
             // Use an array to be consistent with objectPutCopyPart where there
             // could be multiple locations.
             const partLocations = [dataGetInfo];
@@ -243,7 +245,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             error: err,
                             method: 'objectPutPart::metadata.putObjectMD',
                         });
-                        return next(err);
+                        return next(err, bucket);
                     }
                     // Clean up any old data now that new metadata (with new
                     // data locations) has been stored.
@@ -253,16 +255,18 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                             .newRequestLoggerFromSerializedUids(log
                             .getSerializedUids()));
                     }
-                    return next(null, hexDigest, prevObjectSize);
+                    return next(null, bucket, hexDigest, prevObjectSize);
                 });
         },
-    ], (err, hexDigest, prevObjectSize) => {
+    ], (err, bucket, hexDigest, prevObjectSize) => {
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         if (err) {
             log.error('error in object put part (upload part)', {
                 error: err,
                 method: 'objectPutPart',
             });
-            return cb(err);
+            return cb(err, null, corsHeaders);
         }
         pushMetric('uploadPart', log, {
             authInfo,
@@ -270,6 +274,6 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
             newByteLength: size,
             oldByteLength: prevObjectSize,
         });
-        return cb(null, hexDigest);
+        return cb(null, hexDigest, corsHeaders);
     });
 }

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -1,5 +1,6 @@
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import metadata from '../metadata/wrapper';
 import bucketShield from './apiUtils/bucket/bucketShield';
@@ -20,17 +21,19 @@ import { pushMetric } from '../utapi/utilities';
  * @param {string} bucketName - bucket name from request
  * @param {string} objectKey - object key from request (or as translated in
  * websiteGet)
+ * @param {object} corsHeaders - CORS-related response headers
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
 function _errorActions(err, errorDocument, routingRules,
-    bucketName, objectKey, log, callback) {
+    bucketName, objectKey, corsHeaders, log, callback) {
     const errRoutingRule = findRoutingRule(routingRules,
         objectKey, err.code);
     if (errRoutingRule) {
         // route will redirect
-        return callback(err, false, null, null, errRoutingRule, objectKey);
+        return callback(err, false, null, corsHeaders, errRoutingRule,
+            objectKey);
     }
     if (errorDocument) {
         return metadata.getObjectMD(bucketName, errorDocument, log,
@@ -39,7 +42,7 @@ function _errorActions(err, errorDocument, routingRules,
                     // error retrieving error document so return original error
                     // and set boolean of error retrieving user's error document
                     // to true
-                    return callback(err, true);
+                    return callback(err, true, null, corsHeaders);
                 }
                 const dataLocator = errObjMD.location;
                 if (errObjMD['x-amz-server-side-encryption']) {
@@ -51,7 +54,8 @@ function _errorActions(err, errorDocument, routingRules,
                             errObjMD['x-amz-server-side-encryption'];
                     }
                 }
-                const responseMetaHeaders = collectResponseHeaders(errObjMD);
+                const responseMetaHeaders = collectResponseHeaders(errObjMD,
+                    corsHeaders);
                 pushMetric('getObject', log, {
                     bucket: bucketName,
                     newByteLength: responseMetaHeaders['Content-Length'],
@@ -59,7 +63,7 @@ function _errorActions(err, errorDocument, routingRules,
                 return callback(err, false, dataLocator, responseMetaHeaders);
             });
     }
-    return callback(err, false);
+    return callback(err, false, null, corsHeaders);
 }
 
 /**
@@ -85,11 +89,14 @@ function websiteGet(request, log, callback) {
             log.trace('bucket in transient/deleted state so shielding');
             return callback(errors.NoSuchBucket, false);
         }
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         // bucket ACL's do not matter for website get since it is always the
         // get of an object. object ACL's are what matter
         const websiteConfig = bucket.getWebsiteConfiguration();
         if (!websiteConfig) {
-            return callback(errors.NoSuchWebsiteConfiguration, false);
+            return callback(errors.NoSuchWebsiteConfiguration, false, null,
+            corsHeaders);
         }
         // any errors above would be our own created generic error html
         // if have a website config, error going forward would be user's
@@ -97,7 +104,7 @@ function websiteGet(request, log, callback) {
 
         // handle redirect all
         if (websiteConfig.getRedirectAllRequestsTo()) {
-            return callback(null, false, null, null,
+            return callback(null, false, null, corsHeaders,
                 websiteConfig.getRedirectAllRequestsTo(), objectKey);
         }
 
@@ -108,7 +115,7 @@ function websiteGet(request, log, callback) {
         if (keyRoutingRule) {
             // TODO: optimize by not rerouting if only routing
             // rule is to change out key
-            return callback(null, false, null, null,
+            return callback(null, false, null, corsHeaders,
                 keyRoutingRule, objectKey);
         }
 
@@ -138,15 +145,15 @@ function websiteGet(request, log, callback) {
                     }
                     return _errorActions(returnErr,
                       websiteConfig.getErrorDocument(), routingRules,
-                      bucketName, reqObjectKey, log, callback);
+                      bucketName, reqObjectKey, corsHeaders, log, callback);
                 }
                 if (!isObjAuthorized(bucket, objMD, 'objectGet',
                     constants.publicId)) {
                     const err = errors.AccessDenied;
                     log.trace('request not authorized', { error: err });
                     return _errorActions(err, websiteConfig.getErrorDocument(),
-                        routingRules, bucketName, reqObjectKey, log,
-                        callback);
+                        routingRules, bucketName, reqObjectKey, corsHeaders,
+                        log, callback);
                 }
 
                 const headerValResult = validateHeaders(objMD, request.headers);
@@ -154,8 +161,8 @@ function websiteGet(request, log, callback) {
                     const err = headerValResult.error;
                     log.trace('header validation error', { error: err });
                     return _errorActions(err, websiteConfig.getErrorDocument(),
-                        routingRules, bucketName, reqObjectKey, log,
-                        callback);
+                        routingRules, bucketName, reqObjectKey, corsHeaders,
+                        log, callback);
                 }
                 // check if object to serve has website redirect header
                 // Note: AWS prioritizes website configuration rules over
@@ -168,11 +175,13 @@ function websiteGet(request, log, callback) {
                         extractRedirectInfo(redirectLocation);
                     log.trace('redirecting to x-amz-website-redirect-location',
                         { location: redirectLocation });
-                    return callback(null, false, null, null, redirectInfo, '');
+                    return callback(null, false, null, corsHeaders,
+                        redirectInfo, '');
                 }
                 // got obj metadata, authorized and headers validated,
                 // good to go
-                const responseMetaHeaders = collectResponseHeaders(objMD);
+                const responseMetaHeaders = collectResponseHeaders(objMD,
+                    corsHeaders);
                 const dataLocator = objMD.location;
                 if (objMD['x-amz-server-side-encryption']) {
                     for (let i = 0; i < dataLocator.length; i++) {

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -1,5 +1,6 @@
 import { errors } from 'arsenal';
 
+import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import metadata from '../metadata/wrapper';
 import bucketShield from './apiUtils/bucket/bucketShield';
@@ -19,17 +20,19 @@ import { pushMetric } from '../utapi/utilities';
  * @param {object []} routingRules - array of routingRule objects
  * @param {string} objectKey - object key from request (or as translated in
  * websiteGet)
+ * @param {object} corsHeaders - CORS-related response headers
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
-function _errorActions(err, routingRules, objectKey, log, callback) {
+function _errorActions(err, routingRules, objectKey, corsHeaders, log,
+    callback) {
     const errRoutingRule = findRoutingRule(routingRules, objectKey, err.code);
     if (errRoutingRule) {
         // route will redirect
-        return callback(err, null, errRoutingRule, objectKey);
+        return callback(err, corsHeaders, errRoutingRule, objectKey);
     }
-    return callback(err);
+    return callback(err, corsHeaders);
 }
 
 
@@ -55,6 +58,8 @@ export default function websiteHead(request, log, callback) {
             log.trace('bucket in transient/deleted state so shielding');
             return callback(errors.NoSuchBucket);
         }
+        const corsHeaders = collectCorsHeaders(request.headers.origin,
+            request.method, bucket);
         // bucket ACL's do not matter for website head since it is always the
         // head of an object. object ACL's are what matter
         const websiteConfig = bucket.getWebsiteConfiguration();
@@ -67,7 +72,7 @@ export default function websiteHead(request, log, callback) {
 
         // handle redirect all
         if (websiteConfig.getRedirectAllRequestsTo()) {
-            return callback(null, null,
+            return callback(null, corsHeaders,
                 websiteConfig.getRedirectAllRequestsTo(), objectKey);
         }
 
@@ -85,7 +90,7 @@ export default function websiteHead(request, log, callback) {
         const keyRoutingRule = findRoutingRule(routingRules, objectKey);
 
         if (keyRoutingRule) {
-            return callback(null, null, keyRoutingRule, reqObjectKey);
+            return callback(null, corsHeaders, keyRoutingRule, reqObjectKey);
         }
 
         // get object metadata and check authorization and header
@@ -104,14 +109,14 @@ export default function websiteHead(request, log, callback) {
                         returnErr = errors.AccessDenied;
                     }
                     return _errorActions(returnErr, routingRules,
-                        reqObjectKey, log, callback);
+                        reqObjectKey, corsHeaders, log, callback);
                 }
                 if (!isObjAuthorized(bucket, objMD, 'objectGet',
                     constants.publicId)) {
                     const err = errors.AccessDenied;
                     log.trace('request not authorized', { error: err });
                     return _errorActions(err, routingRules, reqObjectKey,
-                        log, callback);
+                        corsHeaders, log, callback);
                 }
 
                 const headerValResult = validateHeaders(objMD, request.headers);
@@ -119,7 +124,7 @@ export default function websiteHead(request, log, callback) {
                     const err = headerValResult.error;
                     log.trace('header validation error', { error: err });
                     return _errorActions(err, routingRules, reqObjectKey,
-                        log, callback);
+                        corsHeaders, log, callback);
                 }
 
                 // check if object to serve has website redirect header
@@ -133,12 +138,13 @@ export default function websiteHead(request, log, callback) {
                         extractRedirectInfo(redirectLocation);
                     log.trace('redirecting to x-amz-website-redirect-location',
                         { location: redirectLocation });
-                    return callback(null, null, redirectInfo, '');
+                    return callback(null, corsHeaders, redirectInfo, '');
                 }
 
                 // got obj metadata, authorized and headers validated,
                 // good to go
-                const responseMetaHeaders = collectResponseHeaders(objMD);
+                const responseMetaHeaders = collectResponseHeaders(objMD,
+                    corsHeaders);
                 pushMetric('headObject', log, {
                     bucket: bucketName,
                 });

--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -14,48 +14,48 @@ export default function routeDELETE(request, response, log, statsClient) {
               'specified'), null, response, 200, log);
         }
         api.callApiMethod('multipartDelete', request, log,
-            (err, resHeaders) => {
+            (err, corsHeaders) => {
                 statsReport500(err, statsClient);
-                return routesUtils.responseNoBody(err, resHeaders, response,
+                return routesUtils.responseNoBody(err, corsHeaders, response,
                     204, log);
             });
     } else {
         if (request.objectKey === undefined) {
             if (request.query.website !== undefined) {
                 return api.callApiMethod('bucketDeleteWebsite', request,
-                log, err => {
+                log, (err, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 204,
-                        log);
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 204, log);
                 });
             } else if (request.query.cors !== undefined) {
                 return api.callApiMethod('bucketDeleteCors', request, log,
-                err => {
+                (err, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 204,
-                        log);
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 204, log);
                 });
             }
             api.callApiMethod('bucketDelete', request, log,
-            (err, resHeaders) => {
+            (err, corsHeaders) => {
                 statsReport500(err, statsClient);
-                return routesUtils.responseNoBody(err, resHeaders, response,
+                return routesUtils.responseNoBody(err, corsHeaders, response,
                   204, log);
             });
         } else {
             api.callApiMethod('objectDelete', request, log,
-              err => {
+              (err, corsHeaders) => {
                   /*
                   * Since AWS expects a 204 regardless of the existence of
                   the object, the error NoSuchKey should not be sent back
                   * as a response.
                   */
                   if (err && !err.NoSuchKey) {
-                      return routesUtils.responseNoBody(err, null,
+                      return routesUtils.responseNoBody(err, corsHeaders,
                         response, null, log);
                   }
                   statsReport500(err, statsClient);
-                  return routesUtils.responseNoBody(null, null, response,
+                  return routesUtils.responseNoBody(null, corsHeaders, response,
                     204, log);
               });
         }

--- a/lib/routes/routeGET.js
+++ b/lib/routes/routeGET.js
@@ -17,55 +17,67 @@ export default function routerGET(request, response, log, statsClient) {
     } else if (request.objectKey === undefined) {
         // GET bucket ACL
         if (request.query.acl !== undefined) {
-            api.callApiMethod('bucketGetACL', request, log, (err, xml) => {
+            api.callApiMethod('bucketGetACL', request, log,
+            (err, xml, corsHeaders) => {
                 statsReport500(err, statsClient);
-                return routesUtils.responseXMLBody(err, xml, response, log);
+                return routesUtils.responseXMLBody(err, xml, response, log,
+                    corsHeaders);
             });
         } else if (request.query.cors !== undefined) {
             api.callApiMethod('bucketGetCors', request, log,
-                (err, xml) => {
+                (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    routesUtils.responseXMLBody(err, xml, response, log);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
                 });
         } else if (request.query.versioning !== undefined) {
             api.callApiMethod('bucketGetVersioning', request, log,
-                (err, xml) => {
+                (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    routesUtils.responseXMLBody(err, xml, response, log);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
                 });
         } else if (request.query.website !== undefined) {
             api.callApiMethod('bucketGetWebsite', request, log,
-                (err, xml) => {
+                (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    routesUtils.responseXMLBody(err, xml, response, log);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
                 });
         } else if (request.query.uploads !== undefined) {
             // List MultipartUploads
             api.callApiMethod('listMultipartUploads', request, log,
-                (err, xml) => {
+                (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    return routesUtils.responseXMLBody(err, xml, response, log);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
                 });
         } else {
             // GET bucket
-            api.callApiMethod('bucketGet', request, log, (err, xml) => {
-                statsReport500(err, statsClient);
-                return routesUtils.responseXMLBody(err, xml, response, log);
-            });
+            api.callApiMethod('bucketGet', request, log,
+                (err, xml, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
         }
     } else {
         if (request.query.acl !== undefined) {
             // GET object ACL
-            api.callApiMethod('objectGetACL', request, log, (err, xml) => {
-                statsReport500(err, statsClient);
-                return routesUtils.responseXMLBody(err, xml, response, log);
-            });
+            api.callApiMethod('objectGetACL', request, log,
+                (err, xml, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
             // List parts of an open multipart upload
         } else if (request.query.uploadId !== undefined) {
-            api.callApiMethod('listParts', request, log, (err, xml) => {
-                statsReport500(err, statsClient);
-                return routesUtils.responseXMLBody(err, xml, response, log);
-            });
+            api.callApiMethod('listParts', request, log,
+                (err, xml, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseXMLBody(err, xml, response, log,
+                        corsHeaders);
+                });
         } else {
             // GET object
             api.callApiMethod('objectGet', request, log, (err, dataGetInfo,

--- a/lib/routes/routeHEAD.js
+++ b/lib/routes/routeHEAD.js
@@ -11,9 +11,9 @@ export default function routeHEAD(request, response, log, statsClient) {
             null, response, log);
     } else if (request.objectKey === undefined) {
         // HEAD bucket
-        api.callApiMethod('bucketHead', request, log, (err, resHeaders) => {
+        api.callApiMethod('bucketHead', request, log, (err, corsHeaders) => {
             statsReport500(err, statsClient);
-            return routesUtils.responseNoBody(err, resHeaders, response, 200,
+            return routesUtils.responseNoBody(err, corsHeaders, response, 200,
                 log);
         });
     } else {

--- a/lib/routes/routePOST.js
+++ b/lib/routes/routePOST.js
@@ -51,22 +51,25 @@ export default function routePOST(request, response, log) {
         // POST initiate multipart upload
         if (request.query.uploads !== undefined) {
             return api.callApiMethod('initiateMultipartUpload', request, log,
-                (err, result) =>
-                    routesUtils.responseXMLBody(err, result, response, log));
+                (err, result, corsHeaders) =>
+                routesUtils.responseXMLBody(err, result, response, log,
+                    corsHeaders));
         }
 
         // POST complete multipart upload
         if (request.query.uploadId !== undefined) {
             return api.callApiMethod('completeMultipartUpload', request, log,
-                (err, result) =>
-                    routesUtils.responseXMLBody(err, result, response, log));
+                (err, result, corsHeaders) =>
+                routesUtils.responseXMLBody(err, result, response, log,
+                    corsHeaders));
         }
 
         // POST multiObjectDelete
         if (request.query.delete !== undefined) {
             return api.callApiMethod('multiObjectDelete', request, log,
-                (err, xml) =>
-                    routesUtils.responseXMLBody(err, xml, response, log));
+                (err, xml, corsHeaders) =>
+                routesUtils.responseXMLBody(err, xml, response, log,
+                    corsHeaders));
         }
 
         return routesUtils.responseNoBody(errors.NotImplemented, null, response,

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -60,10 +60,11 @@ export default function routePUT(request, response, log, statsClient) {
 
             // PUT bucket ACL
             if (request.query.acl !== undefined) {
-                api.callApiMethod('bucketPutACL', request, log, err => {
+                api.callApiMethod('bucketPutACL', request, log,
+                (err, corsHeaders) => {
                     statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 200,
-                        log);
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 200, log);
                 });
             } else if (request.query.versioning !== undefined) {
                 if (request.post === '') {
@@ -97,24 +98,26 @@ export default function routePUT(request, response, log, statsClient) {
                             response, null, log);
                     }
                     return api.callApiMethod('bucketPutVersioning', request,
-                        log, err => {
+                        log, (err, corsHeaders) => {
                             statsReport500(err, statsClient);
                             routesUtils.responseNoBody(
-                                err, null, response, 200, log);
+                                err, corsHeaders, response, 200, log);
                         });
                 });
             } else if (request.query.website !== undefined) {
-                api.callApiMethod('bucketPutWebsite', request, log, err => {
-                    statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 200,
-                        log);
-                });
+                api.callApiMethod('bucketPutWebsite', request, log,
+                    (err, corsHeaders) => {
+                        statsReport500(err, statsClient);
+                        return routesUtils.responseNoBody(err, corsHeaders,
+                            response, 200, log);
+                    });
             } else if (request.query.cors !== undefined) {
-                api.callApiMethod('bucketPutCors', request, log, err => {
-                    statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 200,
-                        log);
-                });
+                api.callApiMethod('bucketPutCors', request, log,
+                    (err, corsHeaders) => {
+                        statsReport500(err, statsClient);
+                        return routesUtils.responseNoBody(err, corsHeaders,
+                            response, 200, log);
+                    });
             } else if (request.query.acl === undefined) {
                 // PUT bucket
                 const location = { Location: `/${request.bucketName}` };
@@ -137,18 +140,25 @@ export default function routePUT(request, response, log, statsClient) {
                         log.trace('location constraint',
                             { locationConstraint });
                         return api.callApiMethod('bucketPut', request, log,
-                        err => {
+                        (err, corsHeaders) => {
                             statsReport500(err, statsClient);
-                            return routesUtils.responseNoBody(err, location,
+                            const resHeaders = corsHeaders ?
+                                Object.assign({}, location, corsHeaders) :
+                                location;
+                            return routesUtils.responseNoBody(err, resHeaders,
                               response, 200, log);
                         }, locationConstraint);
                     });
                 }
-                return api.callApiMethod('bucketPut', request, log, err => {
-                    statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, location, response,
-                      200, log);
-                });
+                return api.callApiMethod('bucketPut', request, log,
+                    (err, corsHeaders) => {
+                        statsReport500(err, statsClient);
+                        const resHeaders = corsHeaders ?
+                            Object.assign({}, location, corsHeaders) :
+                            location;
+                        return routesUtils.responseNoBody(err, resHeaders,
+                            response, 200, log);
+                    });
             }
             return undefined;
         });
@@ -197,11 +207,16 @@ export default function routePUT(request, response, log, statsClient) {
                 });
             } else {
                 api.callApiMethod('objectPutPart', request, log,
-                    (err, calculatedHash) => {
+                    (err, calculatedHash, corsHeaders) => {
+                        if (err) {
+                            return routesUtils.responseNoBody(err, corsHeaders,
+                                response, 200, log);
+                        }
                         // ETag's hex should always be enclosed in quotes
-                        const resMetaHeaders = { ETag: `"${calculatedHash}"` };
+                        const resMetaHeaders = corsHeaders || {};
+                        resMetaHeaders.ETag = `"${calculatedHash}"`;
                         statsReport500(err, statsClient);
-                        routesUtils.responseNoBody(err, resMetaHeaders,
+                        return routesUtils.responseNoBody(err, resMetaHeaders,
                             response, 200, log);
                     });
             }
@@ -211,11 +226,12 @@ export default function routePUT(request, response, log, statsClient) {
                 request.post += chunk.toString();
             });
             request.on('end', () => {
-                api.callApiMethod('objectPutACL', request, log, err => {
-                    statsReport500(err, statsClient);
-                    return routesUtils.responseNoBody(err, null, response, 200,
-                        log);
-                });
+                api.callApiMethod('objectPutACL', request, log,
+                    (err, corsHeaders) => {
+                        statsReport500(err, statsClient);
+                        return routesUtils.responseNoBody(err, corsHeaders,
+                            response, 200, log);
+                    });
             });
         } else if (request.headers['x-amz-copy-source']) {
             return api.callApiMethod('objectCopy', request, log, (err, xml,
@@ -239,12 +255,16 @@ export default function routePUT(request, response, log, statsClient) {
                 contentLength: request.parsedContentLength,
             });
 
-            api.callApiMethod('objectPut', request, log, (err, contentMD5) => {
+            api.callApiMethod('objectPut', request, log,
+            (err, contentMD5, corsHeaders) => {
+                if (err) {
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 200, log);
+                }
                 // ETag's hex should always be enclosed in quotes
                 statsReport500(err, statsClient);
-                const resMetaHeaders = {
-                    ETag: `"${contentMD5}"`,
-                };
+                const resMetaHeaders = corsHeaders || {};
+                resMetaHeaders.ETag = `"${contentMD5}"`;
                 return routesUtils.responseNoBody(err, resMetaHeaders,
                     response, 200, log);
             });

--- a/lib/routes/routeWebsite.js
+++ b/lib/routes/routeWebsite.js
@@ -11,7 +11,7 @@ export default function routerWebsite(request, response, log, statsClient) {
     if ((request.method !== 'GET' && request.method !== 'HEAD')
         || !request.bucketName) {
         return routesUtils.errorHtmlResponse(errors.MethodNotAllowed,
-            false, request.bucketName, response, log);
+            false, request.bucketName, response, null, log);
     }
     if (request.method === 'GET') {
         return api.callApiMethod('websiteGet', request, log,
@@ -24,18 +24,18 @@ export default function routerWebsite(request, response, log, statsClient) {
                     // api to add index document
                     return routesUtils.redirectRequest(redirectInfo,
                         key, request.connection.encrypted,
-                        response, request.headers.host, log);
+                        response, request.headers.host, resMetaHeaders, log);
                 }
                 // user has their own error page
                 if (err && dataGetInfo) {
                     return routesUtils.streamUserErrorPage(err, dataGetInfo,
-                        response, log);
+                        response, resMetaHeaders, log);
                 }
                 // send default error html response
                 if (err) {
                     return routesUtils.errorHtmlResponse(err,
                         userErrorPageFailure, request.bucketName,
-                        response, log);
+                        response, resMetaHeaders, log);
                 }
                 // no error, stream data
                 return routesUtils.responseStreamData(null, request.headers,
@@ -49,11 +49,12 @@ export default function routerWebsite(request, response, log, statsClient) {
             if (redirectInfo) {
                 return routesUtils.redirectRequest(redirectInfo,
                     key, request.connection.encrypted,
-                    response, request.headers.host, log);
+                    response, request.headers.host, resMetaHeaders, log);
             }
             // could redirect on err so check for redirectInfo first
             if (err) {
-                return routesUtils.errorHeaderResponse(err, response, log);
+                return routesUtils.errorHeaderResponse(err, response,
+                    resMetaHeaders, log);
             }
             return routesUtils.responseContentHeaders(err, {}, resMetaHeaders,
                 response, log);

--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -75,7 +75,7 @@ function okXMLResponse(xml, response, log, additionalHeaders) {
     });
 }
 
-function errorXMLResponse(errCode, response, log) {
+function errorXMLResponse(errCode, response, log, corsHeaders) {
     log.trace('sending error xml response', { errCode });
     /*
     <?xml version="1.0" encoding="UTF-8"?>
@@ -101,7 +101,7 @@ function errorXMLResponse(errCode, response, log) {
     log.addDefaultFields({
         bytesSent,
     });
-    setCommonResponseHeaders(null, response, log);
+    setCommonResponseHeaders(corsHeaders, response, log);
     response.writeHead(errCode.code, { 'Content-type': 'application/xml' });
     return response.end(xmlStr, 'utf8', () => {
         log.end().info('responded with error XML', {
@@ -184,7 +184,7 @@ const routesUtils = {
      */
     responseXMLBody(errCode, xml, response, log, additionalHeaders) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log);
+            return errorXMLResponse(errCode, response, log, additionalHeaders);
         }
         if (!response.headersSent) {
             return okXMLResponse(xml, response, log, additionalHeaders);
@@ -203,7 +203,7 @@ const routesUtils = {
      */
     responseNoBody(errCode, resHeaders, response, httpCode = 200, log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log);
+            return errorXMLResponse(errCode, response, log, resHeaders);
         }
         if (!response.headersSent) {
             return okHeaderResponse(resHeaders, response, httpCode, log);
@@ -223,7 +223,7 @@ const routesUtils = {
     responseContentHeaders(errCode, overrideHeaders, resHeaders, response,
                            log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log);
+            return errorXMLResponse(errCode, response, log, resHeaders);
         }
         if (!response.headersSent) {
             // Undefined added as an argument since need to send range to
@@ -339,7 +339,7 @@ const routesUtils = {
     responseStreamData(errCode, overrideHeaders,
             resHeaders, dataLocations, response, range, log) {
         if (errCode && !response.headersSent) {
-            return errorXMLResponse(errCode, response, log);
+            return errorXMLResponse(errCode, response, log, resHeaders);
         }
         if (!response.headersSent) {
             okContentHeadersResponse(overrideHeaders, resHeaders, response,
@@ -367,11 +367,12 @@ const routesUtils = {
      * @param {array} dataLocations --
      *   - array of locations to get streams from sproxyd
      * @param {http.ServerResponse} response - response sent to the client
+     * @param {object} corsHeaders - CORS-related response headers
      * @param {object} log - Werelogs logger
      * @return {undefined}
      */
-    streamUserErrorPage(err, dataLocations, response, log) {
-        setCommonResponseHeaders(null, response, log);
+    streamUserErrorPage(err, dataLocations, response, corsHeaders, log) {
+        setCommonResponseHeaders(corsHeaders, response, log);
         response.writeHead(err.code, { 'Content-type': 'text/html' });
         response.on('finish', () => {
             log.end().info('responded with streamed content', {
@@ -387,13 +388,15 @@ const routesUtils = {
      * retrieving the user's error page
      * @param {string} bucketName - bucketName from request
      * @param {http.ServerResponse} response - response sent to the client
+     * @param {object} corsHeaders - CORS-related response headers
      * @param {object} log - Werelogs logger
      * @return {undefined}
      */
-    errorHtmlResponse(err, userErrorPageFailure, bucketName, response, log) {
+    errorHtmlResponse(err, userErrorPageFailure, bucketName, response,
+        corsHeaders, log) {
         log.trace('sending generic html error page',
             { err });
-        setCommonResponseHeaders(null, response, log);
+        setCommonResponseHeaders(corsHeaders, response, log);
         response.writeHead(err.code, { 'Content-type': 'text/html' });
         const html = [];
         // response.statusMessage will provide standard message for status
@@ -446,13 +449,14 @@ const routesUtils = {
     /**
  * @param {object} err - arsenal error object
  * @param {http.ServerResponse} response - response sent to the client
+ * @param {object} corsHeaders - CORS-related response headers
  * @param {object} log - Werelogs logger
  * @return {undefined}
  */
-    errorHeaderResponse(err, response, log) {
+    errorHeaderResponse(err, response, corsHeaders, log) {
         log.trace('sending error header response',
             { err });
-        setCommonResponseHeaders(null, response, log);
+        setCommonResponseHeaders(corsHeaders, response, log);
         response.setHeader('x-amz-error-code', err.message);
         response.setHeader('x-amz-error-message', err.description);
         response.writeHead(err.code);
@@ -485,11 +489,12 @@ const routesUtils = {
      * @param {boolean} encrypted - whether request was https
      * @param {object} response - response object
      * @param {string} hostHeader - host sent in original request.headers
+     * @param {object} corsHeaders - CORS-related response headers
      * @param {object} log - Werelogs instance
      * @return {undefined}
      */
     redirectRequest(routingInfo, objectKey, encrypted, response, hostHeader,
-        log) {
+        corsHeaders, log) {
         const { justPath, redirectLocationHeader, hostName, protocol,
             httpRedirectCode, replaceKeyPrefixWith,
             replaceKeyWith, prefixFromRule } = routingInfo;
@@ -497,6 +502,8 @@ const routesUtils = {
         const redirectProtocol = protocol || encrypted ? 'https' : 'http';
         const redirectCode = httpRedirectCode || 301;
         const redirectHostName = hostName || hostHeader;
+
+        setCommonResponseHeaders(corsHeaders, response, log);
 
         let redirectKey = objectKey;
         // will only have either replaceKeyWith defined or replaceKeyPrefixWith

--- a/lib/services.js
+++ b/lib/services.js
@@ -89,7 +89,8 @@ export default {
                     log.debug('access denied for user on bucket', {
                         requestType,
                     });
-                    return cb(errors.AccessDenied);
+                    // still return bucket for CORS headers
+                    return cb(errors.AccessDenied, bucket);
                 }
                 log.trace('found bucket in metadata');
                 return cb(null, bucket, null);
@@ -116,7 +117,7 @@ export default {
             }
             if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
                 log.debug('access denied for user on bucket', { requestType });
-                return cb(errors.AccessDenied);
+                return cb(errors.AccessDenied, bucket);
             }
             if (!obj) {
                 // NEED to pass on three arguments here for the objectPut
@@ -127,7 +128,7 @@ export default {
             // TODO: Add bucket policy and IAM checks
             if (!isObjAuthorized(bucket, obj, requestType, canonicalID)) {
                 log.debug('access denied for user on object', { requestType });
-                return cb(errors.AccessDenied);
+                return cb(errors.AccessDenied, bucket);
             }
             log.trace('found bucket and object in metadata');
             return cb(null, bucket, obj);

--- a/lib/utilities/collectCorsHeaders.js
+++ b/lib/utilities/collectCorsHeaders.js
@@ -1,0 +1,33 @@
+import { findCorsRule,
+generateCorsResHeaders } from '../api/apiUtils/object/corsResponse.js';
+
+/**
+ * collectCorsHeaders - gather any relevant CORS headers
+ * @param {object} origin - value of Origin header of CORS request
+ * @param {object} httpMethod - http method of CORS request
+ * @param {BucketInfo} bucket - instance of BucketInfo class
+ * @return {object} - object containing CORS headers
+ */
+export default function collectCorsHeaders(origin, httpMethod, bucket) {
+    // NOTE: Because collecting CORS headers requires making a call to
+    // metadata to retrieve the bucket's CORS configuration, we opt not to
+    // return the CORS headers if the request encounters an error before
+    // the api method retrieves the bucket from metadata (an example
+    // being if a request is not properly authenticated). This is a slight
+    // deviation from AWS compatibility, but has the benefit of avoiding
+    // additional backend calls for an invalid request. Also, we anticipate
+    // that the preflight OPTIONS route will serve most client needs regarding
+    // CORS.
+    if (!origin || !bucket) {
+        return {};
+    }
+    const corsRules = bucket.getCors();
+    if (!corsRules) {
+        return {};
+    }
+    const matchingRule = findCorsRule(corsRules, origin, httpMethod, null);
+    if (!matchingRule) {
+        return {};
+    }
+    return generateCorsResHeaders(matchingRule, origin, httpMethod, null);
+}

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -1,13 +1,14 @@
 /**
  * Pulls data from saved object metadata to send in response
  * @param {object} objectMD - object's metadata
- * @param {object} headers - contains headers from request object
+ * @param {object} corsHeaders - if cors headers exist, use as basis for adding
+ * other response headers
  * @return {object} responseMetaHeaders headers with object metadata to include
  * in response to client
  */
-function collectResponseHeaders(objectMD) {
+function collectResponseHeaders(objectMD, corsHeaders) {
     // Add user meta headers from objectMD
-    const responseMetaHeaders = {};
+    const responseMetaHeaders = Object.assign({}, corsHeaders);
     Object.keys(objectMD).filter(val => (val.substr(0, 11) === 'x-amz-meta-' ||
         val === 'x-amz-website-redirect-location'))
         .forEach(id => { responseMetaHeaders[id] = objectMD[id]; });

--- a/tests/functional/aws-node-sdk/test/object/corsHeaders.js
+++ b/tests/functional/aws-node-sdk/test/object/corsHeaders.js
@@ -1,0 +1,691 @@
+import { S3 } from 'aws-sdk';
+import assert from 'assert';
+import async from 'async';
+
+import getConfig from '../support/config';
+import methodRequest from '../../lib/utility/cors-util';
+import { generateCorsParams } from '../../lib/utility/cors-util';
+import { WebsiteConfigTester } from '../../lib/utility/website-util';
+
+const config = getConfig('default', { signatureVersion: 'v4' });
+const s3 = new S3(config);
+
+const bucket = 'bucketcorsheadertest';
+const objectKey = 'objectKeyName';
+const allowedOrigin = 'http://www.allowedwebsite.com';
+const notAllowedOrigin = 'http://www.notallowedwebsite.com';
+const vary = 'Origin, Access-Control-Request-Headers, ' +
+    'Access-Control-Request-Method';
+const defaultOptions = {
+    allowedMethods: ['GET'],
+    allowedOrigins: [allowedOrigin],
+};
+
+// To run any of the tests for the following by itself, change value of
+// `checkForCorsHeaders` or `checkNoCorsHeaders` to true.
+const apiMethods = [
+    {
+        description: 'GET bucket (list objects)',
+        action: s3.listObjects,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET bucket ACL',
+        action: s3.getBucketAcl,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET bucket CORS',
+        action: s3.getBucketCors,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET bucket versioning',
+        action: s3.getBucketVersioning,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET bucket website',
+        action: s3.getBucketWebsite,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET bucket uploads (list multipart uploads)',
+        action: s3.listMultipartUploads,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET object',
+        action: s3.getObject,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET object ACL',
+        action: s3.getObjectAcl,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'GET object uploadId (list multipart upload parts)',
+        action: s3.listParts,
+        params: { Bucket: bucket, Key: objectKey, UploadId: 'testId' },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'HEAD bucket',
+        action: s3.headBucket,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'HEAD object',
+        action: s3.headObject,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT bucket (create bucket)',
+        action: s3.createBucket,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT bucket ACL',
+        action: s3.putBucketAcl,
+        params: { Bucket: bucket, ACL: 'private' },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT bucket versioning',
+        action: s3.putBucketVersioning,
+        params: {
+            Bucket: bucket,
+            VersioningConfiguration: {
+                Status: 'Enabled',
+            },
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT bucket website',
+        action: s3.putBucketWebsite,
+        params: {
+            Bucket: bucket,
+            WebsiteConfiguration: {
+                IndexDocument: { Suffix: 'index.html' },
+            },
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT bucket CORS',
+        action: s3.putBucketCors,
+        params: {
+            Bucket: bucket,
+            CORSConfiguration: {
+                CORSRules: [{
+                    AllowedOrigins: [allowedOrigin],
+                    AllowedMethods: ['PUT'],
+                }],
+            },
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT object',
+        action: s3.putObject,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT object ACL',
+        action: s3.putObjectAcl,
+        params: {
+            Bucket: bucket,
+            Key: objectKey,
+            ACL: 'private',
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT object copy (copy object)',
+        action: s3.copyObject,
+        params: {
+            Bucket: bucket,
+            CopySource: `${bucket}/${objectKey}`, // 'sourceBucket/testSource',
+            Key: objectKey,
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT object part (upload part)',
+        action: s3.uploadPart,
+        params: {
+            Bucket: bucket,
+            Key: objectKey,
+            PartNumber: 1,
+            UploadId: 'testId',
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'PUT object part copy (upload part copy)',
+        action: s3.uploadPartCopy,
+        params: {
+            Bucket: bucket,
+            CopySource: `${bucket}/${objectKey}`, // 'sourceBucket/testSource',
+            Key: objectKey,
+            PartNumber: 1,
+            UploadId: 'testId',
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'POST uploads (create multipart upload)',
+        action: s3.createMultipartUpload,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'POST uploadId (complete multipart upload)',
+        action: s3.completeMultipartUpload,
+        params: { Bucket: bucket, Key: objectKey, UploadId: 'testId' },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'POST delete (multi object delete)',
+        action: s3.deleteObjects,
+        params: {
+            Bucket: bucket,
+            Delete: {
+                Objects: [
+                    { Key: objectKey },
+                ],
+            },
+        },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'DELETE bucket',
+        action: s3.deleteBucket,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'DELETE bucket website',
+        action: s3.deleteBucketWebsite,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'DELETE bucket CORS',
+        action: s3.deleteBucketCors,
+        params: { Bucket: bucket },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'DELETE object',
+        action: s3.deleteObject,
+        params: { Bucket: bucket, Key: objectKey },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+    {
+        description: 'DELETE object uploadId (abort multipart upload)',
+        action: s3.abortMultipartUpload,
+        params: { Bucket: bucket, Key: objectKey, UploadId: 'testId' },
+        onlyRun: {
+            checkForCorsHeaders: false,
+            checkNoCorsHeaders: false,
+        },
+    },
+];
+
+// AWS seems to take a bit long so sometimes by the time we send the request
+// the bucket has not yet been created or the bucket has been deleted.
+function _waitForAWS(callback, err) {
+    if (process.env.AWS_ON_AIR) {
+        setTimeout(() => callback(err), 1000);
+    } else {
+        callback(err);
+    }
+}
+
+function _checkHeaders(action, params, origin, expectedHeaders, callback) {
+    function _runAssertions(resHeaders, cb) {
+        if (expectedHeaders) {
+            Object.keys(expectedHeaders).forEach(key => {
+                assert.deepEqual(resHeaders[key], expectedHeaders[key],
+                  `error header: ${key}`);
+            });
+        } else {
+            // if no headersResponse provided, should not have these headers
+            // in the request
+            ['access-control-allow-origin',
+            'access-control-allow-methods',
+            'access-control-allow-credentials',
+            'vary'].forEach(key => {
+                assert.strictEqual(resHeaders[key], undefined,
+                    `Error: ${key} should not have value`);
+            });
+        }
+        cb();
+    }
+    const method = action.bind(s3);
+    const request = method(params);
+    // modify underlying http request object created by aws sdk to add
+    // origin header
+    request.on('build', () => {
+        request.httpRequest.headers.origin = origin;
+    });
+    request.on('success', response => {
+        const resHeaders = response.httpResponse.headers;
+        _runAssertions(resHeaders, () => {
+            if (response.data.UploadId) {
+                // abort multipart upload before deleting bucket in afterEach
+                return s3.abortMultipartUpload({ Bucket: bucket, Key: objectKey,
+                UploadId: response.data.UploadId }, callback);
+            }
+            return callback();
+        });
+    });
+    // CORS headers should still be sent in case of errors as long as
+    // request matches CORS configuration
+    request.on('error', () => {
+        const resHeaders = request.response.httpResponse.headers;
+        _runAssertions(resHeaders, callback);
+    });
+    request.send();
+}
+
+describe('Cross Origin Resource Sharing requests', () => {
+    beforeEach(done => {
+        s3.createBucket({ Bucket: bucket, ACL: 'public-read-write' }, err => {
+            if (err) {
+                process.stdout.write(`Error in beforeEach ${err}`);
+            }
+            return _waitForAWS(done, err);
+        });
+    });
+
+    afterEach(done => {
+        s3.deleteBucket({ Bucket: bucket }, err => {
+            if (err && err.code !== 'NoSuchBucket') {
+                process.stdout.write(`Error in afterEach ${err}`);
+                return _waitForAWS(done, err);
+            }
+            return _waitForAWS(done);
+        });
+    });
+
+    describe('on non-existing bucket', () => {
+        it('should not respond to request with CORS headers, even ' +
+            'if request was sent with Origin header', done => {
+            _checkHeaders(s3.listObjects, { Bucket: 'nonexistingbucket' },
+            allowedOrigin, null, done);
+        });
+    });
+
+    describe('on bucket without CORS configuration', () => {
+        it('should not respond to request with CORS headers, even ' +
+            'if request was sent with Origin header', done => {
+            _checkHeaders(s3.listObjects, { Bucket: bucket },
+            allowedOrigin, null, done);
+        });
+    });
+
+    describe('on bucket with CORS configuration: ' +
+            'allow one origin and all methods', () => {
+        const corsParams = generateCorsParams(bucket, {
+            allowedMethods: ['GET', 'PUT', 'HEAD', 'POST', 'DELETE'],
+            allowedOrigins: [allowedOrigin],
+        });
+        const expectedHeaders = {
+            'access-control-allow-origin': allowedOrigin,
+            'access-control-allow-methods': corsParams.CORSConfiguration
+                .CORSRules[0].AllowedMethods.join(', '),
+            'access-control-allow-credentials': 'true',
+            vary,
+        };
+
+        beforeEach(done => s3.putBucketCors(corsParams, done));
+
+        afterEach(done => {
+            s3.deleteObject({ Bucket: bucket, Key: objectKey }, err => {
+                if (err && err.code !== 'NoSuchKey' &&
+                err.code !== 'NoSuchBucket') {
+                    process.stdout.write(`Unexpected err in afterEach: ${err}`);
+                    return done(err);
+                }
+                return done();
+            });
+        });
+
+        describe('when request Origin/method match CORS configuration', () => {
+            it('should not respond with CORS headers to GET service (list ' +
+            'buckets), even if Origin/method match CORS rule', done => {
+                // no bucket specified in this request
+                _checkHeaders(s3.listBuckets, {}, allowedOrigin,
+                null, done);
+            });
+
+            it('should not respond with CORS headers after deleting bucket, ' +
+            'even if Origin/method match CORS rule', done => {
+                s3.deleteBucket({ Bucket: bucket }, err => {
+                    assert.strictEqual(err, null, `Unexpected err ${err}`);
+                    _checkHeaders(s3.listObjects, { Bucket: bucket },
+                    allowedOrigin, null, done);
+                });
+            });
+
+            apiMethods.forEach(method => {
+                const itFlag = method.onlyRun.checkForCorsHeaders ?
+                    it.only : it;
+                itFlag(`should respond to ${method.description} with CORS ` +
+                'headers (access-control-allow-origin, access-control-allow-' +
+                'methods, access-control-allow-credentials and vary)', done => {
+                    _checkHeaders(method.action, method.params, allowedOrigin,
+                    expectedHeaders, done);
+                });
+            });
+        });
+
+        describe('when request Origin does not match CORS rule', () => {
+            apiMethods.forEach(method => {
+                const itFlag = method.onlyRun.checkNoCorsHeaders ? it.only : it;
+                itFlag(`should not respond to ${method.description} with ` +
+                'CORS headers', done => {
+                    _checkHeaders(method.action, method.params,
+                    notAllowedOrigin, null, done);
+                });
+            });
+        });
+    });
+
+    describe('on bucket with CORS configuration: ' +
+            'allow PUT method and one origin', () => {
+        const corsParams = generateCorsParams(bucket, {
+            allowedMethods: ['PUT'],
+            allowedOrigins: [allowedOrigin],
+        });
+
+        beforeEach(done => {
+            s3.putBucketCors(corsParams, done);
+        });
+
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        it('when request method does not match CORS rule ' +
+        'should not respond with CORS headers', done => {
+            _checkHeaders(s3.listObjects, { Bucket: bucket },
+            allowedOrigin, null, done);
+        });
+    });
+
+    describe('on bucket with CORS configuration and website configuration',
+    () => {
+        const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
+            'bucketwebsitetester';
+        const corsParams = generateCorsParams(bucket, {
+            allowedMethods: ['GET', 'HEAD'],
+            allowedOrigins: [allowedOrigin],
+        });
+        const headersResponse = {
+            'access-control-allow-origin': allowedOrigin,
+            'access-control-allow-methods': 'GET, HEAD',
+            'access-control-allow-credentials': 'true',
+            vary,
+        };
+        const webConfig = new WebsiteConfigTester('index.html');
+        const condition = { KeyPrefixEquals: 'redirect' };
+        const redirect = { HostName: 'www.google.com' };
+        webConfig.addRoutingRule(redirect, condition);
+
+        beforeEach(done =>
+            async.series([
+                next => s3.createBucket({
+                    Bucket: bucket,
+                    ACL: 'public-read',
+                }, next),
+                next => s3.putBucketCors(corsParams, next),
+                next => s3.putBucketWebsite({ Bucket: bucket,
+                WebsiteConfiguration: webConfig }, next),
+                next => s3.putObject({
+                    Bucket: bucket,
+                    Key: 'index.html',
+                    ACL: 'public-read',
+                }, next),
+            ], err => {
+                assert.strictEqual(err, null,
+                    `Unexpected err ${err} in beforeEach`);
+                done(err);
+            })
+        );
+
+        afterEach(done =>
+            s3.deleteObject({ Bucket: bucket, Key: 'index.html' }, err => {
+                assert.strictEqual(err, null,
+                    `Unexpected err ${err} in afterEach`);
+                s3.deleteBucket({ Bucket: bucket }, err => {
+                    if (err) {
+                        process.stdout.write(`Error in afterEach ${err}`);
+                        return _waitForAWS(done, err);
+                    }
+                    return _waitForAWS(done);
+                });
+            })
+        );
+
+        it('should respond with CORS headers at website endpoint (GET)',
+        done => {
+            const headers = { Origin: allowedOrigin };
+            methodRequest({ method: 'GET', bucket, headers, headersResponse,
+            code: 200, isWebsite: true }, done);
+        });
+
+        it('should respond with CORS headers at website endpoint (GET) ' +
+        'even in case of error',
+        done => {
+            const headers = { Origin: allowedOrigin };
+            // NOTE: separate PR to address Issue #553 will result in
+            // different error code
+            methodRequest({ method: 'GET', bucket, objectKey: 'test',
+            headers, headersResponse, code: 403, isWebsite: true }, done);
+        });
+
+        it('should respond with CORS headers at website endpoint (GET) ' +
+        'even in case of redirect',
+        done => {
+            const headers = { Origin: allowedOrigin };
+            methodRequest({ method: 'GET', bucket, objectKey: 'redirect',
+            headers, headersResponse, code: 301, isWebsite: true }, done);
+        });
+
+        it('should respond with CORS headers at website endpoint (HEAD)',
+        done => {
+            const headers = { Origin: allowedOrigin };
+            methodRequest({ method: 'HEAD', bucket, headers, headersResponse,
+            code: 200, isWebsite: true }, done);
+        });
+    });
+
+    describe('on bucket with additional cors configuration',
+    () => {
+        afterEach(done => {
+            s3.deleteBucketCors({ Bucket: bucket }, done);
+        });
+
+        describe('cors configuration : AllowedHeaders', () => {
+            const corsParams = generateCorsParams(bucket, defaultOptions);
+            corsParams.CORSConfiguration.CORSRules[0]
+                .AllowedHeaders = ['Content-Type'];
+
+            const headersResponse = {
+                'access-control-allow-origin': allowedOrigin,
+                'access-control-allow-methods': 'GET',
+                'access-control-allow-credentials': 'true',
+                vary,
+            };
+
+            beforeEach(done => {
+                s3.putBucketCors(corsParams, done);
+            });
+
+            it('should not return access-control-allow-headers response ' +
+            'header even if request matches CORS rule and other access-' +
+            'control headers are returned', done => {
+                const headers = {
+                    'Origin': allowedOrigin,
+                    'Content-Type': 'testvalue',
+                };
+                const headersOmitted = ['access-control-allow-headers'];
+                methodRequest({ method: 'GET', bucket, headers, headersResponse,
+                headersOmitted, code: 200 }, done);
+            });
+
+            it('Request with matching Origin/method but additional headers ' +
+            'that violate CORS rule:\n\t should still respond with access-' +
+            'control headers (headers are only checked in preflight requests)',
+            done => {
+                const headers = {
+                    Origin: allowedOrigin,
+                    Test: 'test',
+                    Expires: 86400,
+                };
+                methodRequest({ method: 'GET', bucket, headers, headersResponse,
+                code: 200 }, done);
+            });
+        });
+
+        [
+            {
+                name: 'MaxAgeSeconds',
+                header: 'access-control-max-age',
+                testValue: '86400',
+            },
+            {
+                name: 'ExposeHeaders',
+                header: 'access-control-expose-headers',
+                testValue: ['Content-Type'],
+            },
+        ].forEach(elem => {
+            describe(`cors configuration : ${elem.name}`, () => {
+                const corsParams = generateCorsParams(bucket, defaultOptions);
+                corsParams.CORSConfiguration.CORSRules[0][elem.name] =
+                    elem.testValue;
+
+                beforeEach(done => {
+                    s3.putBucketCors(corsParams, done);
+                });
+
+                it(`should respond with ${elem.header} header ` +
+                'if request matches CORS rule', done => {
+                    const headers = { Origin: allowedOrigin };
+                    const headersResponse = {
+                        'access-control-allow-origin': allowedOrigin,
+                        'access-control-allow-methods': 'GET',
+                        'access-control-allow-credentials': 'true',
+                        vary,
+                    };
+                    headersResponse[elem.header] =
+                        Array.isArray(elem.testValue) ? elem.testValue[0] :
+                        elem.testValue;
+                    methodRequest({ method: 'GET', bucket, headers,
+                    headersResponse, code: 200 }, done);
+                });
+            });
+        });
+    });
+});

--- a/tests/unit/api/bucketDelete.js
+++ b/tests/unit/api/bucketDelete.js
@@ -41,7 +41,7 @@ describe('bucketDelete API', () => {
         }, postBody);
 
         bucketPut(authInfo, testRequest, locationConstraint, log, err => {
-            assert.strictEqual(err, undefined);
+            assert.strictEqual(err, null);
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
                 assert.strictEqual(err, null);
                 bucketDelete(authInfo, testRequest, log, err => {

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -74,15 +74,17 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
+            next =>
+                bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
+            (corsHeaders, next) =>
+                objectPut(authInfo, testPutObjectRequest1, undefined,
                 log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest2, undefined, log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) =>
+                bucketGet(authInfo, testGetRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult
@@ -105,13 +107,13 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
-                log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, next),
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest2, undefined, log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
@@ -134,13 +136,13 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
-                log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, next),
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest2, undefined, log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
@@ -176,13 +178,13 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
-                log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, next),
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest2, undefined, log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.MaxKeys[0],
@@ -203,15 +205,15 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
-                log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, next),
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest2, undefined, log, next),
-            (result, prevLen, next) => objectPut(authInfo,
+            (result, corsHeaders, next) => objectPut(authInfo,
                 testPutObjectRequest3, undefined, log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
@@ -235,11 +237,11 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest1, undefined,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, next),
+            (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
                 log, next),
-            (result, prevLen, next) => bucketGet(authInfo, testGetRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.Contents[0].Key[0],
@@ -260,8 +262,9 @@ describe('bucketGet API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => bucketGet(authInfo, testGetRequest, log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketGet(authInfo, testGetRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult.$.xmlns,

--- a/tests/unit/api/bucketGetACL.js
+++ b/tests/unit/api/bucketGetACL.js
@@ -50,10 +50,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo,
+                testGetACLRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -83,10 +84,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -127,10 +129,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -165,10 +168,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -204,10 +208,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -263,10 +268,11 @@ describe('bucketGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => bucketPutACL(authInfo, testPutACLRequest, log, next),
-            (result, next) => bucketGetACL(authInfo, testGetACLRequest, log,
-                                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) =>
+                bucketPutACL(authInfo, testPutACLRequest, log, next),
+            (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
+                log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -38,12 +38,11 @@ describe('bucketHead API', () => {
         });
     });
 
-    it('should return a success message if ' +
-       'bucket exists and user is authorized', done => {
+    it('should return no error if bucket exists and user is authorized',
+    done => {
         bucketPut(authInfo, testRequest, locationConstraint, log, () => {
-            bucketHead(authInfo, testRequest, log, (err, result) => {
-                assert.strictEqual(result,
-                                   'Bucket exists and user authorized -- 200');
+            bucketHead(authInfo, testRequest, log, err => {
+                assert.strictEqual(err, null);
                 done();
             });
         });

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -138,7 +138,7 @@ describe('bucketPut API', () => {
             post: '',
         };
         bucketPut(authInfo, testRequest, locationConstraint, log, err => {
-            assert.strictEqual(err, undefined);
+            assert.strictEqual(err, null);
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(err, null);
                 assert.strictEqual(md.getAcl().Canned, 'public-read');
@@ -174,7 +174,7 @@ describe('bucketPut API', () => {
         const canonicalIDforSample2 =
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
         bucketPut(authInfo, testRequest, locationConstraint, log, err => {
-            assert.strictEqual(err, undefined, 'Error creating bucket');
+            assert.strictEqual(err, null, 'Error creating bucket');
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(md.getAcl().READ[0], constants.logId);
                 assert.strictEqual(md.getAcl().WRITE[0], constants.publicId);

--- a/tests/unit/api/listMultipartUploads.js
+++ b/tests/unit/api/listMultipartUploads.js
@@ -70,13 +70,14 @@ describe('listMultipartUploads API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
-                        log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest2, log, next),
-            (result, next) => listMultipartUploads(authInfo, testListRequest,
-                                log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest1, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest2, log, next),
+            (result, corsHeaders, next) => listMultipartUploads(authInfo,
+                testListRequest, log, next),
+            (result, corsHeaders, next) =>
+                parseString(result, corsHeaders, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListMultipartUploadsResult
@@ -100,13 +101,14 @@ describe('listMultipartUploads API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
-                        log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest2, log, next),
-            (result, next) => listMultipartUploads(authInfo, testListRequest,
-                                log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest1, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest2, log, next),
+            (result, corsHeaders, next) =>
+                listMultipartUploads(authInfo, testListRequest, log, next),
+            (result, corsHeaders, next) =>
+                parseString(result, corsHeaders, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListMultipartUploadsResult
@@ -132,13 +134,14 @@ describe('listMultipartUploads API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
-                        log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest2, log, next),
-            (result, next) => listMultipartUploads(authInfo, testListRequest,
-                                log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest1, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest2, log, next),
+            (result, corsHeaders, next) => listMultipartUploads(authInfo,
+                testListRequest, log, next),
+            (result, corsHeaders, next) =>
+                parseString(result, corsHeaders, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListMultipartUploadsResult
@@ -168,15 +171,16 @@ describe('listMultipartUploads API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
-                        log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest2, log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest3, log, next),
-            (result, next) => listMultipartUploads(authInfo, testListRequest,
-                                log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest1, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest2, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest3, log, next),
+            (result, corsHeaders, next) => listMultipartUploads(authInfo,
+                testListRequest, log, next),
+            (result, corsHeaders, next) =>
+                parseString(result, corsHeaders, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListMultipartUploadsResult
@@ -200,15 +204,16 @@ describe('listMultipartUploads API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testPutBucketRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, testInitiateMPURequest1,
-                        log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest2, log, next),
-            (result, next) => initiateMultipartUpload(authInfo,
-                                testInitiateMPURequest3, log, next),
-            (result, next) => listMultipartUploads(authInfo, testListRequest,
-                                log, next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest1, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest2, log, next),
+            (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
+                testInitiateMPURequest3, log, next),
+            (result, corsHeaders, next) => listMultipartUploads(authInfo,
+                testListRequest, log, next),
+            (result, corsHeaders, next) =>
+                parseString(result, corsHeaders, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListMultipartUploadsResult

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -74,9 +74,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => {
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => {
                 const mpuKeys = metadata.keyMaps.get(mpuBucket);
                 assert.strictEqual(mpuKeys.size, 1);
                 assert(mpuKeys.keys().next().value
@@ -140,9 +140,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -189,9 +189,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -226,9 +226,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -266,9 +266,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -307,9 +307,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -390,9 +390,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -478,11 +478,11 @@ describe('Multipart Upload API', () => {
                 bucketPut(authInfo, bucketPutRequest,
                     locationConstraint, log, next);
             },
-            function waterfall2(next) {
+            function waterfall2(corsHeaders, next) {
                 initiateMultipartUpload(
                     authInfo, initiateRequest, log, next);
             },
-            function waterfall3(result, next) {
+            function waterfall3(result, corsHeaders, next) {
                 parseString(result, next);
             },
         ],
@@ -558,9 +558,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -611,9 +611,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -664,9 +664,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -741,9 +741,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -799,9 +799,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -873,9 +873,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -955,9 +955,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -1058,9 +1058,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -1161,9 +1161,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -1248,9 +1248,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId
@@ -1294,9 +1294,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => {
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => {
                 const mpuKeys = metadata.keyMaps.get(mpuBucket);
                 assert.strictEqual(mpuKeys.size, 1);
                 parseString(result, next);
@@ -1345,9 +1345,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest, locationConstraint,
                 log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
             (json, next) => {
                 const testUploadId =
                           json.InitiateMultipartUploadResult.UploadId[0];
@@ -1420,7 +1420,7 @@ describe('Multipart Upload API', () => {
                 assert.deepStrictEqual(ds[2].value, partBody);
                 initiateMultipartUpload(authInfo, initiateRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
             (json, next) => {
                 const testUploadId =
                     json.InitiateMultipartUploadResult.UploadId[0];
@@ -1484,9 +1484,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest, locationConstraint,
                 log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
             (json, next) => {
                 uploadId = json.InitiateMultipartUploadResult.UploadId[0];
                 const requestObj = {
@@ -1570,9 +1570,9 @@ describe('Multipart Upload API', () => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,
                 locationConstraint, log, next),
-            next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                        next),
-            (result, next) => parseString(result, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, json) => {
             // Need to build request in here since do not have uploadId

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -27,7 +27,7 @@ function testAuth(bucketOwner, authUser, bucketPutReq, objPutReq, objDelReq,
             objectPut(bucketOwner, objPutReq, undefined, log, err => {
                 assert.strictEqual(err, null);
                 objectDelete(authUser, objDelReq, log, err => {
-                    assert.strictEqual(err, undefined);
+                    assert.strictEqual(err, null);
                     cb();
                 });
             });
@@ -80,7 +80,7 @@ describe('objectDelete API', () => {
                 objectPut(authInfo, testPutObjectRequest,
                     undefined, log, () => {
                         objectDelete(authInfo, testDeleteRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             objectGet(authInfo, testGetObjectRequest,
                                 log, err => {
                                     assert.deepStrictEqual(err,
@@ -105,7 +105,7 @@ describe('objectDelete API', () => {
                 objectPut(authInfo, testPutObjectRequest,
                     undefined, log, () => {
                         objectDelete(authInfo, testDeleteRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             objectGet(authInfo, testGetObjectRequest,
                                 log, err => {
                                     const expected =

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -109,9 +109,9 @@ describe('objectGet API', () => {
             async.waterfall([
                 next => bucketPut(authInfo, testPutBucketRequest,
                     locationConstraint, log, next),
-                next => initiateMultipartUpload(authInfo, initiateRequest, log,
-                            next),
-                (result, next) => parseString(result, next),
+                (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                    initiateRequest, log, next),
+                (result, corsHeaders, next) => parseString(result, next),
                 (json, next) => {
                     const testUploadId =
                     json.InitiateMultipartUploadResult.UploadId[0];

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -42,6 +42,7 @@ describe('objectGetACL API', () => {
     const testGetACLRequest = {
         bucketName,
         namespace,
+        headers: {},
         objectKey: objectName,
         url: `/${bucketName}/${objectName}?acl`,
         query: { acl: '' },
@@ -59,13 +60,13 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -100,13 +101,13 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -137,13 +138,13 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -181,13 +182,13 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -222,13 +223,13 @@ describe('objectGetACL API', () => {
             next =>
                 bucketPut(otherAccountAuthInfo, testBucketPutRequest,
                     locationConstraint, log, next),
-            next => objectPut(
+            (corsHeaders, next) => objectPut(
                 authInfo, testPutObjectRequest, undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -262,13 +263,13 @@ describe('objectGetACL API', () => {
             next =>
                 bucketPut(otherAccountAuthInfo, testBucketPutRequest,
                     locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.
@@ -312,13 +313,13 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
                 locationConstraint, log, next),
-            next => objectPut(authInfo, testPutObjectRequest,
+            (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
-            (result, prevLen, next) => {
+            (result, corsHeaders, next) => {
                 assert.strictEqual(result, correctMD5);
                 objectGetACL(authInfo, testGetACLRequest, log, next);
             },
-            (result, next) => parseString(result, next),
+            (result, corsHeaders, next) => parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.AccessControlPolicy.

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -89,7 +89,7 @@ describe('putObjectACL API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             metadata.getObjectMD(bucketName, objectName, log,
                             (err, md) => {
                                 assert.strictEqual(md.acl.Canned,
@@ -127,14 +127,14 @@ describe('putObjectACL API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest1, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             metadata.getObjectMD(bucketName, objectName, log,
                             (err, md) => {
                                 assert.strictEqual(md.acl.Canned,
                                 'public-read');
                                 objectPutACL(authInfo, testObjACLRequest2, log,
                                     err => {
-                                        assert.strictEqual(err, undefined);
+                                        assert.strictEqual(err, null);
                                         metadata.getObjectMD(bucketName,
                                             objectName, log, (err, md) => {
                                                 assert.strictEqual(md
@@ -171,7 +171,7 @@ describe('putObjectACL API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             metadata.getObjectMD(bucketName, objectName, log,
                             (err, md) => {
                                 assert.strictEqual(err, null);
@@ -246,7 +246,7 @@ describe('putObjectACL API', () => {
                     log, (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             metadata.getObjectMD(bucketName, objectName, log,
                             (err, md) => {
                                 assert.strictEqual(md
@@ -312,7 +312,7 @@ describe('putObjectACL API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, undefined);
+                            assert.strictEqual(err, null);
                             metadata.getObjectMD(bucketName, objectName, log,
                             (err, md) => {
                                 assert.strictEqual(md.acl.Canned, '');

--- a/tests/unit/api/serviceGet.js
+++ b/tests/unit/api/serviceGet.js
@@ -52,15 +52,15 @@ describe('serviceGet API', () => {
                 bucketPut(authInfo, testbucketPutRequest1, locationConstraint,
                     log, next);
             },
-            function waterfall2(next) {
+            function waterfall2(corsHeaders, next) {
                 bucketPut(authInfo, testbucketPutRequest2, locationConstraint,
                     log, next);
             },
-            function waterfall3(next) {
+            function waterfall3(corsHeaders, next) {
                 bucketPut(authInfo, testbucketPutRequest3, locationConstraint,
                     log, next);
             },
-            function waterfall4(next) {
+            function waterfall4(corsHeaders, next) {
                 serviceGet(authInfo, serviceGetRequest, log, next);
             },
             function waterfall4(result, next) {


### PR DESCRIPTION
Part of S3 CORS implementation.
If Origin header designates request as a CORS request and bucket has CORS configuration, should respond with `access-control-allow-origin`, `access-control-allow-methods`, `access-control-allow-credentials` and `vary` headers if the request matches a CORS rule.

Because the cors headers require checking the cors configuration of the bucket, this involved refactoring the api methods to return an extra parameter `corsHeaders` to be added to the response meta headers, even in case of errors. 

As noted, we opted to avoid making extra calls to the metadata backend (departure from AWS compatibility) and instead gather the headers once existing metadata calls to retrieve bucketInfo are completed, generally for bucket authorization.