### PR TITLE
README: Use s3api instead of s3 for awscli

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,16 @@ aws_access_key_id = accessKey1
 aws_secret_access_key = verySecretKey1
 ```
 
+Create a bucket:
+
+```shell
+aws s3api create-buket --endpoint-url=http://localhost:8000 --bucket mybucket
+```
+
 See all buckets:
 
 ```shell
-aws s3 ls --endpoint-url=http://localhost:8000
+aws s3api list-buckets --endpoint-url=http://localhost:8000 --output=text
 ```
 
 #### [s3cmd](http://s3tools.org/s3cmd)

--- a/README.md
+++ b/README.md
@@ -186,16 +186,24 @@ aws_access_key_id = accessKey1
 aws_secret_access_key = verySecretKey1
 ```
 
+Also, `~/.aws/config` on Linux, OS X, or Unix or
+`C:\Users\USERNAME\.aws\config` on Windows
+
+```shell
+[default]
+region = us-east-1
+```
+
 Create a bucket:
 
 ```shell
-aws s3api create-buket --endpoint-url=http://localhost:8000 --bucket mybucket
+aws s3 --endpoint-url=http://localhost:8000 mb s3://mybucket
 ```
 
 See all buckets:
 
 ```shell
-aws s3api list-buckets --endpoint-url=http://localhost:8000 --output=text
+aws s3 --endpoint-url=http://localhost:8000 ls
 ```
 
 #### [s3cmd](http://s3tools.org/s3cmd)


### PR DESCRIPTION
Hey guys,

Just went through the README to bootstrap a s3 server on my machine and I found it easier to use `s3api` subcommand from the `aws` CLI too instead of `s3`. Reason is that with `s3` one has to specify a region and I haven't found any workout to deal with it, since it is not describe in the `README.md`.

What do you thinks?

Cheers,