### PR TITLE
FIX: large mpu test socket hangup

### DIFF
--- a/tests/functional/aws-node-sdk/test/object/bigMpu.js
+++ b/tests/functional/aws-node-sdk/test/object/bigMpu.js
@@ -39,9 +39,13 @@ describe('large mpu', function tester() {
     before(done => {
         const config = getConfig('default', { signatureVersion: 'v4' });
         s3 = new S3(config);
-        // disable retries so sdk will not resend request because complete mpu
-        // is taking long, the retry causing test to fail (see Integration#449)
+        // disable node sdk retries and timeout to prevent InvalidPart
+        // and SocketHangUp errors. If retries are allowed, sdk will send
+        // another request after first request has already deleted parts,
+        // causing InvalidPart. Meanwhile, if request takes too long to finish,
+        // sdk will create SocketHangUp error before response.
         s3.config.update({ maxRetries: 0 });
+        s3.config.update({ httpOptions: { timeout: 0 } });
         s3.createBucket({ Bucket: bucket }, done);
     });
 


### PR DESCRIPTION
https://github.com/scality/Integration/issues/449

This test has been flaky on end-to-end CI tests recently. Disabling retries prevented InvalidPart errors but we have still encountered SocketHangUp errors since. This aims to prevent those errors by increasing SDK timeout config for this test from default of 2 minutes to 5 minutes.