### PR TITLE
FIX: Exit server when connections are drained

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -84,8 +84,7 @@ class S3Server {
      */
     cleanUp() {
         logger.info('server shutting down');
-        this.server.close();
-        process.exit(0);
+        this.server.close(() => process.exit(0));
     }
 
     caughtExceptionShutdown() {


### PR DESCRIPTION
This allows seamless exits/restarts where already-connected clients
won't get any errors for in-flight requests.

Fix #550