### PR TITLE
listenOn: Disable IP parsing to allow the usage of FQDNs

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
-import { ipCheck } from 'arsenal';
 
 import authDataChecker from './auth/in_memory/checker';
 
@@ -58,9 +57,6 @@ class Config {
                     item.substr(0, lastColon);
                 // the port should not include the colon
                 const port = item.substr(lastColon + 1);
-                // parseIp returns as empty object if the address is invalid
-                assert(Object.keys(ipCheck.parseIp(ipAddress)).length !== 0,
-                    'bad config: listenOn IP address must be valid');
                 assert(parseInt(port, 10),
                     'bad config: listenOn port must be a positive integer');
                 this.listenOn.push({ ip: ipAddress, port });


### PR DESCRIPTION
This patch removes the check of the IP's format, since we want to be able to use FQDNs instead.

Related to our ongoing multi-ports fixes.