### PR TITLE
S3C-92 GET wont report the size in the correct field

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -80,8 +80,8 @@ export default function routes(req, res, logger) {
     log.addDefaultFields({
         bucketName: req.bucketName,
         objectKey: req.objectKey,
-        bytesReceived: req.parsedContentLength || 0,
-        bodyLength: parseInt(req.headers['content-length'], 10) || 0,
+        bytesReceived: req.socket.bytesRead || 0,
+        bytesSent: req.socket.bytesWritten || 0,
     });
     // if empty name and request not a list Buckets
     if (!req.bucketName &&

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -251,9 +251,6 @@ export default function routePUT(request, response, log, statsClient) {
                 return routesUtils.responseNoBody(errors.BadRequest,
                     null, response, 400, log);
             }
-            log.end().addDefaultFields({
-                contentLength: request.parsedContentLength,
-            });
 
             api.callApiMethod('objectPut', request, log,
             (err, contentMD5, corsHeaders) => {


### PR DESCRIPTION
- `bodyLength: req.parsedContentLength || 0,` because for streaming v4 auth, the total body content length without the chunk metadata is sent as the `x-amz-decoded-content-length` 
- Getting rid of `contentLength: request.parsedContentLength,` in routePut.js since contentLength === bodyLength === req.parsedContentLength