### PR TITLE
FIX: Include part size sum in Utapi object

### DIFF
--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -107,6 +107,9 @@ function multipartDelete(authInfo, request, log, callback) {
             // Reconstruct mpuOverviewKey
             const mpuOverviewKey =
                 `overview${splitter}${objectKey}${splitter}${uploadId}`;
+            // Get the sum of all part sizes to include in pushMetric object
+            const partSizeSum = storedParts.map(item => item.value.Size)
+                .reduce((currPart, nextPart) => currPart + nextPart, 0);
             const keysToDelete = storedParts.map(item => item.key);
             keysToDelete.push(mpuOverviewKey);
             services.batchDeleteObjectMetadata(mpuBucket.getName(),
@@ -117,6 +120,7 @@ function multipartDelete(authInfo, request, log, callback) {
                     pushMetric('abortMultipartUpload', log, {
                         authInfo,
                         bucket: bucketName,
+                        byteLength: partSizeSum,
                     });
                     return next(null, destBucket);
                 });


### PR DESCRIPTION
Get sum of part sizes from existing part objects to pass to utapiClient.