### PR TITLE
FIX: abortMpu return 404 only if usEastBehavior

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,5 +34,6 @@
     },
     "healthChecks": {
         "allowFrom": ["127.0.0.1/8", "::1"]
-    }
+    },
+    "usEastBehavior": false
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -57,6 +57,11 @@ class Config {
             this.clusters = config.clusters;
         }
 
+        this.usEastBehavior = false;
+        if (config.usEastBehavior !== undefined) {
+            assert(typeof config.usEastBehavior === 'boolean');
+            this.usEastBehavior = config.usEastBehavior;
+        }
         this.sproxyd = { bootstrap: [] };
         if (config.sproxyd !== undefined) {
             if (config.sproxyd.bootstrap !== undefined) {

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -1,4 +1,6 @@
 import async from 'async';
+import { errors } from 'arsenal';
+import config from '../Config';
 
 import constants from '../../constants';
 import data from '../data/wrapper';
@@ -22,6 +24,7 @@ function multipartDelete(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
     const uploadId = request.query.uploadId;
+
     const metadataValMPUparams = {
         authInfo,
         bucketName,
@@ -34,7 +37,7 @@ function multipartDelete(authInfo, request, log, callback) {
     // params are the same as validating at the MPU level
     // but the requestType is the more general 'objectDelete'
     const metadataValParams = Object.assign({}, metadataValMPUparams);
-    metadataValParams.requestType = 'objectPut';
+    metadataValParams.requestType = 'objectDelete';
 
     async.waterfall([
         function checkDestBucketVal(next) {
@@ -57,10 +60,22 @@ function multipartDelete(authInfo, request, log, callback) {
                 });
         },
         function checkMPUval(next) {
-            services.metadataValidateMultipart(metadataValParams, next);
+            services.metadataValidateMultipart(metadataValParams,
+                (err, mpuBucket, mpuOverviewArray) => {
+                    if (err === errors.NoSuchUpload) {
+                        log.trace('did not find valid mpu with uploadId' +
+                        `${uploadId}`, { method: 'multipartDelete' });
+                        // return 404 if usEastBehavior is enabled in config
+                        if (config.usEastBehavior) {
+                            return callback(err);
+                        } // otherwise return 204
+                        return callback();
+                    }
+                    return next(null, mpuBucket, mpuOverviewArray);
+                });
         },
         function getPartLocations(mpuBucket, mpuOverviewArray, next) {
-            services.getMPUparts(mpuBucket.getName(), uploadId, log,
+            return services.getMPUparts(mpuBucket.getName(), uploadId, log,
                 (err, result) => {
                     if (err) {
                         return next(err);

--- a/tests/unit/api/multipartDelete.js
+++ b/tests/unit/api/multipartDelete.js
@@ -1,0 +1,87 @@
+import assert from 'assert';
+import async from 'async';
+import { errors } from 'arsenal';
+import { parseString } from 'xml2js';
+
+import config from '../../../lib/Config';
+import { cleanup, DummyRequestLogger } from '../helpers';
+import bucketPut from '../../../lib/api/bucketPut';
+import initiateMultipartUpload
+    from '../../../lib/api/initiateMultipartUpload';
+import multipartDelete from '../../../lib/api/multipartDelete';
+import { makeAuthInfo } from '../helpers';
+
+const bucketName = 'multipartdeletebucket';
+const log = new DummyRequestLogger();
+const locationConstraint = 'us-east-1';
+const authInfo = makeAuthInfo('accessKey1');
+
+const namespace = 'default';
+const bucketPutRequest = {
+    bucketName,
+    namespace,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+    post: '',
+};
+const objectKey = 'testObject';
+const initiateRequest = {
+    bucketName,
+    namespace,
+    objectKey,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: `/${objectKey}?uploads`,
+};
+const originalUsEastValue = config.usEastBehavior;
+
+function _createAndAbortMpu(usEastSetting, fakeUploadID, callback) {
+    config.usEastBehavior = usEastSetting;
+    async.waterfall([
+        next => bucketPut(authInfo, bucketPutRequest, locationConstraint, log,
+            next),
+        next =>
+            initiateMultipartUpload(authInfo, initiateRequest, log, next),
+        (result, next) => parseString(result, next),
+        (json, next) => {
+            const testUploadId = fakeUploadID ? 'nonexistinguploadid' :
+                json.InitiateMultipartUploadResult.UploadId[0];
+            const deleteMpuRequest = {
+                bucketName,
+                namespace,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                url: `/${objectKey}`,
+                query: `uploadId=${testUploadId}`,
+            };
+            next(null, deleteMpuRequest);
+        },
+        (deleteMpuRequest, next) =>
+            multipartDelete(authInfo, deleteMpuRequest, log, next),
+    ], callback);
+}
+
+describe('Multipart Delete API', () => {
+    beforeEach(() => {
+        cleanup();
+    });
+    afterEach(() => {
+        config.usEastBehavior = originalUsEastValue; // set back to default
+        cleanup();
+    });
+
+    it('should return 404 if uploadId does not exist and usEastBehavior' +
+    'set to true', done => {
+        _createAndAbortMpu(true, true, err => {
+            assert.strictEqual(err, errors.NoSuchUpload,
+                `Expected NoSuchUpload, got ${err}`);
+            done();
+        });
+    });
+
+    it('should return no error if uploadId does not exist and usEastBehavior' +
+    'set to false', done => {
+        _createAndAbortMpu(false, true, err => {
+            assert.strictEqual(err, undefined, `Expected no error, got ${err}`);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
FIX #568

Change response so returns 204 instead of 404 when UploadID does not exist, unless usEastBehavior is set to true.

Note: Since changes to save locationConstraint in metadata have not been introduced yet in this branch, we do not check region and rely on usEastBehavior alone.