### PR TITLE
FIX: remove auth credential check from websiteHead/Get

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -44,8 +44,10 @@ auth.setHandler(vault);
 
 const api = {
     callApiMethod(apiMethod, request, log, callback, locationConstraint) {
-        // no need to check auth on cors preflight requests
-        if (apiMethod === 'corsPreflight') {
+        // no need to check auth on website serving (head or get)
+        // or cors preflight requests
+        if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
+        apiMethod === 'corsPreflight') {
             return this[apiMethod](request, log, callback);
         }
         let sourceBucket;

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -77,14 +77,13 @@ function _errorActions(err, errorDocument, routingRules,
 
 /**
  * GET Website - Gets object for website or redirects
- * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - normalized request object
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
 export default
-function websiteGet(authInfo, request, log, callback) {
+function websiteGet(request, log, callback) {
     log.debug('processing request', { method: 'websiteGet' });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
@@ -147,9 +146,8 @@ function websiteGet(authInfo, request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
-                    const canonicalID = authInfo.getCanonicalID();
                     const bucketAuthorized = isBucketAuthorized(bucket,
-                      'bucketGet', canonicalID);
+                      'bucketGet', constants.publicId);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
                     if (err === errors.NoSuchKey && !bucketAuthorized) {

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -39,13 +39,12 @@ function _errorActions(err, routingRules, objectKey, corsHeaders, log,
 
 /**
  * HEAD Website - Gets metadata for object for website or redirects
- * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - normalized request object
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
-export default function websiteHead(authInfo, request, log, callback) {
+export default function websiteHead(request, log, callback) {
     log.debug('processing request', { method: 'websiteHead' });
     const bucketName = request.bucketName;
     const reqObjectKey = request.objectKey ? request.objectKey : '';
@@ -106,9 +105,8 @@ export default function websiteHead(authInfo, request, log, callback) {
                     log.trace('error retrieving object metadata',
                     { error: err });
                     let returnErr = err;
-                    const canonicalID = authInfo.getCanonicalID();
                     const bucketAuthorized = isBucketAuthorized(bucket,
-                      'bucketGet', canonicalID);
+                      'bucketGet', constants.publicId);
                     // if index object does not exist and bucket is private AWS
                     // returns 403 - AccessDenied error.
                     if (err === errors.NoSuchKey && !bucketAuthorized) {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "mocha-junit-reporter": "1.11.1",
     "node-mocks-http": "^1.5.2",
     "s3blaster": "scality/s3blaster",
-    "tv4": "^1.2.7",
-    "zombie": "^5.0.5"
+    "tv4": "^1.2.7"
   },
   "scripts": {
     "ft_awssdk": "cd tests/functional/aws-node-sdk && npm test",
@@ -68,7 +67,7 @@
     "ft_s3curl": "cd tests/functional/s3curl && npm test",
     "ft_test": "mocha tester.js --compilers js:babel-core/register",
     "init": "node init.js",
-    "install_ft_deps": "npm install aws-sdk@2.2.11 bluebird@3.3.1 mocha@2.3.4 mocha-junit-reporter@1.11.1 tv4@1.2.7 zombie@5.0.5",
+    "install_ft_deps": "npm install aws-sdk@2.2.11 bluebird@3.3.1 mocha@2.3.4 mocha-junit-reporter@1.11.1 tv4@1.2.7",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
     "mem_backend": "S3BACKEND=mem node index.js",

--- a/tests/functional/aws-node-sdk/lib/utility/website-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/website-util.js
@@ -6,17 +6,72 @@ import url from 'url';
 
 import makeRequest from '../../../raw-node/utils/makeRequest';
 
-function _makeWebsiteRequest(urlstring, method, callback) {
+const bucketName = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
+    'bucketwebsitetester';
+let awsCredentials;
+
+function _parseConfigValue(string, fileSlice) {
+    const line = fileSlice.find(element => element.indexOf(string) > -1);
+    const keyValue = line.replace(/ /g, '').split('=');
+    // the element after the '=' should be the value
+    return keyValue[1];
+}
+
+function _retrieveAWSCredentials(profile) {
+    const filename = path.join(process.env.HOME, '/.aws/scality');
+    let file;
+
+    try {
+        file = fs.readFileSync(filename, 'utf8');
+    } catch (e) {
+        const msg = `AWS credential file does not exist: ${filename}`;
+        throw new Error(msg);
+    }
+
+    const fileContents = file.split('\n');
+    const profileIndex = file.indexOf(`[${profile}]`);
+    if (profileIndex > -1) {
+        const accessKey = _parseConfigValue('aws_access_key_id',
+            fileContents.slice(profileIndex));
+        const secretKey = _parseConfigValue('aws_secret_access_key',
+            fileContents.slice(profileIndex));
+        return { accessKey, secretKey };
+    }
+    const msg = `Profile ${profile} does not exist in AWS credential file`;
+    throw new Error(msg);
+}
+
+if (process.env.AWS_ON_AIR) {
+    awsCredentials = _retrieveAWSCredentials('default');
+}
+
+function _makeWebsiteRequest(auth, method, urlstring, callback) {
+    let authCredentials;
+    if (auth === 'valid credentials') {
+        authCredentials = awsCredentials || {
+            accessKey: 'accessKey1',
+            secretKey: 'verySecretKey1',
+        };
+    } else if (auth === 'invalid credentials') {
+        authCredentials = {
+            accessKey: 'fakeKey1',
+            secretKey: 'fakeSecretKey1',
+        };
+    } else if (auth !== undefined) {
+        throw new Error(`Unsupported auth type ${auth}`);
+    }
     const { hostname, port, path } = url.parse(urlstring);
-    makeRequest({ hostname, port, method, path }, callback);
+    makeRequest({ hostname, port, method, path, authCredentials }, callback);
 }
 
 function _assertResponseHtml(response, elemtag, content) {
     if (elemtag === 'ul') {
-        const startIndex = response.indexOf('<ul>');
+        const startingTag = '<ul>';
+        const startIndex = response.indexOf(startingTag);
         const endIndex = response.indexOf('</ul>');
         assert(startIndex > -1 && endIndex > -1, 'Did not find ul element');
-        const ulElem = response.slice(startIndex + 4, endIndex);
+        const ulElem = response.slice(startIndex + startingTag.length,
+            endIndex);
         content.forEach(item => {
             _assertResponseHtml(ulElem, 'li', item);
         });
@@ -32,14 +87,29 @@ function _assertContainsHtml(responseBody) {
         responseBody.includes('</html>'), 'Did not find html tags');
 }
 
-function _assertResponseHtml404(method, response, type, bucketName) {
+function _assertResponseHtml404(method, response, type) {
     assert.strictEqual(response.statusCode, 404);
     if (method === 'HEAD') {
-        if (type !== '404-no-such-bucket'
-        && type !== '404-no-such-website-configuration'
-        && type !== '404-not-found') {
-            throw new Error('This 404 error is not checked in ' +
-            'checkHTML()');
+        if (type === '404-no-such-bucket') {
+            assert.strictEqual(response.headers['x-amz-error-code'],
+            'NoSuchBucket');
+            // Need arsenal fixed to remove period at the end
+            // so compatible with aws
+            assert.strictEqual(response.headers['x-amz-error-message'],
+            'The specified bucket does not exist.');
+        } else if (type === '404-no-such-website-configuration') {
+            assert.strictEqual(response.headers['x-amz-error-code'],
+            'NoSuchWebsiteConfiguration');
+            assert.strictEqual(response.headers['x-amz-error-message'],
+            'The specified bucket does not have a website configuration');
+        } else if (type === '404-not-found') {
+            assert.strictEqual(response.headers['x-amz-error-code'],
+            'NoSuchKey');
+            assert.strictEqual(response.headers['x-amz-error-message'],
+            'The specified key does not exist.');
+        } else {
+            throw new Error(`'${type}' is not a recognized 404 ` +
+            'error checked in the WebsiteConfigTester.checkHTML function');
         }
         // don't need to check HTML for head requests
         return;
@@ -66,8 +136,8 @@ function _assertResponseHtml404(method, response, type, bucketName) {
             'Message: The specified key does not exist.',
         ]);
     } else {
-        throw new Error('This 404 error is not checked in ' +
-        'checkHTML()');
+        throw new Error(`'${type}' is not a recognized 404 ` +
+        'error checked in the WebsiteConfigTester.checkHTML function');
     }
 }
 
@@ -80,8 +150,8 @@ function _assertResponseHtml403(method, response, type) {
             assert.strictEqual(response.headers['x-amz-error-message'],
             'Access Denied');
         } else if (type !== '403-retrieve-error-document') {
-            throw new Error('This 403 error is not checked in ' +
-            'checkHTML()');
+            throw new Error(`'${type}' is not a recognized 403 ` +
+            'error checked in the WebsiteConfigTester.checkHTML function');
         }
     } else {
         _assertContainsHtml(response.body);
@@ -95,15 +165,18 @@ function _assertResponseHtml403(method, response, type) {
             _assertResponseHtml(response.body, 'h3',
             'An Error Occurred While Attempting to ' +
             'Retrieve a Custom Error Document');
-            const startIndex = response.body.indexOf('</h3>') + 5;
+            // start searching for second `ul` element after `h3` element
+            const startingTag = '</h3>';
+            const startIndex = response.body.indexOf(startingTag)
+                + startingTag.length;
             _assertResponseHtml(response.body.slice(startIndex),
             'ul', [
                 'Code: AccessDenied',
                 'Message: Access Denied',
             ]);
         } else if (type !== '403-access-denied') {
-            throw new Error('This 403 error is not checked in ' +
-            'checkHTML()');
+            throw new Error(`'${type}' is not a recognized 403 ` +
+            'error checked in the WebsiteConfigTester.checkHTML function');
         }
     }
 }
@@ -128,20 +201,24 @@ function _assertResponseHtmlIndexUser(response) {
         'extraordinary bucket website testing page');
 }
 
-function _assertResponseHtmlRedirect(response, type, redirectUrl) {
+function _assertResponseHtmlRedirect(response, type, redirectUrl, method) {
     if (type === 'redirect' || type === 'redirect-user') {
         assert.strictEqual(response.statusCode, 301);
         assert.strictEqual(response.body, '');
         assert.strictEqual(response.headers.location, redirectUrl);
     } else if (type === 'redirected-user') {
         assert.strictEqual(response.statusCode, 200);
+        if (method === 'HEAD') {
+            return;
+            // no need to check HTML
+        }
         _assertResponseHtml(response.body, 'title',
         'Best redirect link ever');
         _assertResponseHtml(response.body, 'h1',
         'Welcome to your redirection file');
     } else {
-        throw new Error('This redirect type is not checked in ' +
-        'checkHTML()');
+        throw new Error(`'${type}' is not a recognized redirect type ` +
+        'checked in the WebsiteConfigTester.checkHTML function');
     }
 }
 
@@ -179,32 +256,75 @@ export class WebsiteConfigTester {
         this.RoutingRules.push(newRule);
     }
 
-    static checkHTML(method, url, type, redirectUrl, bucketName, callback) {
-        _makeWebsiteRequest(url, method, (err, res) => {
+    /** checkHTML - check response for website head or get
+    * @param {object} params - function params
+    * @param {string} params.method - type of website request, 'HEAD' or 'GET'
+    * @param {string} params.responseType - type of response expected
+    * @param {string} [params.auth] - whether to use valid or invalid auth
+    *   crendentials: 'valid credentials' or 'invalid credentials'
+    * @param {string} [params.url] - request url
+    * @param {string} [params.redirectUrl] - redirect
+    * @param {function} callback - callback
+    * @return {undefined}
+    */
+    static checkHTML(params, callback) {
+        const { method, responseType, auth, url, redirectUrl } = params;
+        _makeWebsiteRequest(auth, method, url, (err, res) => {
             assert.strictEqual(err, null, `Unexpected request err ${err}`);
-            if (type) {
-                if (type.startsWith('404')) {
-                    _assertResponseHtml404(method, res, type, bucketName);
-                } else if (type.startsWith('403')) {
-                    _assertResponseHtml403(method, res, type);
-                } else if (type.startsWith('error-user')) {
-                    _assertResponseHtmlErrorUser(res, type);
-                } else if (type.startsWith('redirect')) {
-                    _assertResponseHtmlRedirect(res, type, redirectUrl);
-                    if (type === 'redirect-user') {
+            if (responseType) {
+                if (responseType.startsWith('404')) {
+                    _assertResponseHtml404(method, res, responseType);
+                } else if (responseType.startsWith('403')) {
+                    _assertResponseHtml403(method, res, responseType);
+                } else if (responseType.startsWith('error-user')) {
+                    _assertResponseHtmlErrorUser(res, responseType);
+                } else if (responseType.startsWith('redirect')) {
+                    _assertResponseHtmlRedirect(res, responseType, redirectUrl,
+                        method);
+                    if (responseType === 'redirect-user') {
                         process.stdout.write('Following redirect location\n');
-                        return this.checkHTML(method, res.headers.location,
-                        'redirected-user', null, null, callback);
+                        return this.checkHTML({ method,
+                            url: res.headers.location,
+                            responseType: 'redirected-user' },
+                        callback);
                     }
-                } else if (type === 'index-user') {
+                } else if (responseType === 'index-user') {
                     _assertResponseHtmlIndexUser(res);
                 } else {
-                    throw new Error('This is not checked in checkHTML()');
+                    throw new Error(`'${responseType}' is not a response ` +
+                    'type recognized by WebsiteConfigTester.checkHTML');
                 }
             }
             return callback();
         });
     }
+
+    /**
+     * makeHeadRequest - makes head request and asserts expected response
+     * @param {(string|null)} auth - whether to use valid, invalid,
+     * or no authentication credentials
+     * @param {string} url - request url
+     * @param {number} expectedStatusCode - expected response code
+     * @param {object} expectedHeaders - expected headers in response with
+     * expected values (e.g., {x-amz-error-code: AccessDenied})
+     * @param {function} cb - callback to end test
+     * @return {undefined}
+     */
+    static makeHeadRequest(auth, url, expectedStatusCode, expectedHeaders,
+        cb) {
+        _makeWebsiteRequest(auth, 'HEAD', url, (err, res) => {
+            // body should be empty
+            assert.deepStrictEqual(res.body, '');
+            assert.strictEqual(res.statusCode, expectedStatusCode);
+            const headers = Object.keys(expectedHeaders);
+            headers.forEach(header => {
+                assert.strictEqual(res.headers[header],
+                    expectedHeaders[header]);
+            });
+            return cb();
+        });
+    }
+
     static createPutBucketWebsite(s3, bucket, bucketACL, objects, done) {
         s3.createBucket({ Bucket: bucket, ACL: bucketACL },
         err => {

--- a/tests/functional/aws-node-sdk/lib/utility/website-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/website-util.js
@@ -1,6 +1,149 @@
+import assert from 'assert';
 import async from 'async';
 import fs from 'fs';
 import path from 'path';
+import url from 'url';
+
+import makeRequest from '../../../raw-node/utils/makeRequest';
+
+function _makeWebsiteRequest(urlstring, method, callback) {
+    const { hostname, port, path } = url.parse(urlstring);
+    makeRequest({ hostname, port, method, path }, callback);
+}
+
+function _assertResponseHtml(response, elemtag, content) {
+    if (elemtag === 'ul') {
+        const startIndex = response.indexOf('<ul>');
+        const endIndex = response.indexOf('</ul>');
+        assert(startIndex > -1 && endIndex > -1, 'Did not find ul element');
+        const ulElem = response.slice(startIndex + 4, endIndex);
+        content.forEach(item => {
+            _assertResponseHtml(ulElem, 'li', item);
+        });
+    } else {
+        const elem = `<${elemtag}>${content}</${elemtag}>`;
+        assert(response.includes(elem),
+            `Expected but did not find '${elem}' in html`);
+    }
+}
+
+function _assertContainsHtml(responseBody) {
+    assert(responseBody.startsWith('<html>') &&
+        responseBody.includes('</html>'), 'Did not find html tags');
+}
+
+function _assertResponseHtml404(method, response, type, bucketName) {
+    assert.strictEqual(response.statusCode, 404);
+    if (method === 'HEAD') {
+        if (type !== '404-no-such-bucket'
+        && type !== '404-no-such-website-configuration'
+        && type !== '404-not-found') {
+            throw new Error('This 404 error is not checked in ' +
+            'checkHTML()');
+        }
+        // don't need to check HTML for head requests
+        return;
+    }
+    _assertContainsHtml(response.body);
+    _assertResponseHtml(response.body, 'title', '404 Not Found');
+    _assertResponseHtml(response.body, 'h1', '404 Not Found');
+    if (type === '404-no-such-bucket') {
+        _assertResponseHtml(response.body, 'ul', [
+            'Code: NoSuchBucket',
+            'Message: The specified bucket does not exist.',
+            `BucketName: ${bucketName}`,
+        ]);
+    } else if (type === '404-no-such-website-configuration') {
+        _assertResponseHtml(response.body, 'ul', [
+            'Code: NoSuchWebsiteConfiguration',
+            'Message: The specified bucket does not have a ' +
+            'website configuration',
+            `BucketName: ${bucketName}`,
+        ]);
+    } else if (type === '404-not-found') {
+        _assertResponseHtml(response.body, 'ul', [
+            'Code: NoSuchKey',
+            'Message: The specified key does not exist.',
+        ]);
+    } else {
+        throw new Error('This 404 error is not checked in ' +
+        'checkHTML()');
+    }
+}
+
+function _assertResponseHtml403(method, response, type) {
+    assert.strictEqual(response.statusCode, 403);
+    if (method === 'HEAD') {
+        if (type === '403-access-denied') {
+            assert.strictEqual(response.headers['x-amz-error-code'],
+            'AccessDenied');
+            assert.strictEqual(response.headers['x-amz-error-message'],
+            'Access Denied');
+        } else if (type !== '403-retrieve-error-document') {
+            throw new Error('This 403 error is not checked in ' +
+            'checkHTML()');
+        }
+    } else {
+        _assertContainsHtml(response.body);
+        _assertResponseHtml(response.body, 'title', '403 Forbidden');
+        _assertResponseHtml(response.body, 'h1', '403 Forbidden');
+        _assertResponseHtml(response.body, 'ul', [
+            'Code: AccessDenied',
+            'Message: Access Denied',
+        ]);
+        if (type === '403-retrieve-error-document') {
+            _assertResponseHtml(response.body, 'h3',
+            'An Error Occurred While Attempting to ' +
+            'Retrieve a Custom Error Document');
+            const startIndex = response.body.indexOf('</h3>') + 5;
+            _assertResponseHtml(response.body.slice(startIndex),
+            'ul', [
+                'Code: AccessDenied',
+                'Message: Access Denied',
+            ]);
+        } else if (type !== '403-access-denied') {
+            throw new Error('This 403 error is not checked in ' +
+            'checkHTML()');
+        }
+    }
+}
+
+function _assertResponseHtmlErrorUser(response, type) {
+    if (type === 'error-user') {
+        assert.strictEqual(response.statusCode, 403);
+    } else if (type === 'error-user-404') {
+        assert.strictEqual(response.statusCode, 404);
+    }
+    _assertResponseHtml(response.body, 'title',
+        'Error!!');
+    _assertResponseHtml(response.body, 'h1',
+        'It appears you messed up');
+}
+
+function _assertResponseHtmlIndexUser(response) {
+    assert.strictEqual(response.statusCode, 200);
+    _assertResponseHtml(response.body, 'title',
+        'Best testing website ever');
+    _assertResponseHtml(response.body, 'h1', 'Welcome to my ' +
+        'extraordinary bucket website testing page');
+}
+
+function _assertResponseHtmlRedirect(response, type, redirectUrl) {
+    if (type === 'redirect' || type === 'redirect-user') {
+        assert.strictEqual(response.statusCode, 301);
+        assert.strictEqual(response.body, '');
+        assert.strictEqual(response.headers.location, redirectUrl);
+    } else if (type === 'redirected-user') {
+        assert.strictEqual(response.statusCode, 200);
+        _assertResponseHtml(response.body, 'title',
+        'Best redirect link ever');
+        _assertResponseHtml(response.body, 'h1',
+        'Welcome to your redirection file');
+    } else {
+        throw new Error('This redirect type is not checked in ' +
+        'checkHTML()');
+    }
+}
 
 export class WebsiteConfigTester {
     constructor(indexDocument, errorDocument, redirectAllReqTo) {
@@ -36,90 +179,31 @@ export class WebsiteConfigTester {
         this.RoutingRules.push(newRule);
     }
 
-    static checkHTML(browser, type, url, bucketName) {
-        // 404 error
-        if (url) {
-            browser.assert.url(url);
-        }
-        if (type) {
-            if (type.startsWith('404')) {
-                browser.assert.status(404);
-                browser.assert.text('title', '404 Not Found');
-                browser.assert.text('h1', '404 Not Found');
-                // ul section
-                if (type === '404-no-such-bucket') {
-                    browser.assert.text('ul:first-of-type > li:first-child',
-                    'Code: NoSuchBucket');
-                    browser.assert.text('ul:first-of-type > li:nth-child(2)',
-                    'Message: The specified bucket does not exist.');
-                    browser.assert.text('ul:first-of-type > li:nth-child(3)',
-                    `BucketName: ${bucketName}`);
-                } else if (type === '404-no-such-website-configuration') {
-                    browser.assert.text('ul:first-of-type > li:first-child',
-                    'Code: NoSuchWebsiteConfiguration');
-                    browser.assert.text('ul:first-of-type > li:nth-child(2)',
-                    'Message: The specified bucket does not have a website ' +
-                    'configuration');
-                    browser.assert.text('ul:first-of-type > li:nth-child(3)',
-                    `BucketName: ${bucketName}`);
-                } else if (type === '404-not-found') {
-                    browser.assert.text('ul:first-of-type > li:first-child',
-                    'Code: NoSuchKey');
-                    browser.assert.text('ul:first-of-type > li:nth-child(2)',
-                    'Message: The specified key does not exist.');
+    static checkHTML(method, url, type, redirectUrl, bucketName, callback) {
+        _makeWebsiteRequest(url, method, (err, res) => {
+            assert.strictEqual(err, null, `Unexpected request err ${err}`);
+            if (type) {
+                if (type.startsWith('404')) {
+                    _assertResponseHtml404(method, res, type, bucketName);
+                } else if (type.startsWith('403')) {
+                    _assertResponseHtml403(method, res, type);
+                } else if (type.startsWith('error-user')) {
+                    _assertResponseHtmlErrorUser(res, type);
+                } else if (type.startsWith('redirect')) {
+                    _assertResponseHtmlRedirect(res, type, redirectUrl);
+                    if (type === 'redirect-user') {
+                        process.stdout.write('Following redirect location\n');
+                        return this.checkHTML(method, res.headers.location,
+                        'redirected-user', null, null, callback);
+                    }
+                } else if (type === 'index-user') {
+                    _assertResponseHtmlIndexUser(res);
                 } else {
-                    throw new Error('This 404 error is not checked in ' +
-                    'checkHTML()');
+                    throw new Error('This is not checked in checkHTML()');
                 }
-            // 403 error
-            } else if (type.startsWith('403')) {
-                browser.assert.status(403);
-                browser.assert.text('title', '403 Forbidden');
-                browser.assert.text('h1', '403 Forbidden');
-                if (type === '403-access-denied') {
-                    browser.assert.text('ul:first-of-type > li:first-child',
-                    'Code: AccessDenied');
-                    browser.assert.text('ul:first-of-type > li:nth-child(2)',
-                    'Message: Access Denied');
-                } else if (type === '403-retrieve-error-document') {
-                    browser.assert.text('ul:first-of-type > li:first-child',
-                    'Code: AccessDenied');
-                    browser.assert.text('ul:first-of-type > li:nth-child(2)',
-                    'Message: Access Denied');
-                    browser.assert.text('h3', 'An Error Occurred While ' +
-                    'Attempting to Retrieve a Custom Error Document');
-                    browser.assert.text('ul:nth-of-type(2) > li:first-child',
-                    'Code: AccessDenied');
-                    browser.assert.text('ul:nth-of-type(2) > li:nth-child(2)',
-                    'Message: Access Denied');
-                } else {
-                    throw new Error('This 403 error is not checked in ' +
-                    'checkHTML()');
-                }
-            } else if (type === 'index-user') {
-                browser.assert.status(200);
-                browser.assert.text('title',
-                    'Best testing website ever');
-                browser.assert.text('h1', 'Welcome to my ' +
-                    'extraordinary bucket website testing page');
-            } else if (type === '200') {
-                browser.assert.status(200);
-            } else if (type === 'error-user') {
-                browser.assert.status(403);
-                browser.assert.text('title', 'Error!!');
-                browser.assert.text('h1', 'It appears you messed up');
-            } else if (type === 'error-user-404') {
-                browser.assert.status(404);
-                browser.assert.text('title', 'Error!!');
-                browser.assert.text('h1', 'It appears you messed up');
-            } else if (type === 'redirect-user') {
-                browser.assert.status(200);
-                browser.assert.text('title', 'Best redirect link ever');
-                browser.assert.text('h1', 'Welcome to your redirection file');
-            } else {
-                throw new Error('This is not checked in checkHTML()');
             }
-        }
+            return callback();
+        });
     }
     static createPutBucketWebsite(s3, bucket, bucketACL, objects, done) {
         s3.createBucket({ Bucket: bucket, ACL: bucketACL },

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -15,12 +15,14 @@ const s3 = new S3(config);
 const transport = conf.https ? 'https' : 'http';
 const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
     'bucketwebsitetester';
+const port = process.env.AWS_ON_AIR ? 80 : 8000;
 const hostname = `${bucket}.s3-website-us-east-1.amazonaws.com`;
-const endpoint = process.env.AWS_ON_AIR ? `${transport}://${hostname}` :
-    `${transport}://${hostname}:8000`;
-const redirectEndpoint = conf.https ? 'https://www.google.com' :
-    'http://www.google.com';
+const endpoint = `${transport}://${hostname}:${port}`;
+const redirectEndpoint = `${transport}://www.google.com`;
 
+// Note: To run these tests locally, you may need to edit the machine's
+// /etc/hosts file to include the following line:
+// `127.0.0.1 bucketwebsitetester.s3-website-us-east-1.amazonaws.com`
 
 function putBucketWebsiteAndPutObjectRedirect(redirect, condition, key, done) {
     const webConfig = new WebsiteConfigTester('index.html');
@@ -39,12 +41,13 @@ function putBucketWebsiteAndPutObjectRedirect(redirect, condition, key, done) {
     });
 }
 
-// Note: To run these tests locally, you may need to edit the /etc/hosts file
-// to include `127.0.0.1 bucketwebsitetester.s3-website-us-east-1.amazonaws.com`
 describe('User visits bucket website endpoint', () => {
     it('should return 404 when no such bucket', done => {
-        WebsiteConfigTester.checkHTML('GET', endpoint, '404-no-such-bucket',
-        null, bucket, done);
+        WebsiteConfigTester.checkHTML({
+            method: 'GET',
+            url: endpoint,
+            responseType: '404-no-such-bucket',
+        }, done);
     });
 
     describe('with existing bucket', () => {
@@ -53,8 +56,11 @@ describe('User visits bucket website endpoint', () => {
         afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
 
         it('should return 404 when no website configuration', done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint,
-            '404-no-such-website-configuration', null, bucket, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: '404-no-such-website-configuration',
+            }, done);
         });
 
         describe('with existing configuration', () => {
@@ -85,7 +91,7 @@ describe('User visits bucket website endpoint', () => {
             'or head', done => {
                 makeRequest({
                     hostname,
-                    port: process.env.AWS_ON_AIR ? 80 : 8000,
+                    port,
                     method: 'POST',
                 }, (err, res) => {
                     assert.strictEqual(err, null,
@@ -98,12 +104,18 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should serve indexDocument if no key requested', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'index-user',
-                null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'index-user',
+                }, done);
             });
             it('should serve indexDocument if key requested', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/index.html`,
-                'index-user', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/index.html`,
+                    responseType: 'index-user',
+                }, done);
             });
         });
         describe('with path in request with/without key', () => {
@@ -130,15 +142,20 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve indexDocument if path request without key',
             done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/pathprefix/`,
-                'index-user', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/pathprefix/`,
+                    responseType: 'index-user',
+                }, done);
             });
 
             it('should serve indexDocument if path request with key',
             done => {
-                WebsiteConfigTester.checkHTML('GET',
-                `${endpoint}/pathprefix/index.html`,
-                'index-user', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/pathprefix/index.html`,
+                    responseType: 'index-user',
+                }, done);
             });
         });
 
@@ -163,8 +180,11 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should return 403 if key is private', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint,
-                '403-access-denied', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: '403-access-denied',
+                }, done);
             });
         });
 
@@ -176,8 +196,11 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should return 403 if nonexisting index document key', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint,
-                '403-access-denied', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: '403-access-denied',
+                }, done);
             });
         });
 
@@ -193,13 +216,21 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it(`should redirect to ${redirectEndpoint}`, done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-                `${redirectEndpoint}/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/`,
+                }, done);
             });
 
             it(`should redirect to ${redirectEndpoint}/about`, done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about`,
-                'redirect', `${redirectEndpoint}/about`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about`,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/about`,
+                }, done);
             });
         });
 
@@ -220,13 +251,21 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should redirect to https://google.com/', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-                'https://www.google.com/', null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'redirect',
+                    redirectUrl: 'https://www.google.com/',
+                }, done);
             });
 
             it('should redirect to https://google.com/about', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about`,
-                'redirect', 'https://www.google.com/about', null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about`,
+                    responseType: 'redirect',
+                    redirectUrl: 'https://www.google.com/about',
+                }, done);
             });
         });
 
@@ -253,8 +292,11 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve custom error document if an error occurred',
             done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'error-user',
-                null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'error-user',
+                }, done);
             });
         });
 
@@ -268,8 +310,11 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve s3 error file if unfound custom error document ' +
             'and an error occurred', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint,
-                '403-retrieve-error-document', null, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: '403-retrieve-error-document',
+                }, done);
             });
         });
 
@@ -289,8 +334,12 @@ describe('User visits bucket website endpoint', () => {
 
             it(`should redirect to ${redirectEndpoint} if error 403` +
             ' occured', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint,
-                'redirect', `${redirectEndpoint}/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/`,
+                }, done);
             });
         });
 
@@ -310,8 +359,12 @@ describe('User visits bucket website endpoint', () => {
 
             it(`should redirect to ${redirectEndpoint}/about/ if ` +
             'key prefix is equal to "about"', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect', `${redirectEndpoint}/about/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/about/`,
+                }, done);
             });
         });
 
@@ -333,8 +386,12 @@ describe('User visits bucket website endpoint', () => {
 
             it(`should redirect to ${redirectEndpoint} if ` +
             'key prefix is equal to "about" AND error code 403', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect', `${redirectEndpoint}/about/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/about/`,
+                }, done);
             });
         });
 
@@ -357,8 +414,12 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should redirect to the first one', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect', `${redirectEndpoint}/about/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/about/`,
+                }, done);
             });
         });
 
@@ -380,8 +441,12 @@ describe('User visits bucket website endpoint', () => {
 
             it('should redirect to https://www.google.com/about if ' +
             'https protocols', done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect', 'https://www.google.com/about/', null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect',
+                    redirectUrl: 'https://www.google.com/about/',
+                }, done);
             });
         });
 
@@ -404,8 +469,12 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve redirect file if error 403 error occured',
             done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect-user',
-                `${endpoint}/redirect.html`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'redirect-user',
+                    redirectUrl: `${endpoint}/redirect.html`,
+                }, done);
             });
         });
 
@@ -425,9 +494,13 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it(`should redirect to ${redirectEndpoint}/about/ if ` +
-            'ReplaceKeyPrefixWith equals "about"', done => {
-                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-                `${redirectEndpoint}/about/`, null, done);
+            'ReplaceKeyPrefixWith equals "about/"', done => {
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: endpoint,
+                    responseType: 'redirect',
+                    redirectUrl: `${redirectEndpoint}/about/`,
+                }, done);
             });
         });
 
@@ -451,8 +524,12 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve redirect file if key prefix is equal to "about"',
             done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect-user', `${endpoint}/redirect/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect-user',
+                    redirectUrl: `${endpoint}/redirect/`,
+                }, done);
             });
         });
 
@@ -478,8 +555,12 @@ describe('User visits bucket website endpoint', () => {
             it('should serve redirect file if key prefix is equal to ' +
             '"about" and error 403',
             done => {
-                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-                'redirect-user', `${endpoint}/redirect/`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'GET',
+                    url: `${endpoint}/about/`,
+                    responseType: 'redirect-user',
+                    redirectUrl: `${endpoint}/redirect/`,
+                }, done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/websiteGet.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGet.js
@@ -1,14 +1,12 @@
 import assert from 'assert';
 import fs from 'fs';
-import http from 'http';
-import https from 'https';
 import path from 'path';
 
 import { S3 } from 'aws-sdk';
-import Browser from 'zombie';
 
 import conf from '../../../../../lib/Config';
 import getConfig from '../support/config';
+import makeRequest from '../../../raw-node/utils/makeRequest';
 import { WebsiteConfigTester } from '../../lib/utility/website-util';
 
 const config = getConfig('default', { signatureVersion: 'v4' });
@@ -18,14 +16,11 @@ const transport = conf.https ? 'https' : 'http';
 const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
     'bucketwebsitetester';
 const hostname = `${bucket}.s3-website-us-east-1.amazonaws.com`;
-
 const endpoint = process.env.AWS_ON_AIR ? `${transport}://${hostname}` :
     `${transport}://${hostname}:8000`;
-
 const redirectEndpoint = conf.https ? 'https://www.google.com' :
     'http://www.google.com';
 
-const redirectWaitingPeriod = 12000;
 
 function putBucketWebsiteAndPutObjectRedirect(redirect, condition, key, done) {
     const webConfig = new WebsiteConfigTester('index.html');
@@ -44,28 +39,12 @@ function putBucketWebsiteAndPutObjectRedirect(redirect, condition, key, done) {
     });
 }
 
-// Note: Timeouts are set on tests with redirects to a URL as they are flaky
-// without them. If they still fail, consider increasing the timeout or using
-// mocha's this.retries method to auto-retry the test after failure.
+// Note: To run these tests locally, you may need to edit the /etc/hosts file
+// to include `127.0.0.1 bucketwebsitetester.s3-website-us-east-1.amazonaws.com`
 describe('User visits bucket website endpoint', () => {
-    const browser = new Browser({ strictSSL: false });
-    browser.on('error', err => {
-        process.stdout.write('zombie encountered err loading resource or ' +
-            'evaluating javascript:', err);
-    });
-
-    before(() => {
-        // so that redirects will not time out, have zombie visit
-        // redirectEndpoint first
-        browser.visit(redirectEndpoint);
-    });
-
     it('should return 404 when no such bucket', done => {
-        browser.visit(endpoint, () => {
-            WebsiteConfigTester.checkHTML(browser, '404-no-such-bucket', null,
-              bucket);
-            done();
-        });
+        WebsiteConfigTester.checkHTML('GET', endpoint, '404-no-such-bucket',
+        null, bucket, done);
     });
 
     describe('with existing bucket', () => {
@@ -74,11 +53,8 @@ describe('User visits bucket website endpoint', () => {
         afterEach(done => s3.deleteBucket({ Bucket: bucket }, done));
 
         it('should return 404 when no website configuration', done => {
-            browser.visit(endpoint, () => {
-                WebsiteConfigTester.checkHTML(browser,
-                  '404-no-such-website-configuration', null, bucket);
-                done();
-            });
+            WebsiteConfigTester.checkHTML('GET', endpoint,
+            '404-no-such-website-configuration', null, bucket, done);
         });
 
         describe('with existing configuration', () => {
@@ -106,50 +82,28 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should return 405 when user requests method other than get ' +
-            'or head',
-                done => {
-                    const options = {
-                        hostname,
-                        port: process.env.AWS_ON_AIR ? 80 : 8000,
-                        method: 'POST',
-                        rejectUnauthorized: false,
-                    };
-                    const module = conf.https ? https : http;
-                    const req = module.request(options, res => {
-                        const body = [];
-                        res.on('data', chunk => {
-                            body.push(chunk);
-                        });
-                        res.on('error', err => {
-                            process.stdout.write('err on post response');
-                            return done(err);
-                        });
-                        res.on('end', () => {
-                            assert.strictEqual(res.statusCode, 405);
-                            const total = body.join('');
-                            assert(total.indexOf('<head><title>405 ' +
-                                'Method Not Allowed</title></head>') > -1);
-                            return done();
-                        });
-                    });
-                    req.on('error', err => {
-                        process.stdout.write('err from post request');
-                        return done(err);
-                    });
-                    req.end();
-                });
-
-            it('should serve indexDocument if no key requested', done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'index-user');
-                    done();
+            'or head', done => {
+                makeRequest({
+                    hostname,
+                    port: process.env.AWS_ON_AIR ? 80 : 8000,
+                    method: 'POST',
+                }, (err, res) => {
+                    assert.strictEqual(err, null,
+                        `Err with request ${err}`);
+                    assert.strictEqual(res.statusCode, 405);
+                    assert(res.body.indexOf('<head><title>405 ' +
+                        'Method Not Allowed</title></head>') > -1);
+                    return done();
                 });
             });
+
+            it('should serve indexDocument if no key requested', done => {
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'index-user',
+                null, null, done);
+            });
             it('should serve indexDocument if key requested', done => {
-                browser.visit(`${endpoint}/index.html`, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'index-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/index.html`,
+                'index-user', null, null, done);
             });
         });
         describe('with path in request with/without key', () => {
@@ -176,18 +130,15 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve indexDocument if path request without key',
             done => {
-                browser.visit(`${endpoint}/pathprefix/`, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'index-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/pathprefix/`,
+                'index-user', null, null, done);
             });
 
             it('should serve indexDocument if path request with key',
             done => {
-                browser.visit(`${endpoint}/pathprefix/index.html`, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'index-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET',
+                `${endpoint}/pathprefix/index.html`,
+                'index-user', null, null, done);
             });
         });
 
@@ -212,10 +163,8 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should return 403 if key is private', done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser, '403-access-denied');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', endpoint,
+                '403-access-denied', null, null, done);
             });
         });
 
@@ -227,10 +176,8 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should return 403 if nonexisting index document key', done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser, '403-access-denied');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', endpoint,
+                '403-access-denied', null, null, done);
             });
         });
 
@@ -246,19 +193,13 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it(`should redirect to ${redirectEndpoint}`, done => {
-                browser.visit(endpoint, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      redirectEndpoint);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
+                `${redirectEndpoint}/`, null, done);
             });
 
             it(`should redirect to ${redirectEndpoint}/about`, done => {
-                browser.visit(`${endpoint}/about`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      `${redirectEndpoint}/about/`);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about`,
+                'redirect', `${redirectEndpoint}/about`, null, done);
             });
         });
 
@@ -278,20 +219,14 @@ describe('User visits bucket website endpoint', () => {
                     WebsiteConfiguration: webConfig }, done);
             });
 
-            it('should redirect to https://google.com', done => {
-                browser.visit(endpoint, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      'https://www.google.com');
-                    done();
-                }, redirectWaitingPeriod));
+            it('should redirect to https://google.com/', done => {
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
+                'https://www.google.com/', null, done);
             });
 
             it('should redirect to https://google.com/about', done => {
-                browser.visit(`${endpoint}/about`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      'https://www.google.com/about/');
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about`,
+                'redirect', 'https://www.google.com/about', null, done);
             });
         });
 
@@ -318,10 +253,8 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve custom error document if an error occurred',
             done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'error-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'error-user',
+                null, null, done);
             });
         });
 
@@ -335,11 +268,8 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve s3 error file if unfound custom error document ' +
             'and an error occurred', done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser,
-                      '403-retrieve-error-document');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', endpoint,
+                '403-retrieve-error-document', null, null, done);
             });
         });
 
@@ -359,11 +289,8 @@ describe('User visits bucket website endpoint', () => {
 
             it(`should redirect to ${redirectEndpoint} if error 403` +
             ' occured', done => {
-                browser.visit(endpoint, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                    redirectEndpoint);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', endpoint,
+                'redirect', `${redirectEndpoint}/`, null, done);
             });
         });
 
@@ -381,13 +308,10 @@ describe('User visits bucket website endpoint', () => {
                     WebsiteConfiguration: webConfig }, done);
             });
 
-            it(`should redirect to ${redirectEndpoint}/about if ` +
+            it(`should redirect to ${redirectEndpoint}/about/ if ` +
             'key prefix is equal to "about"', done => {
-                browser.visit(`${endpoint}/about/`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                    `${redirectEndpoint}/about/`);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect', `${redirectEndpoint}/about/`, null, done);
             });
         });
 
@@ -409,11 +333,8 @@ describe('User visits bucket website endpoint', () => {
 
             it(`should redirect to ${redirectEndpoint} if ` +
             'key prefix is equal to "about" AND error code 403', done => {
-                browser.visit(`${endpoint}/about/`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      `${redirectEndpoint}/about/`);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect', `${redirectEndpoint}/about/`, null, done);
             });
         });
 
@@ -436,11 +357,8 @@ describe('User visits bucket website endpoint', () => {
             });
 
             it('should redirect to the first one', done => {
-                browser.visit(`${endpoint}/about/`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      `${redirectEndpoint}/about/`);
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect', `${redirectEndpoint}/about/`, null, done);
             });
         });
 
@@ -462,11 +380,8 @@ describe('User visits bucket website endpoint', () => {
 
             it('should redirect to https://www.google.com/about if ' +
             'https protocols', done => {
-                browser.visit(`${endpoint}/about/`, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                      'https://www.google.com/about/');
-                    done();
-                }, redirectWaitingPeriod));
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect', 'https://www.google.com/about/', null, done);
             });
         });
 
@@ -489,10 +404,8 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve redirect file if error 403 error occured',
             done => {
-                browser.visit(endpoint, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'redirect-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect-user',
+                `${endpoint}/redirect.html`, null, done);
             });
         });
 
@@ -504,20 +417,17 @@ describe('User visits bucket website endpoint', () => {
                 };
                 const redirect = {
                     HostName: 'www.google.com',
-                    ReplaceKeyPrefixWith: '/about',
+                    ReplaceKeyPrefixWith: 'about/',
                 };
                 webConfig.addRoutingRule(redirect, condition);
                 s3.putBucketWebsite({ Bucket: bucket,
                     WebsiteConfiguration: webConfig }, done);
             });
 
-            it(`should redirect to ${redirectEndpoint}/about if ` +
-            'ReplaceKeyPrefixWith equals "/about"', done => {
-                browser.visit(endpoint, () => setTimeout(() => {
-                    WebsiteConfigTester.checkHTML(browser, '200',
-                    `${redirectEndpoint}/about/`);
-                    done();
-                }, redirectWaitingPeriod));
+            it(`should redirect to ${redirectEndpoint}/about/ if ` +
+            'ReplaceKeyPrefixWith equals "about"', done => {
+                WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
+                `${redirectEndpoint}/about/`, null, done);
             });
         });
 
@@ -541,10 +451,8 @@ describe('User visits bucket website endpoint', () => {
 
             it('should serve redirect file if key prefix is equal to "about"',
             done => {
-                browser.visit(`${endpoint}/about/`, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'redirect-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect-user', `${endpoint}/redirect/`, null, done);
             });
         });
 
@@ -570,10 +478,8 @@ describe('User visits bucket website endpoint', () => {
             it('should serve redirect file if key prefix is equal to ' +
             '"about" and error 403',
             done => {
-                browser.visit(`${endpoint}/about/`, () => {
-                    WebsiteConfigTester.checkHTML(browser, 'redirect-user');
-                    done();
-                });
+                WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
+                'redirect-user', `${endpoint}/redirect/`, null, done);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/object/websiteGetWithACL.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteGetWithACL.js
@@ -1,5 +1,4 @@
 import { S3 } from 'aws-sdk';
-import Browser from 'zombie';
 
 import conf from '../../../../../lib/Config';
 import getConfig from '../support/config';
@@ -12,7 +11,6 @@ const transport = conf.https ? 'https' : 'http';
 const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
     'bucketwebsitetester';
 const hostname = `${bucket}.s3-website-us-east-1.amazonaws.com`;
-
 const endpoint = process.env.AWS_ON_AIR ? `${transport}://${hostname}` :
     `${transport}://${hostname}:8000`;
 
@@ -118,11 +116,6 @@ const aclTests = [
 ];
 
 describe('User visits bucket website endpoint with ACL', () => {
-    const browser = new Browser({ strictSSL: false });
-    browser.on('error', err => {
-        process.stdout.write('zombie encountered err loading resource or ' +
-            'evaluating javascript:', err);
-    });
     aclTests.forEach(test => {
         aclEquivalent[test.bucketACL].forEach(bucketACL => {
             describe(`with existing bucket with ${bucketACL} acl`, () => {
@@ -136,10 +129,8 @@ describe('User visits bucket website endpoint with ACL', () => {
                 });
 
                 it(`${test.it}`, done => {
-                    browser.visit(endpoint, () => {
-                        WebsiteConfigTester.checkHTML(browser, test.html);
-                        done();
-                    });
+                    WebsiteConfigTester.checkHTML(endpoint, test.html,
+                    null, null, done);
                 });
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/websiteHeadWithACL.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHeadWithACL.js
@@ -3,7 +3,6 @@ import https from 'https';
 import assert from 'assert';
 
 import { S3 } from 'aws-sdk';
-import Browser from 'zombie';
 
 import conf from '../../../../../lib/Config';
 import getConfig from '../support/config';
@@ -171,11 +170,6 @@ const aclTests = [
 ];
 
 describe('Head request on bucket website endpoint with ACL', () => {
-    const browser = new Browser({ strictSSL: false });
-    browser.on('error', err => {
-        process.stdout.write('zombie encountered err loading resource or ' +
-            'evaluating javascript:', err);
-    });
     aclTests.forEach(test => {
         aclEquivalent[test.bucketACL].forEach(bucketACL => {
             describe(`with existing bucket with ${bucketACL} acl`, () => {

--- a/tests/functional/aws-node-sdk/test/object/websiteHeadWithACL.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteHeadWithACL.js
@@ -1,7 +1,3 @@
-import http from 'http';
-import https from 'https';
-import assert from 'assert';
-
 import { S3 } from 'aws-sdk';
 
 import conf from '../../../../../lib/Config';
@@ -11,50 +7,21 @@ import { WebsiteConfigTester } from '../../lib/utility/website-util';
 const config = getConfig('default', { signatureVersion: 'v4' });
 const s3 = new S3(config);
 
+// Note: To run these tests locally, you may need to edit the machine's
+// /etc/hosts file to include the following line:
+// `127.0.0.1 bucketwebsitetester.s3-website-us-east-1.amazonaws.com`
+
+const transport = conf.https ? 'https' : 'http';
 const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
     'bucketwebsitetester';
 const hostname = `${bucket}.s3-website-us-east-1.amazonaws.com`;
+const endpoint = process.env.AWS_ON_AIR ? `${transport}://${hostname}` :
+    `${transport}://${hostname}:8000`;
 
 const aclEquivalent = {
     public: ['public-read-write', 'public-read'],
     private: ['private', 'authenticated-read'],
 };
-
-function makeHeadRequest(expectedStatusCode, expectedHeaders, cb) {
-    const options = {
-        hostname,
-        port: process.env.AWS_ON_AIR ? 80 : 8000,
-        method: 'HEAD',
-        rejectUnauthorized: false,
-    };
-    const module = conf.https ? https : http;
-    const req = module.request(options, res => {
-        const body = [];
-        res.on('data', chunk => {
-            body.push(chunk);
-        });
-        res.on('error', err => {
-            process.stdout.write('err on post response');
-            return cb(err);
-        });
-        res.on('end', () => {
-            // body should be empty
-            assert.deepStrictEqual(body, []);
-            assert.strictEqual(res.statusCode, expectedStatusCode);
-            const headers = Object.keys(expectedHeaders);
-            for (let i = 0; i < headers.length; i++) {
-                assert.strictEqual(res.headers[headers[i]],
-                    expectedHeaders[headers[i]]);
-            }
-            return cb();
-        });
-    });
-    req.on('error', err => {
-        process.stdout.write('err from post request');
-        return cb(err);
-    });
-    req.end();
-}
 
 const headersACL = {
     accessDenied: {
@@ -182,10 +149,25 @@ describe('Head request on bucket website endpoint with ACL', () => {
                       test.objects, done);
                 });
 
-                it(`${test.it}`, done => {
+                it(`${test.it} with no auth credentials sent`, done => {
                     const result = test.result;
-                    makeHeadRequest(headersACL[result].status,
-                      headersACL[result].expectedHeaders, done);
+                    WebsiteConfigTester.makeHeadRequest(undefined, endpoint,
+                        headersACL[result].status,
+                        headersACL[result].expectedHeaders, done);
+                });
+
+                it(`${test.it} even with invalid auth credentials`, done => {
+                    const result = test.result;
+                    WebsiteConfigTester.makeHeadRequest('invalid credentials',
+                        endpoint, headersACL[result].status,
+                        headersACL[result].expectedHeaders, done);
+                });
+
+                it(`${test.it} even with valid auth credentials`, done => {
+                    const result = test.result;
+                    WebsiteConfigTester.makeHeadRequest('valid credentials',
+                        endpoint, headersACL[result].status,
+                        headersACL[result].expectedHeaders, done);
                 });
             });
         });

--- a/tests/functional/aws-node-sdk/test/object/websiteRuleMixing.js
+++ b/tests/functional/aws-node-sdk/test/object/websiteRuleMixing.js
@@ -10,6 +10,10 @@ const config = getConfig('default', { signatureVersion: 'v4' });
 const bucketUtil = new BucketUtility('default', config);
 const s3 = bucketUtil.s3;
 
+// Note: To run these tests locally, you may need to edit the machine's
+// /etc/hosts file to include the following line:
+// `127.0.0.1 bucketwebsitetester.s3-website-us-east-1.amazonaws.com`
+
 const transport = conf.https ? 'https' : 'http';
 const bucket = process.env.AWS_ON_AIR ? 'awsbucketwebsitetester' :
     'bucketwebsitetester';
@@ -48,13 +52,21 @@ describe('User visits bucket website endpoint and requests resource ' +
         afterEach(() => bucketUtil.empty(bucket));
 
         it('should serve redirect file on GET request', done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-            '/redirect.html', null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: '/redirect.html',
+            }, done);
         });
 
         it('should redirect to redirect file on HEAD request', done => {
-            WebsiteConfigTester.checkHTML('HEAD', endpoint, 'redirect',
-            '/redirect.html', null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'HEAD',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: '/redirect.html',
+            }, done);
         });
     });
 
@@ -76,14 +88,22 @@ describe('User visits bucket website endpoint and requests resource ' +
         afterEach(() => bucketUtil.empty(bucket));
 
         it('should redirect to https://www.google.com', done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-            'https://www.google.com', null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: 'https://www.google.com',
+            }, done);
         });
 
         it('should redirect to https://www.google.com on HEAD request',
             done => {
-                WebsiteConfigTester.checkHTML('HEAD', endpoint, 'redirect',
-                'https://www.google.com', null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'HEAD',
+                    url: endpoint,
+                    responseType: 'redirect',
+                    redirectUrl: 'https://www.google.com',
+                }, done);
             });
     });
 
@@ -104,14 +124,20 @@ describe('User visits bucket website endpoint and requests resource ' +
 
         it('should return 403 instead of x-amz-website-redirect-location ' +
         'header location', done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint, '403-access-denied',
-            null, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: '403-access-denied',
+            }, done);
         });
 
         it('should return 403 instead of x-amz-website-redirect-location ' +
         'header location on HEAD request', done => {
-            WebsiteConfigTester.checkHTML('HEAD', endpoint, '403-access-denied',
-            null, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'HEAD',
+                url: endpoint,
+                responseType: '403-access-denied',
+            }, done);
         });
     });
 
@@ -147,16 +173,24 @@ describe('User visits bucket website endpoint and requests resource ' +
         it(`should redirect to ${redirectEndpoint} since error 403 ` +
         'occurred instead of x-amz-website-redirect-location header ' +
         'location on GET request', done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-            redirectEndpoint, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: redirectEndpoint,
+            }, done);
         });
 
         it(`should redirect to ${redirectEndpoint} since error 403 ` +
         'occurred instead of x-amz-website-redirect-location header ' +
         'location on HEAD request',
         done => {
-            WebsiteConfigTester.checkHTML('HEAD', endpoint, 'redirect',
-            redirectEndpoint, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'HEAD',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: redirectEndpoint,
+            }, done);
         });
     });
 
@@ -183,15 +217,23 @@ describe('User visits bucket website endpoint and requests resource ' +
         it(`should redirect to ${redirectEndpoint} instead of ` +
         'x-amz-website-redirect-location header location on GET request',
         done => {
-            WebsiteConfigTester.checkHTML('GET', endpoint, 'redirect',
-            redirectEndpoint, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: redirectEndpoint,
+            }, done);
         });
 
         it(`should redirect to ${redirectEndpoint} instead of ` +
         'x-amz-website-redirect-location header location on HEAD request',
         done => {
-            WebsiteConfigTester.checkHTML('HEAD', endpoint, 'redirect',
-            redirectEndpoint, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'HEAD',
+                url: endpoint,
+                responseType: 'redirect',
+                redirectUrl: redirectEndpoint,
+            }, done);
         });
     });
 
@@ -222,15 +264,23 @@ describe('User visits bucket website endpoint and requests resource ' +
         it(`should redirect GET request to ${redirectEndpoint}about/ ` +
             'instead of about/ key x-amz-website-redirect-location ' +
             'header location', done => {
-            WebsiteConfigTester.checkHTML('GET', `${endpoint}/about/`,
-            'redirect', `${redirectEndpoint}about/`, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: `${endpoint}/about/`,
+                responseType: 'redirect',
+                redirectUrl: `${redirectEndpoint}about/`,
+            }, done);
         });
 
         it(`should redirect HEAD request to ${redirectEndpoint}about ` +
             'instead of about/ key x-amz-website-redirect-location ' +
             'header location', done => {
-            WebsiteConfigTester.checkHTML('HEAD', `${endpoint}/about/`,
-            'redirect', `${redirectEndpoint}about/`, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'HEAD',
+                url: `${endpoint}/about/`,
+                responseType: 'redirect',
+                redirectUrl: `${redirectEndpoint}about/`,
+            }, done);
         });
     });
 
@@ -266,15 +316,23 @@ describe('User visits bucket website endpoint and requests resource ' +
         it('should replace key instead of redirecting to key ' +
         'x-amz-website-redirect-location header location on GET request',
         done => {
-            WebsiteConfigTester.checkHTML('GET', `${endpoint}/index.html`,
-            'redirect-user', `${endpoint}/redirect.html`, null, done);
+            WebsiteConfigTester.checkHTML({
+                method: 'GET',
+                url: `${endpoint}/index.html`,
+                responseType: 'redirect-user',
+                redirectUrl: `${endpoint}/redirect.html`,
+            }, done);
         });
 
         it('should replace key instead of redirecting to key ' +
         'x-amz-website-redirect-location header location on HEAD request',
             done => {
-                WebsiteConfigTester.checkHTML('HEAD', `${endpoint}/index.html`,
-                'redirect-user', `${endpoint}/redirect.html`, null, done);
+                WebsiteConfigTester.checkHTML({
+                    method: 'HEAD',
+                    url: `${endpoint}/index.html`,
+                    responseType: 'redirect-user',
+                    redirectUrl: `${endpoint}/redirect.html`,
+                }, done);
             });
     });
 });


### PR DESCRIPTION
FIXES #553

Also includes commit for refactoring website tests and clean-up in preparation for adding auth credentials to the website test requests. Zombie was a neat tool for visiting websites as if in a browser, but since it added unnecessary wait time to the redirect tests and we can check what we need in the response using the node `http`/`https` request module, I removed it.