### PR TITLE
BF: Update error code in routePOST

### DIFF
--- a/lib/routes/routePOST.js
+++ b/lib/routes/routePOST.js
@@ -53,7 +53,7 @@ export default function routePOST(request, response, log, utapi) {
                         log);
                 });
         } else {
-            routesUtils.responseNoBody(errors.InternalError, null, response,
+            routesUtils.responseNoBody(errors.NotImplemented, null, response,
                 200, log);
         }
         return undefined;


### PR DESCRIPTION
Fix #551
Pass `errors.NotImplemented` (err code 501)
instead of `errors.InternalError` (err code 500)