### PR TITLE
node6: worker.suicide and new Buffer() deprecated

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -168,10 +168,7 @@ export default function main() {
                 workerPid: worker.process.pid,
             });
             setTimeout(() => {
-                // TODO: When upgrading to Node v6,
-                // instead of !worker.suicide,
-                // use !worker.exitedAfterDisconnect
-                if (!worker.isDead() && !worker.suicide) {
+                if (!worker.isDead() && !worker.exitedAfterDisconnect) {
                     logger.error('worker not exiting. killing it', {
                         workerId: worker.id,
                         workerPid: worker.pid,

--- a/tests/functional/aws-node-sdk/test/object/deleteObject.js
+++ b/tests/functional/aws-node-sdk/test/object/deleteObject.js
@@ -11,7 +11,7 @@ describe('DELETE object', () => {
         let uploadId;
         const bucketUtil = new BucketUtility('default', sigCfg);
         const s3 = bucketUtil.s3;
-        const testfile = new Buffer(1024 * 1024 * 54);
+        const testfile = Buffer.alloc(1024 * 1024 * 54, 0);
 
         before(() => {
             process.stdout.write('creating bucket\n');


### PR DESCRIPTION
In Node6 
- `worker.suicide` is deprecated. Using `worker.exitedAfterDisconnect` instead.
- `new Buffer(size)` is deprecated. Using `Buffer.allocUnsafe()` instead.