### PR TITLE
Fix logic in parsing of sproxyd config and update tests

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -10,7 +10,7 @@ const defaultHealthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
 const defaultLocalCache = { host: '127.0.0.1', port: 6379 };
 
 export function sproxydAssert(configSproxyd) {
-    let sproxydField;
+    const sproxydFields = [];
     if (configSproxyd.bootstrap !== undefined) {
         assert(Array.isArray(configSproxyd.bootstrap)
             && configSproxyd.bootstrap
@@ -18,16 +18,16 @@ export function sproxydAssert(configSproxyd) {
             'bad config: sproxyd.bootstrap must be a list of strings');
         assert(configSproxyd.bootstrap.length > 0,
                 'bad config: sproxyd bootstrap list is empty');
-        sproxydField = 'bootstrap';
+        sproxydFields.push('bootstrap');
     }
     if (configSproxyd.chordCos !== undefined) {
         assert(typeof configSproxyd.chordCos === 'string',
             'bad config: sproxyd.chordCos must be a string');
         assert(configSproxyd.chordCos.match(/^[0-9a-fA-F]{2}$/),
             'bad config: sproxyd.chordCos must be a 2hex-chars string');
-        sproxydField = 'chordCos';
+        sproxydFields.push('chordCos');
     }
-    return sproxydField;
+    return sproxydFields;
 }
 
 export function locationConstraintAssert(locationConstraints) {
@@ -141,17 +141,20 @@ class Config {
                     assert(typeof lc[l].details.connector === 'object',
                     'bad config: connector must be an object');
                     if (lc[l].details.connector.sproxyd !== undefined) {
-                        const field = sproxydAssert(
+                        this.locationConstraints[l].details.connector.sproxyd =
+                            lc[l].details.connector.sproxyd;
+                        const fields = sproxydAssert(
                             lc[l].details.connector.sproxyd);
-                        if (field === 'chordCos') {
+                        if (fields.indexOf('bootstrap') > -1) {
                             this.locationConstraints[l].details
-                                .connector.sproxyd[field] =
+                                .connector.sproxyd.bootstrap =
+                                lc[l].details.connector.sproxyd.bootstrap;
+                        }
+                        if (fields.indexOf('chordCos') > -1) {
+                            this.locationConstraints[l].details
+                                .connector.sproxyd[fields] =
                                 Number.parseInt(lc[l].details.
-                                    connector.sproxyd[field], 16);
-                        } else {
-                            this.locationConstraints[l].details
-                                .connector.sproxyd[field] =
-                                lc[l].details.connector.sproxyd[field];
+                                    connector.sproxyd[fields], 16);
                         }
                     }
                 }
@@ -195,12 +198,13 @@ class Config {
                 'bad config: use either sproxyd or locationConstraints/' +
                 'restEndpoints configuration, not both');
             this.sproxyd = config.sproxyd;
-            const field = sproxydAssert(config.sproxyd);
-            if (field === 'chordCos') {
-                this.sproxyd[field] =
-                    Number.parseInt(config.sproxyd[field], 16);
-            } else {
-                this.sproxyd[field] = config.sproxyd[field];
+            const fields = sproxydAssert(config.sproxyd);
+            if (fields.indexOf('bootstrap') > -1) {
+                this.sproxyd.boostrap = config.sproxyd.bootstrap;
+            }
+            if (fields.indexOf('chordCos') > -1) {
+                this.sproxyd.chordCos =
+                    Number.parseInt(config.sproxyd.chordCos, 16);
             }
         }
 

--- a/tests/unit/testConfigs/sproxydAssert.js
+++ b/tests/unit/testConfigs/sproxydAssert.js
@@ -1,25 +1,41 @@
 import assert from 'assert';
 import { sproxydAssert } from '../../../lib/Config';
 
-const dummySproxydConfBootstrap = {
+const dummySproxydConfBoot = {
     sproxyd: {
         bootstrap: ['localhost:8181'],
     },
 };
 
-const dummySproxydConfChordcos = {
+const dummySproxydConfChord = {
     sproxyd: {
         chordCos: '20',
     },
 };
 
+const dummySproxydConfBoth = {
+    sproxyd: {
+        bootstrap: ['localhost:8181'],
+        chordCos: '20',
+    },
+};
+
 describe('sproxydAssert', () => {
-    it('should return "bootstrap" if config contains bootstrap', () => {
-        const resString = sproxydAssert(dummySproxydConfBootstrap.sproxyd);
-        assert.strictEqual(resString, 'bootstrap');
+    it('should return array containing "bootstrap" if config ' +
+        'contains bootstrap', () => {
+        const sproxydArray = sproxydAssert(dummySproxydConfBoot.sproxyd);
+        assert.strictEqual(sproxydArray.indexOf('bootstrap'), 0);
     });
-    it('should return "chordCos" if config contains chordCos', () => {
-        const resString = sproxydAssert(dummySproxydConfChordcos.sproxyd);
-        assert.strictEqual(resString, 'chordCos');
+    it('should return array containing "chordCos" if config contains chordCos',
+        () => {
+            const sproxydArray = sproxydAssert(dummySproxydConfChord.sproxyd);
+            assert.strictEqual(sproxydArray.indexOf('chordCos'), 0);
+        });
+    it('should return array of "bootstrap" and "chordCos" if config ' +
+        'contains both fields', () => {
+        const sproxydArray = sproxydAssert(dummySproxydConfBoth.sproxyd);
+        assert.strictEqual(sproxydArray.length, 2);
+        assert.strictEqual(sproxydArray.indexOf('bootstrap') > -1, true);
+        assert.strictEqual(sproxydArray.indexOf('chordCos') > -1, true);
     });
 });


### PR DESCRIPTION
Previously, the parsing logic assumed that sproxyd would have either a bootstrap list or a chordCos value. This PR allows for both to be used