### PR TITLE
FIX: Kill worker less zealously

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -95,12 +95,6 @@ class S3Server {
         // Will close all servers, cause disconnect event on master and kill
         // worker process with 'SIGTERM'.
         this.worker.kill();
-        const killTimer = setTimeout(() => {
-            if (!this.worker.isDead()) {
-                this.worker.kill('SIGKILL');
-            }
-        }, 2000);
-        killTimer.unref();
     }
 }
 
@@ -135,7 +129,10 @@ export default function main() {
                 workerPid: worker.process.pid,
             });
             setTimeout(() => {
-                if (!worker.isDead()) {
+                // TODO: When upgrading to Node v6,
+                // instead of !worker.suicide,
+                // use !worker.exitedAfterDisconnect
+                if (!worker.isDead() && !worker.suicide) {
                     logger.error('worker not exiting. killing it', {
                         workerId: worker.id,
                         workerPid: worker.pid,


### PR DESCRIPTION
Only set one timeout to check worker killed.
Check that worker.suicide not already
set before killing.


Should help prevent seeing errors like those described here: https://github.com/scality/S3/issues/546