### PR TITLE
rf: metadata params for versioning S3C-44

### DIFF
--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -34,7 +34,7 @@ function addToUsersBucket(canonicalID, bucketName, log, cb) {
         const usersBucketBeingCalled = usersBucketAttrs ?
             usersBucket : oldUsersBucket;
         return metadata.putObjectMD(usersBucketBeingCalled, key,
-            omVal, log, err => {
+            omVal, {}, log, err => {
                 if (err && err.NoSuchBucket) {
                     // There must be no usersBucket so createBucket
                     // one using the new format
@@ -67,7 +67,7 @@ function addToUsersBucket(canonicalID, bucketName, log, cb) {
                             // Finally put the key in the new format
                             // usersBucket
                             return metadata.putObjectMD(usersBucket,
-                                key, omVal, log, cb);
+                                key, omVal, {}, log, cb);
                         });
                 }
                 return cb(err);

--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -18,7 +18,7 @@ function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
         '_deleteUserBucketEntry' });
     const keyForUserBucket = createKeyForUserBucket(canonicalID,
         constants.splitter, bucketName);
-    metadata.deleteObjectMD(usersBucket, keyForUserBucket, log, error => {
+    metadata.deleteObjectMD(usersBucket, keyForUserBucket, {}, log, error => {
         // If the object representing the bucket is not in the
         // users bucket just continue
         if (error && error.NoSuchKey) {
@@ -29,7 +29,7 @@ function _deleteUserBucketEntry(bucketName, canonicalID, log, cb) {
             const keyForUserBucket2 = createKeyForUserBucket(canonicalID,
                 constants.oldSplitter, bucketName);
             return metadata.deleteObjectMD(oldUsersBucket, keyForUserBucket2,
-                log, error => {
+                {}, log, error => {
                     if (error && !error.NoSuchKey) {
                         log.error('from metadata while deleting user bucket',
                             { error });

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -323,7 +323,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 `overview${splitter}${objectKey}${splitter}${uploadId}`;
 
             return metadata.getObjectMD(mpuBucket.getName(), mpuOverviewKey,
-                log, (err, storedMetadata) => {
+                {}, log, (err, storedMetadata) => {
                     if (err) {
                         return next(err, destBucket);
                     }

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -129,7 +129,7 @@ export function getObjMetadataAndDelete(bucketName, quietSetting,
     // doing 5 requests at a time. note that the data wrapper
     // will do 5 parallel requests to data backend to delete parts
     return async.forEachLimit(inPlay, 5, (key, moveOn) => {
-        metadata.getObjectMD(bucketName, key, log, (err, objMD) => {
+        metadata.getObjectMD(bucketName, key, {}, log, (err, objMD) => {
             // if general error from metadata return error
             if (err && !err.NoSuchKey) {
                 log.error('error getting object MD', { error: err, key });

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -242,7 +242,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
             next) {
             const partKey =
                 `${uploadId}${constants.splitter}${paddedPartNumber}`;
-            metadata.getObjectMD(mpuBucket.getName(), partKey, log,
+            metadata.getObjectMD(mpuBucket.getName(), partKey, {}, log,
                 (err, result) => {
                     // If there is nothing being overwritten just move on
                     if (err && !err.NoSuchKey) {

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -150,7 +150,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
         (cipherBundle, splitter, bucket, next) => {
             const mpuOverviewKey = _getOverviewKey(splitter, objectKey,
                 uploadId);
-            return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, log,
+            return metadata.getObjectMD(mpuBucketName, mpuOverviewKey, {}, log,
                 (err, res) => {
                     if (err) {
                         log.error('error getting the object from mpu bucket', {
@@ -172,7 +172,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
         (cipherBundle, splitter, bucket, next) => {
             const paddedPartNumber = _getPaddedPartNumber(partNumber);
             const partKey = _getPartKey(uploadId, splitter, paddedPartNumber);
-            return metadata.getObjectMD(mpuBucketName, partKey, log,
+            return metadata.getObjectMD(mpuBucketName, partKey, {}, log,
                 (err, res) => {
                     // If there is no object with the same key, continue.
                     if (err && !err.NoSuchKey) {
@@ -238,7 +238,7 @@ export default function objectPutPart(authInfo, request, streamingV4Params, log,
                 'content-md5': hexDigest,
                 'content-length': size,
             };
-            return metadata.putObjectMD(mpuBucketName, partKey, omVal, log,
+            return metadata.putObjectMD(mpuBucketName, partKey, omVal, {}, log,
                 err => {
                     if (err) {
                         log.error('error putting object in mpu bucket', {

--- a/lib/api/websiteGet.js
+++ b/lib/api/websiteGet.js
@@ -38,7 +38,7 @@ function _errorActions(err, errorDocument, routingRules,
             objectKey);
     }
     if (errorDocument) {
-        return metadata.getObjectMD(bucketName, errorDocument, log,
+        return metadata.getObjectMD(bucketName, errorDocument, {}, log,
             (errObjErr, errObjMD) => {
                 if (errObjErr) {
                     // error retrieving error document so return original error
@@ -137,7 +137,7 @@ function websiteGet(request, log, callback) {
 
         // get object metadata and check authorization and header
         // validation
-        return metadata.getObjectMD(bucketName, objectKey, log,
+        return metadata.getObjectMD(bucketName, objectKey, {}, log,
             (err, objMD) => {
                 // Note: In case of error, we intentionally send the original
                 // object key to _errorActions as in case of a redirect, we do

--- a/lib/api/websiteHead.js
+++ b/lib/api/websiteHead.js
@@ -96,7 +96,7 @@ export default function websiteHead(request, log, callback) {
 
         // get object metadata and check authorization and header
         // validation
-        return metadata.getObjectMD(bucketName, objectKey, log,
+        return metadata.getObjectMD(bucketName, objectKey, {}, log,
             (err, objMD) => {
                 // Note: In case of error, we intentionally send the original
                 // object key to _errorActions as in case of a redirect, we do

--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -16,8 +16,8 @@ const acl = {
         log.trace('updating object acl in metadata');
         // eslint-disable-next-line no-param-reassign
         objectMD.acl = addACLParams;
-        metadata.putObjectMD(bucket.getName(), objectKey, objectMD, log, cb,
-                params);
+        metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log,
+            cb);
     },
 
     parseAclFromHeaders(params, cb) {

--- a/lib/metadata/bucketclient/backend.js
+++ b/lib/metadata/bucketclient/backend.js
@@ -5,23 +5,11 @@ import BucketInfo from '../BucketInfo';
 import { logger } from '../../utilities/logger';
 import config from '../../Config';
 
-const METADATA_DEFAULT_VERSION = 1;
-
 class BucketClientInterface {
     constructor() {
         assert(config.bucketd.bootstrap.length > 0,
                'bucketd bootstrap list is empty');
         const { bootstrap, log } = config.bucketd;
-        // TODO: Determine metadata version via healthcheck
-        // and assign version accordingly.
-        this.metadataVersion = METADATA_DEFAULT_VERSION; // 6.3.0 or earlier
-        // TODO: Once have md version from healthcheck, set whether
-        // extended version or not, as follows:
-        // this.extendedVersion =
-        // this.metadataVersion > METADATA_DEFAULT_VERSION;
-        // TODO: Ideally, remove extendedVersion concept
-        // when getURIComponents has been fixed
-        this.extendedVersion = false;
         if (config.https) {
             const { key, cert, ca } = config.https;
             logger.info('bucketclient configuration', {
@@ -58,15 +46,14 @@ class BucketClientInterface {
         return null;
     }
 
-    getBucketAndObject(bucketName, objName, log, cb, params) {
-        const _params = this.extendedVersion ? params : undefined;
+    getBucketAndObject(bucketName, objName, params, log, cb) {
         this.client.getBucketAndObject(bucketName, objName,
             log.getSerializedUids(), (err, data) => {
                 if (err && (!err.NoSuchKey && !err.ObjNotFound)) {
                     return cb(err);
                 }
                 return cb(null, JSON.parse(data));
-            }, _params);
+            }, params);
         return null;
     }
 
@@ -81,29 +68,26 @@ class BucketClientInterface {
         return null;
     }
 
-    putObject(bucketName, objName, objVal, log, cb, params) {
-        const _params = this.extendedVersion ? params : undefined;
+    putObject(bucketName, objName, objVal, params, log, cb) {
         this.client.putObject(bucketName, objName, JSON.stringify(objVal),
-            log.getSerializedUids(), cb, _params);
+            log.getSerializedUids(), cb, params);
         return null;
     }
 
-    getObject(bucketName, objName, log, cb, params) {
-        const _params = this.extendedVersion ? params : undefined;
+    getObject(bucketName, objName, params, log, cb) {
         this.client.getObject(bucketName, objName, log.getSerializedUids(),
             (err, data) => {
                 if (err) {
                     return cb(err);
                 }
                 return cb(err, JSON.parse(data));
-            }, _params);
+            }, params);
         return null;
     }
 
-    deleteObject(bucketName, objName, log, cb, params) {
-        const _params = this.extendedVersion ? params : undefined;
+    deleteObject(bucketName, objName, params, log, cb) {
         this.client.deleteObject(bucketName, objName, log.getSerializedUids(),
-                                 cb, _params);
+                                 cb, params);
         return null;
     }
 

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -285,7 +285,7 @@ class BucketFileInterface {
         return undefined;
     }
 
-    getBucketAndObject(bucketName, objName, log, cb) {
+    getBucketAndObject(bucketName, objName, params, log, cb) {
         this.loadDBIfExists(bucketName, log, (err, db, bucketAttr) => {
             if (err) {
                 return cb(err);
@@ -351,7 +351,7 @@ class BucketFileInterface {
         return undefined;
     }
 
-    putObject(bucketName, objName, objVal, log, cb) {
+    putObject(bucketName, objName, objVal, params, log, cb) {
         this.loadDBIfExists(bucketName, log, (err, db) => {
             if (err) {
                 return cb(err);
@@ -359,18 +359,20 @@ class BucketFileInterface {
             db.put(objName, JSON.stringify(objVal),
                    OPTIONS, err => {
                        this.unRef();
+                       // TODO: implement versioning for file backend
+                       const data = undefined;
                        if (err) {
                            log.error('error putting object',
                                      { error: err });
                            return cb(errors.InternalError);
                        }
-                       return cb();
+                       return cb(err, data);
                    });
             return undefined;
         });
     }
 
-    getObject(bucketName, objName, log, cb) {
+    getObject(bucketName, objName, params, log, cb) {
         this.loadDBIfExists(bucketName, log, (err, db) => {
             if (err) {
                 return cb(err);
@@ -391,7 +393,7 @@ class BucketFileInterface {
         });
     }
 
-    deleteObject(bucketName, objName, log, cb) {
+    deleteObject(bucketName, objName, params, log, cb) {
         this.loadDBIfExists(bucketName, log, (err, db) => {
             if (err) {
                 return cb(err);

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -60,19 +60,21 @@ const metastore = {
         });
     },
 
-    putObject: (bucketName, objName, objVal, log, cb) => {
+    putObject: (bucketName, objName, objVal, params, log, cb) => {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
+                // TODO: implement versioning for in-memory backend
+                const data = undefined;
                 if (err) {
                     return cb(err);
                 }
                 metadata.keyMaps.get(bucketName).set(objName, objVal);
-                return cb();
+                return cb(err, data);
             });
         });
     },
 
-    getBucketAndObject: (bucketName, objName, log, cb) => {
+    getBucketAndObject: (bucketName, objName, params, log, cb) => {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, (err, bucket) => {
                 if (err) {
@@ -92,7 +94,7 @@ const metastore = {
         });
     },
 
-    getObject: (bucketName, objName, log, cb) => {
+    getObject: (bucketName, objName, params, log, cb) => {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {
@@ -107,7 +109,7 @@ const metastore = {
         });
     },
 
-    deleteObject: (bucketName, objName, log, cb) => {
+    deleteObject: (bucketName, objName, params, log, cb) => {
         process.nextTick(() => {
             metastore.getBucketAttributes(bucketName, log, err => {
                 if (err) {

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -67,54 +67,61 @@ const metadata = {
         });
     },
 
-    putObjectMD: (bucketName, objName, objVal, log, cb, params) => {
+    putObjectMD: (bucketName, objName, objVal, params, log, cb) => {
         log.debug('putting object in metdata');
-        client.putObject(bucketName, objName, objVal, log, err => {
+        client.putObject(bucketName, objName, objVal, params, log,
+        (err, data) => {
             if (err) {
                 log.debug('error from metadata', { implName, error: err });
                 return cb(err);
             }
-            log.debug('object successfully put in metadata');
-            return cb(err);
-        }, params);
+            if (data) {
+                log.debug('object version successfully put in metadata',
+                { version: data });
+            } else {
+                log.debug('object successfully put in metadata');
+            }
+            return cb(err, data);
+        });
     },
 
-    getBucketAndObjectMD: (bucketName, objName, log, cb, params) => {
+    getBucketAndObjectMD: (bucketName, objName, params, log, cb) => {
         log.debug('getting bucket and object from metadata',
                   { database: bucketName, object: objName });
-        client.getBucketAndObject(bucketName, objName, log, (err, data) => {
-            if (err) {
-                log.debug('error from metadata', { implName, err });
-                return cb(err);
-            }
-            log.debug('bucket and object retrieved from metadata',
-                      { database: bucketName, object: objName });
-            return cb(err, data);
-        }, params);
+        client.getBucketAndObject(bucketName, objName, params, log,
+            (err, data) => {
+                if (err) {
+                    log.debug('error from metadata', { implName, err });
+                    return cb(err);
+                }
+                log.debug('bucket and object retrieved from metadata',
+                { database: bucketName, object: objName });
+                return cb(err, data);
+            });
     },
 
-    getObjectMD: (bucketName, objName, log, cb, params) => {
+    getObjectMD: (bucketName, objName, params, log, cb) => {
         log.debug('getting object from metadata');
-        client.getObject(bucketName, objName, log, (err, data) => {
+        client.getObject(bucketName, objName, params, log, (err, data) => {
             if (err) {
                 log.debug('error from metadata', { implName, err });
                 return cb(err);
             }
             log.debug('object retrieved from metadata');
             return cb(err, data);
-        }, params);
+        });
     },
 
-    deleteObjectMD: (bucketName, objName, log, cb, params) => {
+    deleteObjectMD: (bucketName, objName, params, log, cb) => {
         log.debug('deleting object from metadata');
-        client.deleteObject(bucketName, objName, log, err => {
+        client.deleteObject(bucketName, objName, params, log, err => {
             if (err) {
                 log.debug('error from metadata', { implName, err });
                 return cb(err);
             }
             log.debug('object deleted from metadata');
             return cb(err);
-        }, params);
+        });
     },
 
     listObject: (bucketName, listingParams, log, cb) => {

--- a/lib/services.js
+++ b/lib/services.js
@@ -96,12 +96,14 @@ export default {
                 return cb(null, bucket, null);
             });
         }
-        return metadata.getBucketAndObjectMD(bucketName, objectKey, log,
+        return metadata.getBucketAndObjectMD(bucketName, objectKey, {}, log,
         (err, data) => {
             if (err) {
                 log.debug('metadata get failed', { error: err });
                 return cb(err);
             }
+            log.debug('bucket and object retrieved from metadata',
+                { database: bucketName, object: objectKey });
             const bucket = data.bucket ?
                       BucketInfo.deSerialize(data.bucket) : undefined;
             const obj = data.obj ? JSON.parse(data.obj) : undefined;
@@ -254,7 +256,8 @@ export default {
                     return cb(err);
                 }
                 omVal.acl = parsedACL;
-                metadata.putObjectMD(bucketName, objectKey, omVal, log, err => {
+                metadata.putObjectMD(bucketName, objectKey, omVal, {}, log,
+                err => {
                     if (err) {
                         log.error('error from metadata', { error: err });
                         return cb(err);
@@ -265,7 +268,7 @@ export default {
                 return undefined;
             });
         } else {
-            metadata.putObjectMD(bucketName, objectKey, omVal, log, err => {
+            metadata.putObjectMD(bucketName, objectKey, omVal, {}, log, err => {
                 if (err) {
                     log.error('error from metadata', { error: err });
                     return cb(err);
@@ -293,7 +296,7 @@ export default {
             log.trace('object identified as non-versioned');
             // non-versioned buckets
             log.trace('deleteObject: deleting non-versioned object');
-            return metadata.deleteObjectMD(bucketName, objectKey, log,
+            return metadata.deleteObjectMD(bucketName, objectKey, {}, log,
                 err => {
                     if (err) {
                         return cb(err);
@@ -311,7 +314,7 @@ export default {
         }
         // versioning
         log.debug('deleteObject: versioning not fully implemented');
-        return metadata.deleteObjectMD(bucketName, objectKey, log, cb);
+        return metadata.deleteObjectMD(bucketName, objectKey, {}, log, cb);
     },
 
     /**
@@ -417,7 +420,7 @@ export default {
             }
             multipartObjectMD.acl = parsedACL;
             metadata.putObjectMD(bucketName, longMPUIdentifier,
-                multipartObjectMD, log, err => {
+                multipartObjectMD, {}, log, err => {
                     if (err) {
                         log.error('error from metadata', { error: err });
                         return cb(err);
@@ -598,7 +601,7 @@ export default {
             'content-md5': contentMD5,
             'content-length': size,
         };
-        metadata.putObjectMD(mpuBucketName, partKey, omVal, log, err => {
+        metadata.putObjectMD(mpuBucketName, partKey, omVal, {}, log, err => {
             if (err) {
                 log.error('error from metadata', { error: err });
                 return cb(err);
@@ -726,7 +729,7 @@ export default {
         // all at once in production implementation
         assert.strictEqual(typeof mpuBucketName, 'string');
         async.eachLimit(keysToDelete, 5, (key, callback) => {
-            metadata.deleteObjectMD(mpuBucketName, key, log, callback);
+            metadata.deleteObjectMD(mpuBucketName, key, {}, log, callback);
         }, err => cb(err));
     },
 };

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -223,7 +223,7 @@ describe('deleted flag bucket handling', () => {
     describe('objectPut on a bucket with deleted flag', () => {
         const objName = 'objectName';
         afterEach(done => {
-            metadata.deleteObjectMD(bucketName, objName, log, () => {
+            metadata.deleteObjectMD(bucketName, objName, {}, log, () => {
                 done();
             });
         });
@@ -243,7 +243,7 @@ describe('deleted flag bucket handling', () => {
                     assert.strictEqual(data._transient, false);
                     assert.strictEqual(data._deleted, false);
                     assert.strictEqual(data._owner, authInfo.getCanonicalID());
-                    metadata.getObjectMD(bucketName, objName, log,
+                    metadata.getObjectMD(bucketName, objName, {}, log,
                         (err, obj) => {
                             assert.ifError(err);
                             assert.strictEqual(obj['content-md5'], etag);
@@ -272,7 +272,7 @@ describe('deleted flag bucket handling', () => {
         const objName = 'objectName';
         after(done => {
             metadata.deleteObjectMD(`${constants.mpuBucketPrefix}` +
-                `${bucketName}`, objName, log, () => {
+                `${bucketName}`, objName, {}, log, () => {
                     metadata.deleteBucket(`${constants.mpuBucketPrefix}` +
                         `${bucketName}`, log, () => {
                             done();

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -116,7 +116,7 @@ describe('objectPut API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         metadata.getObjectMD(bucketName, objectName,
-                            log, (err, md) => {
+                            {}, log, (err, md) => {
                                 assert(md);
                                 assert
                                 .strictEqual(md['content-md5'], correctMD5);
@@ -150,7 +150,7 @@ describe('objectPut API', () => {
                 objectPut(authInfo, testPutObjectRequest, undefined, log,
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
-                        metadata.getObjectMD(bucketName, objectName, log,
+                        metadata.getObjectMD(bucketName, objectName, {}, log,
                             (err, md) => {
                                 assert(md);
                                 assert.strictEqual(md['x-amz-meta-test'],
@@ -189,7 +189,7 @@ describe('objectPut API', () => {
                     (err, result) => {
                         assert.strictEqual(result, correctMD5);
                         assert.deepStrictEqual(ds, []);
-                        metadata.getObjectMD(bucketName, objectName, log,
+                        metadata.getObjectMD(bucketName, objectName, {}, log,
                             (err, md) => {
                                 assert(md);
                                 assert.strictEqual(md.location, null);

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -92,8 +92,8 @@ describe('putObjectACL API', () => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, log,
-                            (err, md) => {
+                            metadata.getObjectMD(bucketName, objectName, {},
+                            log, (err, md) => {
                                 assert.strictEqual(md.acl.Canned,
                                 'public-read-write');
                                 done();
@@ -130,15 +130,15 @@ describe('putObjectACL API', () => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest1, log, err => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, log,
-                            (err, md) => {
+                            metadata.getObjectMD(bucketName, objectName, {},
+                            log, (err, md) => {
                                 assert.strictEqual(md.acl.Canned,
                                 'public-read');
                                 objectPutACL(authInfo, testObjACLRequest2, log,
                                     err => {
                                         assert.strictEqual(err, null);
                                         metadata.getObjectMD(bucketName,
-                                            objectName, log, (err, md) => {
+                                            objectName, {}, log, (err, md) => {
                                                 assert.strictEqual(md
                                                        .acl.Canned,
                                                        'authenticated-read');
@@ -174,8 +174,8 @@ describe('putObjectACL API', () => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, log,
-                            (err, md) => {
+                            metadata.getObjectMD(bucketName, objectName, {},
+                            log, (err, md) => {
                                 assert.strictEqual(err, null);
                                 const acls = md.acl;
                                 assert.strictEqual(acls.READ[0],
@@ -249,8 +249,8 @@ describe('putObjectACL API', () => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, log,
-                            (err, md) => {
+                            metadata.getObjectMD(bucketName, objectName, {},
+                            log, (err, md) => {
                                 assert.strictEqual(md
                                     .acl.FULL_CONTROL[0], ownerID);
                                 assert.strictEqual(md
@@ -315,8 +315,8 @@ describe('putObjectACL API', () => {
                         assert.strictEqual(result, correctMD5);
                         objectPutACL(authInfo, testObjACLRequest, log, err => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, log,
-                            (err, md) => {
+                            metadata.getObjectMD(bucketName, objectName, {},
+                            log, (err, md) => {
                                 assert.strictEqual(md.acl.Canned, '');
                                 assert.strictEqual(md.acl.FULL_CONTROL[0],
                                     ownerID);

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -168,7 +168,7 @@ describe('transient bucket handling', () => {
     describe('objectPut on a transient bucket', () => {
         const objName = 'objectName';
         after(done => {
-            metadata.deleteObjectMD(bucketName, objName, log, () => {
+            metadata.deleteObjectMD(bucketName, objName, {}, log, () => {
                 done();
             });
         });
@@ -187,7 +187,7 @@ describe('transient bucket handling', () => {
                 metadata.getBucket(bucketName, log, (err, data) => {
                     assert.strictEqual(data._transient, false);
                     assert.strictEqual(data._owner, authInfo.getCanonicalID());
-                    metadata.getObjectMD(bucketName, objName, log,
+                    metadata.getObjectMD(bucketName, objName, {}, log,
                         (err, obj) => {
                             assert.ifError(err);
                             assert.strictEqual(obj['content-md5'], etag);
@@ -202,7 +202,7 @@ describe('transient bucket handling', () => {
         const objName = 'objectName';
         after(done => {
             metadata.deleteObjectMD(`${constants.mpuBucketPrefix}` +
-                `${bucketName}`, objName, log, () => {
+                `${bucketName}`, objName, {}, log, () => {
                     metadata.deleteBucket(`${constants.mpuBucketPrefix}` +
                         `${bucketName}`, log, () => {
                             done();


### PR DESCRIPTION
This PR is in preparation for refactoring the S3 api methods for versioning.
It should be able to be merged immediately.

- reorder metadata wrapper params to precede callback
- pass callback params directly from bucketclient (when versioning is merged in MD, this will include versionId for affected methods)