### PR TITLE
FT: Support Expect header field

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -1,5 +1,4 @@
 import querystring from 'querystring';
-
 import { auth, errors } from 'arsenal';
 
 import bucketDelete from './bucketDelete';
@@ -42,10 +41,10 @@ import websiteHead from './websiteHead';
 
 auth.setHandler(vault);
 
+/* eslint-disable no-param-reassign */
 const api = {
-    callApiMethod(apiMethod, request, log, callback, locationConstraint) {
-        // no need to check auth on website serving (head or get)
-        // or cors preflight requests
+    callApiMethod(apiMethod, request, response, log, callback) {
+        // no need to check auth on website or cors preflight requests
         if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
         apiMethod === 'corsPreflight') {
             return this[apiMethod](request, log, callback);
@@ -68,8 +67,8 @@ const api = {
             sourceBucket = source.slice(0, slashSeparator);
             sourceObject = source.slice(slashSeparator + 1);
         }
-        const requestContexts = prepareRequestContexts(apiMethod,
-            request, locationConstraint, sourceBucket, sourceObject);
+        const requestContexts = prepareRequestContexts(apiMethod, request,
+            sourceBucket, sourceObject);
         return auth.server.doAuth(request, log, (err, userInfo,
             authorizationResults, streamingV4Params) => {
             if (err) {
@@ -84,20 +83,47 @@ const api = {
                     }
                 }
             }
-            if (apiMethod === 'bucketPut') {
-                return bucketPut(userInfo, request, locationConstraint,
-                    log, callback);
-            }
-            if (apiMethod === 'objectCopy' ||
-                apiMethod === 'objectPutCopyPart') {
-                return this[apiMethod](userInfo, request, sourceBucket,
-                    sourceObject, log, callback);
-            }
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
                 return this[apiMethod](userInfo, request, streamingV4Params,
                     log, callback);
             }
-            return this[apiMethod](userInfo, request, log, callback);
+            const MAX_POST_LENGTH = request.method.toUpperCase() === 'POST' ?
+                1024 * 1024 : 1024 * 1024 / 2; // 1 MB or 512 KB
+            const post = [];
+            let postLength = 0;
+            request.on('data', chunk => {
+                postLength += chunk.length;
+                // Sanity check on post length
+                if (postLength <= MAX_POST_LENGTH) {
+                    post.push(chunk);
+                }
+                return undefined;
+            });
+
+            request.on('error', err => {
+                log.trace('error receiving request', {
+                    error: err,
+                });
+                return callback(errors.InternalError);
+            });
+
+            request.on('end', () => {
+                if (postLength > MAX_POST_LENGTH) {
+                    log.error('body length is too long for request type',
+                        { postLength });
+                    return callback(errors.InvalidRequest);
+                }
+                // Convert array of post buffers into one string
+                request.post = Buffer.concat(post, postLength).toString();
+
+                if (apiMethod === 'objectCopy' ||
+                    apiMethod === 'objectPutCopyPart') {
+                    return this[apiMethod](userInfo, request, sourceBucket,
+                        sourceObject, log, callback);
+                }
+                return this[apiMethod](userInfo, request, log, callback);
+            });
+            return undefined;
         }, 's3', requestContexts);
     },
     bucketDelete,

--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -38,6 +38,7 @@ import serviceGet from './serviceGet';
 import vault from '../auth/vault';
 import websiteGet from './websiteGet';
 import websiteHead from './websiteHead';
+import writeContinue from '../utilities/writeContinue';
 
 auth.setHandler(vault);
 
@@ -83,6 +84,8 @@ const api = {
                     }
                 }
             }
+            // issue 100 Continue to the client
+            writeContinue(request, response);
             if (apiMethod === 'objectPut' || apiMethod === 'objectPutPart') {
                 return this[apiMethod](userInfo, request, streamingV4Params,
                     log, callback);

--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -6,19 +6,22 @@ const RequestContext = policies.RequestContext;
  * Prepares the requestContexts array to send to Vault for authorization
  * @param {string} apiMethod - api being called
  * @param {object} request - request object
- * @param {string} locationConstraint - locationConstraint if bucket put
- * operation
  * @param {string} sourceBucket - name of sourceBucket if copy request
  * @param {string} sourceObject - name of sourceObject if copy request
  * @return {RequestContext []} array of requestContexts
  */
-export default function prepareRequestContexts(apiMethod, request,
-    locationConstraint, sourceBucket, sourceObject) {
+export default function prepareRequestContexts(apiMethod, request, sourceBucket,
+    sourceObject) {
     // if multiObjectDelete request, we want to authenticate
     // before parsing the post body and creating multiple requestContexts
     // so send null as requestContexts to Vault to avoid authorization
     // checks at this point
-    if (apiMethod === 'multiObjectDelete') {
+    //
+    // If bucketPut request, we want to do the authorization check in the API
+    // itself (once we parse the locationConstraint from the xml body) so send
+    // null as the requestContext to Vault so it will only do an authentication
+    // check.
+    if (apiMethod === 'multiObjectDelete' || apiMethod === 'bucketPut') {
         return null;
     }
     const requestContexts = [];
@@ -26,17 +29,17 @@ export default function prepareRequestContexts(apiMethod, request,
         const getRequestContext = new RequestContext(request.headers,
             request.query, sourceBucket, sourceObject,
             request.socket.remoteAddress, request.connection.encrypted,
-            'objectGet', 's3', locationConstraint);
+            'objectGet', 's3');
         const putRequestContext = new RequestContext(request.headers,
             request.query, request.bucketName, request.objectKey,
             request.socket.remoteAddress, request.connection.encrypted,
-            'objectPut', 's3', locationConstraint);
+            'objectPut', 's3');
         requestContexts.push(getRequestContext, putRequestContext);
     } else {
         const requestContext = new RequestContext(request.headers,
             request.query, request.bucketName, request.objectKey,
             request.socket.remoteAddress, request.connection.encrypted,
-            apiMethod, 's3', locationConstraint);
+            apiMethod, 's3');
         requestContexts.push(requestContext);
     }
     return requestContexts;

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -1,12 +1,12 @@
-import { errors } from 'arsenal';
-
+import { auth, errors } from 'arsenal';
+import vault from '../auth/vault';
+import { parseString } from 'xml2js';
+import { waterfall } from 'async';
 import { createBucket } from './apiUtils/bucket/bucketCreation';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import config from '../Config';
 import aclUtils from '../utilities/aclUtils';
 import { pushMetric } from '../utapi/utilities';
-
-let locationConstraintChecked;
 
 /*
    Format of xml request:
@@ -17,18 +17,36 @@ let locationConstraintChecked;
    </CreateBucketConfiguration>
    */
 
+function _parseXML(request, log, cb) {
+    if (request.post) {
+        return parseString(request.post, (err, result) => {
+            if (err || !result.CreateBucketConfiguration
+                || !result.CreateBucketConfiguration.LocationConstraint
+                || !result.CreateBucketConfiguration.LocationConstraint[0]) {
+                log.debug('request xml is malformed');
+                return cb(errors.MalformedXML);
+            }
+            const locationConstraint = result.CreateBucketConfiguration
+                .LocationConstraint[0];
+            log.trace('location constraint',
+                { locationConstraint });
+            return cb(null, locationConstraint);
+        });
+    }
+    // We need the second parameter to be `undefined` so the waterfall maintains
+    // the position of the `next` argument.
+    return process.nextTick(() => cb(null, undefined));
+}
+
 /**
  * PUT Service - Create bucket for the user
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - http request object
- * @param {string | undefined} locationConstraint - locationConstraint for
- * bucket (if any)
  * @param {object} log - Werelogs logger
  * @param {function} callback - callback to server
  * @return {undefined}
  */
-export default function bucketPut(authInfo, request, locationConstraint, log,
-    callback) {
+export default function bucketPut(authInfo, request, log, callback) {
     log.debug('processing request', { method: 'bucketPut' });
 
     if (authInfo.isRequesterPublicUser()) {
@@ -39,36 +57,80 @@ export default function bucketPut(authInfo, request, locationConstraint, log,
         log.trace('invalid acl header');
         return callback(errors.InvalidArgument);
     }
-    // - AWS JS SDK sends a request with locationConstraint us-east-1
-    // if no locationConstraint provided.
-    if (locationConstraint && Object.keys(config.locationConstraints).
-        indexOf(locationConstraint) < 0) {
-        log.trace('locationConstraint is invalid',
-          { locationConstraint });
-        return callback(errors.InvalidLocationConstraint);
-    }
+    const { bucketName } = request;
 
-    if (!locationConstraint && request.parsedHost &&
-      config.restEndpoints[request.parsedHost]) {
-        locationConstraintChecked = config.restEndpoints[request.parsedHost];
-    } else {
-        locationConstraintChecked = locationConstraint;
-    }
-    const bucketName = request.bucketName;
-
-    return createBucket(authInfo, bucketName, request.headers,
-        locationConstraintChecked, log,
-        (err, previousBucket) => {
-            // if bucket already existed, gather any relevant cors headers
-            const corsHeaders = collectCorsHeaders(request.headers.origin,
-                request.method, previousBucket);
-            if (err) {
-                return callback(err, corsHeaders);
+    return waterfall([
+        next => _parseXML(request, log, next),
+        // Check policies in Vault for a user.
+        (locationConstraint, next) => {
+            if (authInfo.isRequesterAnIAMUser()) {
+                const authParams = auth.server.extractParams(request, log, 's3',
+                    request.query);
+                const requestContextParams = {
+                    constantParams: {
+                        headers: request.headers,
+                        query: request.query,
+                        generalResource: bucketName,
+                        specificResource: '',
+                        requesterIp: request.socket.remoteAddress,
+                        sslEnabled: request.connection.encrypted,
+                        apiMethod: 'bucketPut',
+                        awsService: 's3',
+                        locationConstraint,
+                        requesterInfo: authInfo,
+                        signatureVersion: authParams.params.data.authType,
+                        authType: authParams.params.data.signatureVersion,
+                        signatureAge: authParams.params.data.signatureAge,
+                    },
+                };
+                return vault.checkPolicies(requestContextParams,
+                    authInfo.getArn(), log, (err, authorizationResults) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        if (authorizationResults[0].isAllowed !== true) {
+                            log.trace('authorization check failed for user',
+                                { locationConstraint });
+                            return next(errors.AccessDenied);
+                        }
+                        return next(null, locationConstraint);
+                    });
             }
-            pushMetric('createBucket', log, {
-                authInfo,
-                bucket: bucketName,
-            });
-            return callback(null, corsHeaders);
-        });
+            return next(null, locationConstraint);
+        },
+        (locationConstraint, next) => {
+            // AWS JS SDK sends a request with locationConstraint us-east-1 if
+            // no locationConstraint provided.
+            const { locationConstraints, restEndpoints } = config;
+            const { parsedHost } = request;
+            if (locationConstraint && Object.keys(locationConstraints)
+                .indexOf(locationConstraint) < 0) {
+                log.trace('locationConstraint is invalid',
+                    { locationConstraint });
+                return next(errors.InvalidLocationConstraint);
+            }
+            let locationConstraintChecked;
+            if (!locationConstraint && parsedHost &&
+                restEndpoints[parsedHost]) {
+                locationConstraintChecked = restEndpoints[parsedHost];
+            } else {
+                locationConstraintChecked = locationConstraint;
+            }
+            return createBucket(authInfo, bucketName, request.headers,
+                locationConstraintChecked, log, (err, previousBucket) => {
+                    // if bucket already existed, gather any relevant cors
+                    // headers
+                    const corsHeaders = collectCorsHeaders(
+                        request.headers.origin, request.method, previousBucket);
+                    if (err) {
+                        return next(err, corsHeaders);
+                    }
+                    pushMetric('createBucket', log, {
+                        authInfo,
+                        bucket: bucketName,
+                    });
+                    return next(null, corsHeaders);
+                });
+        },
+    ], callback);
 }

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -1,3 +1,4 @@
+import { errors } from 'arsenal';
 import { waterfall } from 'async';
 import { parseString } from 'xml2js';
 
@@ -16,6 +17,36 @@ import services from '../services';
  Note that there is the header in the request if setting MfaDelete:
     x-amz-mfa: [SerialNumber] [TokenCode]
  */
+
+function _parseXML(request, log, cb) {
+    if (request.post === '') {
+        log.debug('request xml is missing');
+        return cb(errors.MalformedXML);
+    }
+    return parseString(request.post, (err, result) => {
+        if (err) {
+            log.debug('request xml is malformed');
+            return cb(errors.MalformedXML);
+        }
+        const status = result.VersioningConfiguration.Status ?
+            result.VersioningConfiguration.Status[0] : undefined;
+        const mfaDelete = result.VersioningConfiguration.MfaDelete ?
+            result.VersioningConfiguration.MfaDelete[0] : undefined;
+        const validStatuses = ['Enabled', 'Suspended'];
+        const validMfaDeletes = [undefined, 'Enabled', 'Disabled'];
+        if (validStatuses.indexOf(status) < 0 ||
+            validMfaDeletes.indexOf(mfaDelete) < 0) {
+            log.debug('illegal versioning configuration');
+            return cb(errors.IllegalVersioningConfigurationException);
+        }
+        if (mfaDelete) {
+            log.debug('mfa deletion is not implemented');
+            return cb(errors.NotImplemented
+                .customizedDescription('MFA Deletion is not supported yet.'));
+        }
+        return process.nextTick(() => cb(null));
+    });
+}
 
 /**
  * Bucket Put Versioning - Create or update bucket Versioning
@@ -37,6 +68,7 @@ export default function bucketPutVersioning(authInfo, request, log, callback) {
     };
 
     return waterfall([
+        next => _parseXML(request, log, next),
         next => services.metadataValidateAuthorization(metadataValParams,
             (err, bucket) => next(err, bucket)), // ignore extra null object,
         (bucket, next) => parseString(request.post, (err, result) => {

--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -13,7 +13,7 @@ export default function routeDELETE(request, response, log, statsClient) {
               errors.InvalidRequest.customizeDescription('A key must be ' +
               'specified'), null, response, 200, log);
         }
-        api.callApiMethod('multipartDelete', request, log,
+        api.callApiMethod('multipartDelete', request, response, log,
             (err, corsHeaders) => {
                 statsReport500(err, statsClient);
                 return routesUtils.responseNoBody(err, corsHeaders, response,
@@ -23,27 +23,27 @@ export default function routeDELETE(request, response, log, statsClient) {
         if (request.objectKey === undefined) {
             if (request.query.website !== undefined) {
                 return api.callApiMethod('bucketDeleteWebsite', request,
-                log, (err, corsHeaders) => {
+                response, log, (err, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseNoBody(err, corsHeaders,
                         response, 204, log);
                 });
             } else if (request.query.cors !== undefined) {
-                return api.callApiMethod('bucketDeleteCors', request, log,
-                (err, corsHeaders) => {
+                return api.callApiMethod('bucketDeleteCors', request, response,
+                log, (err, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseNoBody(err, corsHeaders,
                         response, 204, log);
                 });
             }
-            api.callApiMethod('bucketDelete', request, log,
+            api.callApiMethod('bucketDelete', request, response, log,
             (err, corsHeaders) => {
                 statsReport500(err, statsClient);
                 return routesUtils.responseNoBody(err, corsHeaders, response,
                   204, log);
             });
         } else {
-            api.callApiMethod('objectDelete', request, log,
+            api.callApiMethod('objectDelete', request, response, log,
               (err, corsHeaders) => {
                   /*
                   * Since AWS expects a 204 regardless of the existence of

--- a/lib/routes/routeGET.js
+++ b/lib/routes/routeGET.js
@@ -10,35 +10,35 @@ export default function routerGET(request, response, log, statsClient) {
     } else if (request.bucketName === undefined
         && request.objectKey === undefined) {
         // GET service
-        api.callApiMethod('serviceGet', request, log, (err, xml) => {
+        api.callApiMethod('serviceGet', request, response, log, (err, xml) => {
             statsReport500(err, statsClient);
             return routesUtils.responseXMLBody(err, xml, response, log);
         });
     } else if (request.objectKey === undefined) {
         // GET bucket ACL
         if (request.query.acl !== undefined) {
-            api.callApiMethod('bucketGetACL', request, log,
+            api.callApiMethod('bucketGetACL', request, response, log,
             (err, xml, corsHeaders) => {
                 statsReport500(err, statsClient);
                 return routesUtils.responseXMLBody(err, xml, response, log,
                     corsHeaders);
             });
         } else if (request.query.cors !== undefined) {
-            api.callApiMethod('bucketGetCors', request, log,
+            api.callApiMethod('bucketGetCors', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     routesUtils.responseXMLBody(err, xml, response, log,
                         corsHeaders);
                 });
         } else if (request.query.versioning !== undefined) {
-            api.callApiMethod('bucketGetVersioning', request, log,
+            api.callApiMethod('bucketGetVersioning', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     routesUtils.responseXMLBody(err, xml, response, log,
                         corsHeaders);
                 });
         } else if (request.query.website !== undefined) {
-            api.callApiMethod('bucketGetWebsite', request, log,
+            api.callApiMethod('bucketGetWebsite', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     routesUtils.responseXMLBody(err, xml, response, log,
@@ -46,14 +46,14 @@ export default function routerGET(request, response, log, statsClient) {
                 });
         } else if (request.query.uploads !== undefined) {
             // List MultipartUploads
-            api.callApiMethod('listMultipartUploads', request, log,
+            api.callApiMethod('listMultipartUploads', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
                         corsHeaders);
                 });
         } else if (request.query.location !== undefined) {
-            api.callApiMethod('bucketGetLocation', request, log,
+            api.callApiMethod('bucketGetLocation', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
@@ -61,7 +61,7 @@ export default function routerGET(request, response, log, statsClient) {
                 });
         } else {
             // GET bucket
-            api.callApiMethod('bucketGet', request, log,
+            api.callApiMethod('bucketGet', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
@@ -71,7 +71,7 @@ export default function routerGET(request, response, log, statsClient) {
     } else {
         if (request.query.acl !== undefined) {
             // GET object ACL
-            api.callApiMethod('objectGetACL', request, log,
+            api.callApiMethod('objectGetACL', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
@@ -79,7 +79,7 @@ export default function routerGET(request, response, log, statsClient) {
                 });
             // List parts of an open multipart upload
         } else if (request.query.uploadId !== undefined) {
-            api.callApiMethod('listParts', request, log,
+            api.callApiMethod('listParts', request, response, log,
                 (err, xml, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
@@ -87,17 +87,17 @@ export default function routerGET(request, response, log, statsClient) {
                 });
         } else {
             // GET object
-            api.callApiMethod('objectGet', request, log, (err, dataGetInfo,
-                    resMetaHeaders, range) => {
-                let contentLength = 0;
-                if (resMetaHeaders && resMetaHeaders['Content-Length']) {
-                    contentLength = resMetaHeaders['Content-Length'];
-                }
-                log.end().addDefaultFields({ contentLength });
-                statsReport500(err, statsClient);
-                return routesUtils.responseStreamData(err, request.headers,
-                    resMetaHeaders, dataGetInfo, response, range, log);
-            });
+            api.callApiMethod('objectGet', request, response, log,
+                (err, dataGetInfo, resMetaHeaders, range) => {
+                    let contentLength = 0;
+                    if (resMetaHeaders && resMetaHeaders['Content-Length']) {
+                        contentLength = resMetaHeaders['Content-Length'];
+                    }
+                    log.end().addDefaultFields({ contentLength });
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseStreamData(err, request.headers,
+                        resMetaHeaders, dataGetInfo, response, range, log);
+                });
         }
     }
 }

--- a/lib/routes/routeHEAD.js
+++ b/lib/routes/routeHEAD.js
@@ -11,17 +11,19 @@ export default function routeHEAD(request, response, log, statsClient) {
             null, response, log);
     } else if (request.objectKey === undefined) {
         // HEAD bucket
-        api.callApiMethod('bucketHead', request, log, (err, corsHeaders) => {
-            statsReport500(err, statsClient);
-            return routesUtils.responseNoBody(err, corsHeaders, response, 200,
-                log);
-        });
+        api.callApiMethod('bucketHead', request, response, log,
+            (err, corsHeaders) => {
+                statsReport500(err, statsClient);
+                return routesUtils.responseNoBody(err, corsHeaders, response,
+                    200, log);
+            });
     } else {
         // HEAD object
-        api.callApiMethod('objectHead', request, log, (err, resHeaders) => {
-            statsReport500(err, statsClient);
-            return routesUtils.responseContentHeaders(err, {}, resHeaders,
-                                               response, log);
-        });
+        api.callApiMethod('objectHead', request, response, log,
+            (err, resHeaders) => {
+                statsReport500(err, statsClient);
+                return routesUtils.responseContentHeaders(err, {}, resHeaders,
+                    response, log);
+            });
     }
 }

--- a/lib/routes/routeOPTIONS.js
+++ b/lib/routes/routeOPTIONS.js
@@ -23,7 +23,7 @@ export default function routeOPTIONS(request, response, log, statsClient) {
         return routesUtils.responseXMLBody(err, undefined, response, log);
     }
 
-    return api.callApiMethod('corsPreflight', request, log,
+    return api.callApiMethod('corsPreflight', request, response, log,
     (err, resHeaders) => {
         statsReport500(err, statsClient);
         return routesUtils.responseNoBody(err, resHeaders, response, 200,

--- a/lib/routes/routePOST.js
+++ b/lib/routes/routePOST.js
@@ -3,8 +3,6 @@ import { errors } from 'arsenal';
 import api from '../api/api';
 import routesUtils from './routesUtils';
 
-const MAX_POST_LENGTH = 1024 * 1024; // 1 MB
-
 /* eslint-disable no-param-reassign */
 export default function routePOST(request, response, log) {
     log.debug('routing request', { method: 'routePOST' });
@@ -27,54 +25,31 @@ export default function routePOST(request, response, log) {
             response, null, log);
     }
 
-    const post = [];
-    let postLength = 0;
-    request.on('data', chunk => {
-        postLength += chunk.length;
-        // Sanity check on post length
-        if (postLength <= MAX_POST_LENGTH) {
-            post.push(chunk);
-        }
-        return undefined;
-    });
+    // POST initiate multipart upload
+    if (request.query.uploads !== undefined) {
+        return api.callApiMethod('initiateMultipartUpload', request,
+            response, log, (err, result, corsHeaders) =>
+            routesUtils.responseXMLBody(err, result, response, log,
+                corsHeaders));
+    }
 
-    request.on('end', () => {
-        if (postLength > MAX_POST_LENGTH) {
-            log.error('body length is too long for request type',
-                { postLength });
-            return routesUtils.responseXMLBody(errors.InvalidRequest, null,
-                response, log);
-        }
-        // Convert array of post buffers into one string
-        request.post = Buffer.concat(post, postLength).toString();
+    // POST complete multipart upload
+    if (request.query.uploadId !== undefined) {
+        return api.callApiMethod('completeMultipartUpload', request,
+            response, log, (err, result, corsHeaders) =>
+            routesUtils.responseXMLBody(err, result, response, log,
+                corsHeaders));
+    }
 
-        // POST initiate multipart upload
-        if (request.query.uploads !== undefined) {
-            return api.callApiMethod('initiateMultipartUpload', request, log,
-                (err, result, corsHeaders) =>
-                routesUtils.responseXMLBody(err, result, response, log,
-                    corsHeaders));
-        }
+    // POST multiObjectDelete
+    if (request.query.delete !== undefined) {
+        return api.callApiMethod('multiObjectDelete', request, response,
+            log, (err, xml, corsHeaders) =>
+            routesUtils.responseXMLBody(err, xml, response, log,
+                corsHeaders));
+    }
 
-        // POST complete multipart upload
-        if (request.query.uploadId !== undefined) {
-            return api.callApiMethod('completeMultipartUpload', request, log,
-                (err, result, corsHeaders) =>
-                routesUtils.responseXMLBody(err, result, response, log,
-                    corsHeaders));
-        }
-
-        // POST multiObjectDelete
-        if (request.query.delete !== undefined) {
-            return api.callApiMethod('multiObjectDelete', request, log,
-                (err, xml, corsHeaders) =>
-                routesUtils.responseXMLBody(err, xml, response, log,
-                    corsHeaders));
-        }
-
-        return routesUtils.responseNoBody(errors.NotImplemented, null, response,
+    return routesUtils.responseNoBody(errors.NotImplemented, null, response,
                 200, log);
-    });
-    return undefined;
 }
 /* eslint-enable no-param-reassign */

--- a/lib/routes/routePUT.js
+++ b/lib/routes/routePUT.js
@@ -1,5 +1,4 @@
 import { errors } from 'arsenal';
-import { parseString } from 'xml2js';
 
 import api from '../api/api';
 import routesUtils from './routesUtils';
@@ -14,11 +13,6 @@ const encryptionHeaders = [
     'x-amz-server-side-encryption-customer-key',
     'x-amz-server-side-encryption-customer-key-md5',
 ];
-
-const validStatuses = ['Enabled', 'Suspended'];
-const validMfaDeletes = [undefined, 'Enabled', 'Disabled'];
-
-const MAX_POST_LENGTH = 1024 * 1024 / 2; // 512 KB
 
 /* eslint-disable no-param-reassign */
 export default function routePUT(request, response, log, statsClient) {
@@ -35,133 +29,48 @@ export default function routePUT(request, response, log, statsClient) {
             return routesUtils.responseNoBody(
               errors.BadRequest, null, response, null, log);
         }
-        request.post = '';
-        const post = [];
-        let postLength = 0;
-        request.on('data', chunk => {
-            postLength += chunk.length;
-            // Sanity check on post length
-            if (postLength <= MAX_POST_LENGTH) {
-                post.push(chunk);
-            }
-            return undefined;
-        });
 
-        request.on('end', () => {
-            if (postLength > MAX_POST_LENGTH) {
-                log.error('body length is too long for request type',
-                    { postLength });
-                return routesUtils.responseXMLBody(errors.InvalidRequest, null,
-                    response, log);
-            }
-            // Convert array of post buffers into one string
-            request.post = Buffer.concat(post, postLength)
-                             .toString();
-
-            // PUT bucket ACL
-            if (request.query.acl !== undefined) {
-                api.callApiMethod('bucketPutACL', request, log,
+        // PUT bucket ACL
+        if (request.query.acl !== undefined) {
+            api.callApiMethod('bucketPutACL', request, response, log,
+            (err, corsHeaders) => {
+                statsReport500(err, statsClient);
+                return routesUtils.responseNoBody(err, corsHeaders,
+                    response, 200, log);
+            });
+        } else if (request.query.versioning !== undefined) {
+            api.callApiMethod('bucketPutVersioning', request, response, log,
+                (err, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    routesUtils.responseNoBody(err, corsHeaders, response, 200,
+                        log);
+                });
+        } else if (request.query.website !== undefined) {
+            api.callApiMethod('bucketPutWebsite', request, response, log,
                 (err, corsHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseNoBody(err, corsHeaders,
                         response, 200, log);
                 });
-            } else if (request.query.versioning !== undefined) {
-                if (request.post === '') {
-                    log.debug('request xml is missing');
-                    return routesUtils.responseNoBody(
-                        errors.MalformedXML, null, response, null, log);
-                }
-                const xmlToParse = request.post;
-                return parseString(xmlToParse, (err, result) => {
-                    if (err) {
-                        log.debug('request xml is malformed');
-                        return routesUtils.responseNoBody(
-                            errors.MalformedXML, null, response, null, log);
-                    }
-                    const status = result.VersioningConfiguration.Status ?
-                        result.VersioningConfiguration.Status[0] : undefined;
-                    const mfaDelete = result.VersioningConfiguration.MfaDelete ?
-                        result.VersioningConfiguration.MfaDelete[0] : undefined;
-                    if (validStatuses.indexOf(status) < 0 ||
-                        validMfaDeletes.indexOf(mfaDelete) < 0) {
-                        log.debug('illegal versioning configuration');
-                        return routesUtils.responseNoBody(
-                            errors.IllegalVersioningConfigurationException,
-                            null, response, null, log);
-                    }
-                    if (mfaDelete) {
-                        log.debug('mfa deletion is not implemented');
-                        return routesUtils.responseNoBody(
-                            errors.NotImplemented.customizedDescription(
-                                'MFA Deletion is not supported yet.'), null,
-                            response, null, log);
-                    }
-                    return api.callApiMethod('bucketPutVersioning', request,
-                        log, (err, corsHeaders) => {
-                            statsReport500(err, statsClient);
-                            routesUtils.responseNoBody(
-                                err, corsHeaders, response, 200, log);
-                        });
+        } else if (request.query.cors !== undefined) {
+            api.callApiMethod('bucketPutCors', request, response, log,
+                (err, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 200, log);
                 });
-            } else if (request.query.website !== undefined) {
-                api.callApiMethod('bucketPutWebsite', request, log,
-                    (err, corsHeaders) => {
-                        statsReport500(err, statsClient);
-                        return routesUtils.responseNoBody(err, corsHeaders,
-                            response, 200, log);
-                    });
-            } else if (request.query.cors !== undefined) {
-                api.callApiMethod('bucketPutCors', request, log,
-                    (err, corsHeaders) => {
-                        statsReport500(err, statsClient);
-                        return routesUtils.responseNoBody(err, corsHeaders,
-                            response, 200, log);
-                    });
-            } else if (request.query.acl === undefined) {
-                // PUT bucket
-                const location = { Location: `/${request.bucketName}` };
-                if (request.post) {
-                    const xmlToParse = request.post;
-                    return parseString(xmlToParse, (err, result) => {
-                        if (err || !result.CreateBucketConfiguration
-                            || !result.CreateBucketConfiguration
-                                .LocationConstraint
-                            || !result.CreateBucketConfiguration
-                                .LocationConstraint[0]) {
-                            log.debug('request xml is malformed');
-                            return routesUtils.responseNoBody(errors
-                                .MalformedXML,
-                                null, response, null, log);
-                        }
-                        const locationConstraint =
-                            result.CreateBucketConfiguration
-                            .LocationConstraint[0];
-                        log.trace('location constraint',
-                            { locationConstraint });
-                        return api.callApiMethod('bucketPut', request, log,
-                        (err, corsHeaders) => {
-                            statsReport500(err, statsClient);
-                            const resHeaders = corsHeaders ?
-                                Object.assign({}, location, corsHeaders) :
-                                location;
-                            return routesUtils.responseNoBody(err, resHeaders,
-                              response, 200, log);
-                        }, locationConstraint);
-                    });
-                }
-                return api.callApiMethod('bucketPut', request, log,
-                    (err, corsHeaders) => {
-                        statsReport500(err, statsClient);
-                        const resHeaders = corsHeaders ?
-                            Object.assign({}, location, corsHeaders) :
-                            location;
-                        return routesUtils.responseNoBody(err, resHeaders,
-                            response, 200, log);
-                    });
-            }
-            return undefined;
-        });
+        } else if (request.query.acl === undefined) {
+            // PUT bucket
+            return api.callApiMethod('bucketPut', request, response, log,
+                (err, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    const location = { Location: `/${request.bucketName}` };
+                    const resHeaders = corsHeaders ?
+                        Object.assign({}, location, corsHeaders) : location;
+                    return routesUtils.responseNoBody(err, resHeaders,
+                        response, 200, log);
+                });
+        }
     } else {
         // PUT object, PUT object ACL, PUT object multipart or
         // PUT object copy
@@ -199,14 +108,14 @@ export default function routePUT(request, response, log, statsClient) {
         }
         if (request.query.partNumber) {
             if (request.headers['x-amz-copy-source']) {
-                api.callApiMethod('objectPutCopyPart', request, log,
+                api.callApiMethod('objectPutCopyPart', request, response, log,
                 (err, xml, additionalHeaders) => {
                     statsReport500(err, statsClient);
                     return routesUtils.responseXMLBody(err, xml, response, log,
                             additionalHeaders);
                 });
             } else {
-                api.callApiMethod('objectPutPart', request, log,
+                api.callApiMethod('objectPutPart', request, response, log,
                     (err, calculatedHash, corsHeaders) => {
                         if (err) {
                             return routesUtils.responseNoBody(err, corsHeaders,
@@ -221,25 +130,19 @@ export default function routePUT(request, response, log, statsClient) {
                     });
             }
         } else if (request.query.acl !== undefined) {
-            request.post = '';
-            request.on('data', chunk => {
-                request.post += chunk.toString();
-            });
-            request.on('end', () => {
-                api.callApiMethod('objectPutACL', request, log,
-                    (err, corsHeaders) => {
-                        statsReport500(err, statsClient);
-                        return routesUtils.responseNoBody(err, corsHeaders,
-                            response, 200, log);
-                    });
-            });
+            api.callApiMethod('objectPutACL', request, response, log,
+                (err, corsHeaders) => {
+                    statsReport500(err, statsClient);
+                    return routesUtils.responseNoBody(err, corsHeaders,
+                        response, 200, log);
+                });
         } else if (request.headers['x-amz-copy-source']) {
-            return api.callApiMethod('objectCopy', request, log, (err, xml,
-                additionalHeaders) => {
-                statsReport500(err, statsClient);
-                routesUtils.responseXMLBody(err, xml, response, log,
-                    additionalHeaders);
-            });
+            return api.callApiMethod('objectCopy', request, response, log,
+                (err, xml, additionalHeaders) => {
+                    statsReport500(err, statsClient);
+                    routesUtils.responseXMLBody(err, xml, response, log,
+                        additionalHeaders);
+                });
         } else {
             if (request.headers['content-length'] === undefined &&
             request.headers['x-amz-decoded-content-length'] === undefined) {
@@ -255,7 +158,7 @@ export default function routePUT(request, response, log, statsClient) {
                 contentLength: request.parsedContentLength,
             });
 
-            api.callApiMethod('objectPut', request, log,
+            api.callApiMethod('objectPut', request, response, log,
             (err, contentMD5, corsHeaders) => {
                 if (err) {
                     return routesUtils.responseNoBody(err, corsHeaders,

--- a/lib/routes/routeWebsite.js
+++ b/lib/routes/routeWebsite.js
@@ -14,7 +14,7 @@ export default function routerWebsite(request, response, log, statsClient) {
             false, request.bucketName, response, null, log);
     }
     if (request.method === 'GET') {
-        return api.callApiMethod('websiteGet', request, log,
+        return api.callApiMethod('websiteGet', request, response, log,
             (err, userErrorPageFailure, dataGetInfo, resMetaHeaders,
             redirectInfo, key) => {
                 statsReport500(err, statsClient);
@@ -43,7 +43,7 @@ export default function routerWebsite(request, response, log, statsClient) {
             });
     }
     if (request.method === 'HEAD') {
-        return api.callApiMethod('websiteHead', request, log,
+        return api.callApiMethod('websiteHead', request, response, log,
         (err, resMetaHeaders, redirectInfo, key) => {
             statsReport500(err, statsClient);
             if (redirectInfo) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,6 +78,8 @@ class S3Server {
 
         this.server.on('request', this.routeRequest);
 
+        this.server.on('checkContinue', this.routeRequest);
+
         this.server.on('listening', () => {
             const addr = this.server.address() || {
                 address: ipAddress || '[::]',

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,6 +37,12 @@ class S3Server {
         });
     }
 
+    routeRequest(req, res) {
+        // disable nagle algorithm
+        req.socket.setNoDelay();
+        routes(req, res, logger);
+    }
+
     /*
      * This starts the http server.
      */
@@ -66,19 +72,11 @@ class S3Server {
                 { error: err }));
         });
 
-        this.server.on('request', (req, res) => {
-            // disable nagle algorithm
-            req.socket.setNoDelay();
-            routes(req, res, logger);
-        });
-
         // https://nodejs.org/dist/latest-v6.x/
         // docs/api/http.html#http_event_checkexpectation
-        this.server.on('checkExpectation', (req, res) => {
-            // disable nagle algorithm
-            req.socket.setNoDelay();
-            routes(req, res, logger);
-        });
+        this.server.on('checkExpectation', this.routeRequest);
+
+        this.server.on('request', this.routeRequest);
 
         this.server.on('listening', () => {
             const addr = this.server.address() || {

--- a/lib/utilities/writeContinue.js
+++ b/lib/utilities/writeContinue.js
@@ -1,0 +1,17 @@
+/**
+ * writeContinue - Handles sending a HTTP/1.1 100 Continue message to the
+ * client, indicating that the request body should be sent.
+ * @param {object} req - http request object
+ * @param {object} res - http response object
+ * @param {string} apiMethod - The API method to call
+ * @return {undefined}
+ */
+export default function writeContinue(req, res) {
+    const { headers } = req;
+    // The Expect field-value is case-insensitive. Thus, just check for the
+    // Expect header's presence and a valid field-value.
+    if (headers.expect && headers.expect.toLowerCase() === '100-continue') {
+        res.writeContinue();
+    }
+    return undefined;
+}

--- a/tests/functional/aws-node-sdk/test/object/100-continue.js
+++ b/tests/functional/aws-node-sdk/test/object/100-continue.js
@@ -1,0 +1,131 @@
+import assert from 'assert';
+import http from 'http';
+import https from 'https';
+import url from 'url';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+import conf from '../../../../../lib/Config';
+
+const transport = conf.https ? https : http;
+const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
+const hostname = process.env.AWS_ON_AIR ? 's3.amazonaws.com' : ipAddress;
+const port = process.env.AWS_ON_AIR ? 80 : 8000;
+const bucket = 'foo-bucket';
+const key = 'foo-key';
+const body = Buffer.alloc(1024 * 1024);
+
+class ContinueRequestHandler {
+    constructor(path) {
+        this.path = path;
+        return this;
+    }
+
+    setRequestPath(path) {
+        this.path = path;
+        return this;
+    }
+
+    setExpectHeader(header) {
+        this.expectHeader = header;
+        return this;
+    }
+
+    getRequestOptions() {
+        return {
+            path: this.path,
+            hostname,
+            port,
+            method: 'PUT',
+            headers: {
+                'content-length': body.length,
+                'Expect': this.expectHeader || '100-continue',
+            },
+        };
+    }
+
+    hasStatusCode(statusCode, cb) {
+        const options = this.getRequestOptions();
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        const req = transport.request(options, res => {
+            assert.strictEqual(res.statusCode, statusCode);
+            return cb();
+        });
+        // Send the body either on the continue event, or immediately.
+        if (this.expectHeader === '100-continue') {
+            req.on('continue', () => req.end(body));
+        } else {
+            req.end(body);
+        }
+    }
+
+    sendsBodyOnContinue(cb) {
+        const options = this.getRequestOptions();
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+        const req = transport.request(options);
+        // At this point we have only sent the header.
+        assert(req.output.length === 1);
+        const headerLen = req.output[0].length;
+        req.on('continue', () => {
+            // Has only the header been sent?
+            assert.strictEqual(req.socket.bytesWritten, headerLen);
+            // Send the body since the continue event has been emitted.
+            return req.end(body);
+        });
+        req.on('close', () => {
+            const expected = body.length + headerLen;
+            // Has the entire body been sent?
+            assert.strictEqual(req.socket.bytesWritten, expected);
+            return cb();
+        });
+        req.on('error', err => cb(err));
+    }
+}
+
+describe('PUT public object with 100-continue header', () => {
+    withV4(sigCfg => {
+        let bucketUtil;
+        let s3;
+        let continueRequest;
+        const invalidSignedURL = `/${bucket}/${key}`;
+
+        beforeEach(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            const params = {
+                Bucket: bucket,
+                Key: key,
+            };
+            const signedUrl = s3.getSignedUrl('putObject', params);
+            const { path } = url.parse(signedUrl);
+            continueRequest = new ContinueRequestHandler(path);
+            return s3.createBucketAsync({ Bucket: bucket });
+        });
+
+        afterEach(() =>
+            bucketUtil.empty(bucket)
+            .then(() => bucketUtil.deleteOne(bucket)));
+
+        it('should return 200 status code', done =>
+            continueRequest.hasStatusCode(200, done));
+
+        it('should return 200 status code with upper case value', done =>
+            continueRequest.setExpectHeader('100-CONTINUE')
+                .hasStatusCode(200, done));
+
+        it('should return 200 status code if incorrect value', done =>
+            continueRequest.setExpectHeader('101-continue')
+                .hasStatusCode(200, done));
+
+        it('should return 403 status code if cannot authenticate', done =>
+            continueRequest.setRequestPath(invalidSignedURL)
+                .hasStatusCode(403, done));
+
+        it('should wait for continue event before sending body', done =>
+            continueRequest.sendsBodyOnContinue(done));
+
+        it('should continue if a public user', done =>
+            continueRequest.setRequestPath(invalidSignedURL)
+                .sendsBodyOnContinue(done));
+    });
+});

--- a/tests/functional/jaws/src/test/java/com/scality/StreamV4AuthTest.java
+++ b/tests/functional/jaws/src/test/java/com/scality/StreamV4AuthTest.java
@@ -125,8 +125,10 @@ public class StreamV4AuthTest {
         FileInputStream fis = new FileInputStream(sample);
         String md5 = org.apache.commons.codec.digest.DigestUtils.md5Hex(fis);
         fis.close();
-        getS3Client().putObject(new PutObjectRequest(bucketName, objName,
-            sample));
+        PutObjectRequest putObjectReq = new PutObjectRequest(bucketName,
+            objName, sample);
+        putObjectReq.putCustomRequestHeader("Expect", "100-continue");
+        getS3Client().putObject(putObjectReq);
         S3Object object = getS3Client()
             .getObject(new GetObjectRequest(bucketName, objName));
         Assert.assertEquals(object.getObjectMetadata().getETag(), md5);

--- a/tests/multipleBackend/objectPut.js
+++ b/tests/multipleBackend/objectPut.js
@@ -16,12 +16,17 @@ const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const objectName = 'objectName';
 
 function put(bucketLoc, objLoc, bucketHost, cb) {
-    const locationConstraint = bucketLoc;
+    const post = bucketLoc ? '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${bucketLoc}</LocationConstraint>` +
+        '</CreateBucketConfiguration>' : '';
     const bucketPutReq = new DummyRequest({
         bucketName,
         namespace,
         headers: { host: `${bucketName}.s3.amazonaws.com` },
         url: '/',
+        post,
     });
     if (bucketHost) {
         bucketPutReq.parsedHost = bucketHost;
@@ -40,7 +45,7 @@ function put(bucketLoc, objLoc, bucketHost, cb) {
         };
     }
     const testPutObjReq = new DummyRequest(objPutParams, body);
-    bucketPut(authInfo, bucketPutReq, locationConstraint, log, () => {
+    bucketPut(authInfo, bucketPutReq, log, () => {
         objectPut(authInfo, testPutObjReq, undefined, log, (err, result) => {
             assert.strictEqual(err, null, `Error putting object: ${err}`);
             assert.strictEqual(result, correctMD5);
@@ -89,4 +94,3 @@ describe('objectPutAPI with multiple backends', () => {
         });
     });
 });
-

--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -23,15 +23,19 @@ const sourceObjName = 'supersourceobject';
 const destObjName = 'copycatobject';
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
 const body = Buffer.from('I am a body', 'utf8');
-const bucketPutReq = new DummyRequest({
-    bucketName,
-    namespace,
-    headers: { host: `${bucketName}.s3.amazonaws.com` },
-    url: '/',
-});
-
 function copyPutPart(bucketLoc, mpuLoc, srcObjLoc, mpuHost, cb) {
-    const locationConstraint = bucketLoc;
+    const post = bucketLoc ? '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${bucketLoc}</LocationConstraint>` +
+        '</CreateBucketConfiguration>' : '';
+    const bucketPutReq = new DummyRequest({
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post,
+    });
     const initiateReq = {
         bucketName,
         namespace,
@@ -61,7 +65,7 @@ function copyPutPart(bucketLoc, mpuLoc, srcObjLoc, mpuHost, cb) {
 
     async.waterfall([
         next => {
-            bucketPut(authInfo, bucketPutReq, locationConstraint, log, err => {
+            bucketPut(authInfo, bucketPutReq, log, err => {
                 assert.ifError(err, 'Error putting bucket');
                 next(err);
             });

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -21,16 +21,20 @@ const bucketName = 'bucketname';
 const objectName = 'objectName';
 const body = Buffer.from('I am a body', 'utf8');
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
-const bucketPutReq = {
-    bucketName,
-    namespace,
-    headers: { host: `${bucketName}.s3.amazonaws.com` },
-    url: '/',
-    post: '',
-};
 
 function putPart(bucketLoc, mpuLoc, partLoc, host, cb) {
-    const locationConstraint = bucketLoc;
+    const post = bucketLoc ? '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${bucketLoc}</LocationConstraint>` +
+        '</CreateBucketConfiguration>' : '';
+    const bucketPutReq = {
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+        post,
+    };
     const initiateReq = {
         bucketName,
         namespace,
@@ -47,8 +51,7 @@ function putPart(bucketLoc, mpuLoc, partLoc, host, cb) {
     }
     async.waterfall([
         next => {
-            bucketPut(authInfo, bucketPutReq,
-            locationConstraint, log, err => {
+            bucketPut(authInfo, bucketPutReq, log, err => {
                 assert.ifError(err, 'Error putting bucket');
                 next(err);
             });
@@ -162,4 +165,3 @@ describe('objectPutPart API with multiple backends', () => {
         });
     });
 });
-

--- a/tests/unit/api/bucketDelete.js
+++ b/tests/unit/api/bucketDelete.js
@@ -23,7 +23,6 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = Buffer.from('I am a body', 'utf8');
 const usersBucket = constants.usersBucket;
-const locationConstraint = 'us-east-1';
 
 describe('bucketDelete API', () => {
     beforeEach(() => {
@@ -55,7 +54,7 @@ describe('bucketDelete API', () => {
             objectKey: objectName,
         }, postBody);
 
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.strictEqual(err, null);
             objectPut(authInfo, testPutObjectRequest, undefined, log, err => {
                 assert.strictEqual(err, null);
@@ -77,7 +76,7 @@ describe('bucketDelete API', () => {
     });
 
     it('should return an error if the bucket has an initiated mpu', done => {
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.strictEqual(err, null);
             initiateMultipartUpload(authInfo, initiateRequest, log, err => {
                 assert.strictEqual(err, null);
@@ -94,8 +93,7 @@ describe('bucketDelete API', () => {
         const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
         const postBody = Buffer.from('I am a body', 'utf8');
         async.waterfall([
-            next => bucketPut(authInfo, testRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => {
@@ -139,7 +137,7 @@ describe('bucketDelete API', () => {
     });
 
     it('should delete a bucket', done => {
-        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
+        bucketPut(authInfo, testRequest, log, () => {
             bucketDelete(authInfo, testRequest, log, () => {
                 metadata.getBucket(bucketName, log, (err, md) => {
                     assert.deepStrictEqual(err, errors.NoSuchBucket);

--- a/tests/unit/api/bucketDeleteCors.js
+++ b/tests/unit/api/bucketDeleteCors.js
@@ -12,7 +12,6 @@ import metadata from '../../../lib/metadata/wrapper';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 
 const corsUtil = new CorsConfigTester();
 
@@ -29,8 +28,7 @@ const testBucketDeleteCorsRequest =
 describe('deleteBucketCors API', () => {
     beforeEach(done => {
         cleanup();
-        bucketPut(authInfo, testBucketPutRequest, locationConstraint, log,
-        () => {
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
             bucketPutCors(authInfo, testBucketPutCorsRequest, log, done);
         });
     });

--- a/tests/unit/api/bucketDeleteWebsite.js
+++ b/tests/unit/api/bucketDeleteWebsite.js
@@ -13,7 +13,6 @@ import metadata from '../../../lib/metadata/wrapper';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const config = new WebsiteConfig('index.html', 'error.html');
 config.addRoutingRule({ ReplaceKeyPrefixWith: 'documents/' },
 { KeyPrefixEquals: 'docs/' });
@@ -36,8 +35,7 @@ const testBucketPutWebsiteRequest = Object.assign({ post: config.getXml() },
 describe('deleteBucketWebsite API', () => {
     beforeEach(done => {
         cleanup();
-        bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, () => {
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
             bucketPutWebsite(authInfo, testBucketPutWebsiteRequest, log, done);
         });
     });

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -29,11 +29,6 @@ describe('bucketGet API', () => {
     const objectName1 = `${prefix}${delimiter}objectName1`;
     const objectName2 = `${prefix}${delimiter}objectName2`;
     const objectName3 = 'notURIvalid$$';
-    const post = '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<CreateBucketConfiguration ' +
-        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-        '<LocationConstraint>us-east-1</LocationConstraint>' +
-        '</CreateBucketConfiguration>';
 
     beforeEach(() => {
         cleanup();
@@ -42,7 +37,7 @@ describe('bucketGet API', () => {
             headers: {},
             url: `/${bucketName}`,
             namespace,
-        }, post);
+        }, Buffer.alloc(0));
         testPutObjectRequest1 = new DummyRequest({
             bucketName,
             headers: {},

--- a/tests/unit/api/bucketGet.js
+++ b/tests/unit/api/bucketGet.js
@@ -19,7 +19,6 @@ const log = new DummyRequestLogger();
 const namespace = 'default';
 const postBody = Buffer.from('I am a body', 'utf8');
 const prefix = 'sub';
-const locationConstraint = 'us-east-1';
 
 let testPutBucketRequest;
 let testPutObjectRequest1;
@@ -30,6 +29,11 @@ describe('bucketGet API', () => {
     const objectName1 = `${prefix}${delimiter}objectName1`;
     const objectName2 = `${prefix}${delimiter}objectName2`;
     const objectName3 = 'notURIvalid$$';
+    const post = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        '<LocationConstraint>us-east-1</LocationConstraint>' +
+        '</CreateBucketConfiguration>';
 
     beforeEach(() => {
         cleanup();
@@ -38,7 +42,7 @@ describe('bucketGet API', () => {
             headers: {},
             url: `/${bucketName}`,
             namespace,
-        }, Buffer.alloc(0));
+        }, post);
         testPutObjectRequest1 = new DummyRequest({
             bucketName,
             headers: {},
@@ -75,21 +79,18 @@ describe('bucketGet API', () => {
 
         async.waterfall([
             next =>
-                bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
-            (corsHeaders, next) => {
-                objectPut(authInfo, testPutObjectRequest1, undefined,
-                log, next);
-            },
+                bucketPut(authInfo, testPutBucketRequest, log, next),
+            (corsHeaders, next) =>
+                objectPut(authInfo, testPutObjectRequest1, undefined, log,
+                    next),
             (result, corsHeaders, next) => {
-                objectPut(authInfo,
-                testPutObjectRequest2, undefined, log, next);
+                objectPut(authInfo, testPutObjectRequest2, undefined, log,
+                    next);
             },
             (result, corsHeaders, next) =>
                 bucketGet(authInfo, testGetRequest, log, next),
-            (result, corsHeaders, next) => {
-                parseString(result, next);
-            },
+            (result, corsHeaders, next) =>
+                parseString(result, next),
         ],
         (err, result) => {
             assert.strictEqual(result.ListBucketResult
@@ -110,8 +111,7 @@ describe('bucketGet API', () => {
 
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
                 undefined, log, next),
             (result, corsHeaders, next) => objectPut(authInfo,
@@ -139,8 +139,7 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
                 undefined, log, next),
             (result, corsHeaders, next) => objectPut(authInfo,
@@ -181,8 +180,7 @@ describe('bucketGet API', () => {
             query: { 'max-keys': '99999' },
         };
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
                 undefined, log, next),
             (result, corsHeaders, next) => objectPut(authInfo,
@@ -208,8 +206,7 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
                 undefined, log, next),
             (result, corsHeaders, next) => objectPut(authInfo,
@@ -240,8 +237,7 @@ describe('bucketGet API', () => {
 
         testPutObjectRequest1.objectKey += '&><"\'';
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest1,
                 undefined, log, next),
             (result, corsHeaders, next) => bucketGet(authInfo, testGetRequest,
@@ -265,8 +261,7 @@ describe('bucketGet API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) =>
                 bucketGet(authInfo, testGetRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),

--- a/tests/unit/api/bucketGetACL.js
+++ b/tests/unit/api/bucketGetACL.js
@@ -14,7 +14,6 @@ const authInfo = makeAuthInfo(accessKey);
 const canonicalID = authInfo.getCanonicalID();
 const namespace = 'default';
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 
 describe('bucketGetACL API', () => {
     beforeEach(() => {
@@ -48,8 +47,7 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo,
@@ -82,8 +80,7 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
@@ -127,8 +124,7 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
@@ -166,8 +162,7 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
@@ -206,8 +201,7 @@ describe('bucketGetACL API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,
@@ -266,8 +260,7 @@ describe('bucketGetACL API', () => {
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
 
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) =>
                 bucketPutACL(authInfo, testPutACLRequest, log, next),
             (corsHeaders, next) => bucketGetACL(authInfo, testGetACLRequest,

--- a/tests/unit/api/bucketGetCors.js
+++ b/tests/unit/api/bucketGetCors.js
@@ -12,7 +12,6 @@ from '../helpers';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketGetCorsTestBucket';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
@@ -60,8 +59,7 @@ function _comparePutGetXml(sampleXml, done) {
 describe('getBucketCors API', () => {
     beforeEach(done => {
         cleanup();
-        bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, done);
+        bucketPut(authInfo, testBucketPutRequest, log, done);
     });
     afterEach(() => cleanup());
 

--- a/tests/unit/api/bucketGetLocation.js
+++ b/tests/unit/api/bucketGetLocation.js
@@ -29,6 +29,15 @@ const testGetLocationRequest = {
 
 const locationConstraints = config.locationConstraints;
 
+function getBucketRequestObject(location) {
+    const post = location ? '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${location}</LocationConstraint>` +
+        '</CreateBucketConfiguration>' : undefined;
+    return Object.assign({ post }, testBucketPutRequest);
+}
+
 describe('getBucketLocation API', () => {
     Object.keys(locationConstraints).forEach(location => {
         if (location === 'us-east-1') {
@@ -36,11 +45,11 @@ describe('getBucketLocation API', () => {
             // see next test.
             return;
         }
+        const bucketPutRequest = getBucketRequestObject(location);
         describe(`with ${location} LocationConstraint`, () => {
             beforeEach(done => {
                 cleanup();
-                bucketPut(authInfo, testBucketPutRequest,
-                location, log, done);
+                bucketPut(authInfo, bucketPutRequest, log, done);
             });
             afterEach(() => cleanup());
             it(`should return ${location} LocationConstraint xml`, done => {
@@ -58,10 +67,11 @@ describe('getBucketLocation API', () => {
         });
     });
     [undefined, 'us-east-1'].forEach(location => {
+        const bucketPutRequest = getBucketRequestObject(location);
         describe(`with ${location} LocationConstraint`, () => {
             beforeEach(done => {
                 cleanup();
-                bucketPut(authInfo, testBucketPutRequest, location, log, done);
+                bucketPut(authInfo, bucketPutRequest, log, done);
             });
             afterEach(() => cleanup());
             it('should return empty string LocationConstraint xml', done => {

--- a/tests/unit/api/bucketGetWebsite.js
+++ b/tests/unit/api/bucketGetWebsite.js
@@ -11,7 +11,6 @@ from '../helpers';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketGetWebsiteTestBucket';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
@@ -58,8 +57,7 @@ function _comparePutGetXml(sampleXml, done) {
 describe('getBucketWebsite API', () => {
     beforeEach(done => {
         cleanup();
-        bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, done);
+        bucketPut(authInfo, testBucketPutRequest, log, done);
     });
     afterEach(() => cleanup());
 

--- a/tests/unit/api/bucketHead.js
+++ b/tests/unit/api/bucketHead.js
@@ -9,7 +9,6 @@ const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const namespace = 'default';
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const testRequest = {
     bucketName,
     namespace,
@@ -30,7 +29,7 @@ describe('bucketHead API', () => {
 
     it('should return an error if user is not authorized', done => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(otherAuthInfo, testRequest, locationConstraint, log, () => {
+        bucketPut(otherAuthInfo, testRequest, log, () => {
             bucketHead(authInfo, testRequest, log, err => {
                 assert.deepStrictEqual(err, errors.AccessDenied);
                 done();
@@ -40,7 +39,7 @@ describe('bucketHead API', () => {
 
     it('should return no error if bucket exists and user is authorized',
     done => {
-        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
+        bucketPut(authInfo, testRequest, log, () => {
             bucketHead(authInfo, testRequest, log, err => {
                 assert.strictEqual(err, null);
                 done();

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -14,7 +14,6 @@ const namespace = 'default';
 const splitter = constants.splitter;
 const usersBucket = constants.usersBucket;
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const testRequest = {
     bucketName,
     namespace,
@@ -30,8 +29,8 @@ describe('bucketPut API', () => {
 
     it('should return an error if bucket already exists', done => {
         const otherAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(authInfo, testRequest, locationConstraint, log, () => {
-            bucketPut(otherAuthInfo, testRequest, locationConstraint,
+        bucketPut(authInfo, testRequest, log, () => {
+            bucketPut(otherAuthInfo, testRequest,
                 log, err => {
                     assert.deepStrictEqual(err, errors.BucketAlreadyExists);
                     done();
@@ -40,7 +39,7 @@ describe('bucketPut API', () => {
     });
 
     it('should create a bucket', done => {
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             if (err) {
                 return done(new Error(err));
             }
@@ -72,7 +71,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.deepStrictEqual(err, errors.InvalidArgument);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -93,7 +92,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.deepStrictEqual(err, errors.InvalidArgument);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -115,7 +114,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.deepStrictEqual(err, errors.UnresolvableGrantByEmailAddress);
             metadata.getBucket(bucketName, log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
@@ -137,7 +136,7 @@ describe('bucketPut API', () => {
             url: '/',
             post: '',
         };
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.strictEqual(err, null);
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(err, null);
@@ -173,7 +172,7 @@ describe('bucketPut API', () => {
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
         const canonicalIDforSample2 =
             '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf';
-        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, testRequest, log, err => {
             assert.strictEqual(err, null, 'Error creating bucket');
             metadata.getBucket(bucketName, log, (err, md) => {
                 assert.strictEqual(md.getAcl().READ[0], constants.logId);
@@ -193,7 +192,7 @@ describe('bucketPut API', () => {
 
     it('should prevent anonymous user from accessing putBucket API', done => {
         const publicAuthInfo = makeAuthInfo(constants.publicId);
-        bucketPut(publicAuthInfo, testRequest, locationConstraint, log, err => {
+        bucketPut(publicAuthInfo, testRequest, log, err => {
             assert.deepStrictEqual(err, errors.AccessDenied);
         });
         done();

--- a/tests/unit/api/bucketPutACL.js
+++ b/tests/unit/api/bucketPutACL.js
@@ -13,7 +13,6 @@ const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = {
     bucketName,
     namespace,
@@ -27,8 +26,7 @@ const canonicalIDforSample2 =
 
 describe('putBucketACL API', () => {
     before(() => cleanup());
-    beforeEach(done => bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, done));
+    beforeEach(done => bucketPut(authInfo, testBucketPutRequest, log, done));
     afterEach(() => cleanup());
 
     it('should parse a grantheader', () => {

--- a/tests/unit/api/bucketPutCors.js
+++ b/tests/unit/api/bucketPutCors.js
@@ -14,7 +14,6 @@ import metadata from '../../../lib/metadata/wrapper';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
@@ -44,8 +43,7 @@ function _generateSampleXml(value) {
 describe('putBucketCORS API', () => {
     beforeEach(done => {
         cleanup();
-        bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, done);
+        bucketPut(authInfo, testBucketPutRequest, log, done);
     });
     afterEach(() => cleanup());
 

--- a/tests/unit/api/bucketPutWebsite.js
+++ b/tests/unit/api/bucketPutWebsite.js
@@ -15,7 +15,6 @@ import metadata from '../../../lib/metadata/wrapper';
 const log = new DummyRequestLogger();
 const authInfo = makeAuthInfo('accessKey1');
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = {
     bucketName,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
@@ -37,8 +36,7 @@ function _getPutWebsiteRequest(xml) {
 
 describe('putBucketWebsite API', () => {
     before(() => cleanup());
-    beforeEach(done => bucketPut(authInfo, testBucketPutRequest,
-        locationConstraint, log, done));
+    beforeEach(done => bucketPut(authInfo, testBucketPutRequest, log, done));
     afterEach(() => cleanup());
 
     it('should update a bucket\'s metadata with website config obj', done => {

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -47,6 +47,7 @@ const namespace = 'default';
 const usersBucketName = constants.usersBucket;
 const bucketName = 'bucketname';
 const locationConstraint = 'us-east-1';
+
 const baseTestRequest = {
     bucketName,
     namespace,
@@ -118,7 +119,7 @@ describe('deleted flag bucket handling', () => {
 
     it('putBucket request should recreate bucket with deleted flag if ' +
         'request is from same account that originally put', done => {
-        bucketPut(authInfo, baseTestRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, baseTestRequest, log, err => {
             assert.ifError(err);
             metadata.getBucket(bucketName, log, (err, data) => {
                 assert.strictEqual(data._transient, false);
@@ -132,17 +133,16 @@ describe('deleted flag bucket handling', () => {
     it('putBucket request should return error if ' +
         'different account sends put bucket request for bucket with ' +
         'deleted flag', done => {
-        bucketPut(otherAccountAuthInfo, baseTestRequest, locationConstraint,
-            log, err => {
-                assert.deepStrictEqual(err, errors.BucketAlreadyExists);
-                metadata.getBucket(bucketName, log, (err, data) => {
-                    assert.strictEqual(data._transient, false);
-                    assert.strictEqual(data._deleted, true);
-                    assert.strictEqual(data._owner, authInfo.getCanonicalID());
-                    return checkBucketListing(otherAccountAuthInfo,
-                        bucketName, 0, done);
-                });
+        bucketPut(otherAccountAuthInfo, baseTestRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+            metadata.getBucket(bucketName, log, (err, data) => {
+                assert.strictEqual(data._transient, false);
+                assert.strictEqual(data._deleted, true);
+                assert.strictEqual(data._owner, authInfo.getCanonicalID());
+                return checkBucketListing(otherAccountAuthInfo,
+                    bucketName, 0, done);
             });
+        });
     });
 
     it('ACLs from new putBucket request should overwrite ACLs saved ' +
@@ -150,7 +150,7 @@ describe('deleted flag bucket handling', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-acl': 'public-read' }, 'headers',
             baseTestRequest, baseTestRequest.headers);
-        bucketPut(authInfo, alteredRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, alteredRequest, log, err => {
             assert.ifError(err);
             metadata.getBucket(bucketName, log, (err, data) => {
                 assert.strictEqual(data._transient, false);

--- a/tests/unit/api/listMultipartUploads.js
+++ b/tests/unit/api/listMultipartUploads.js
@@ -14,7 +14,6 @@ const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
-const locationConstraint = 'us-east-1';
 
 describe('listMultipartUploads API', () => {
     beforeEach(() => {
@@ -68,8 +67,7 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 testInitiateMPURequest1, log, next),
             (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
@@ -99,8 +97,7 @@ describe('listMultipartUploads API', () => {
 
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 testInitiateMPURequest1, log, next),
             (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
@@ -132,8 +129,7 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 testInitiateMPURequest1, log, next),
             (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
@@ -169,8 +165,7 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 testInitiateMPURequest1, log, next),
             (result, corsHeaders, next) => initiateMultipartUpload(authInfo,
@@ -202,8 +197,7 @@ describe('listMultipartUploads API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, testPutBucketRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testPutBucketRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 testInitiateMPURequest1, log, next),
             (result, corsHeaders, next) => initiateMultipartUpload(authInfo,

--- a/tests/unit/api/multiObjectDelete.js
+++ b/tests/unit/api/multiObjectDelete.js
@@ -18,7 +18,6 @@ const postBody = Buffer.from('I am a body', 'utf8');
 const contentLength = 2 * postBody.length;
 const objectKey1 = 'objectName1';
 const objectKey2 = 'objectName2';
-const locationConstraint = 'us-east-1';
 const testBucketPutRequest = new DummyRequest({
     bucketName,
     namespace,
@@ -46,22 +45,21 @@ describe('getObjMetadataAndDelete function for multiObjectDelete', () => {
             headers: {},
             url: `/${bucketName}/${objectKey2}`,
         }, postBody);
-        bucketPut(authInfo, testBucketPutRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest1,
-                    undefined, log, () => {
-                        objectPut(authInfo, testPutObjectRequest2,
-                            undefined, log, () => {
-                                assert.strictEqual(metadata.keyMaps
-                                    .get(bucketName)
-                                    .has(objectKey1), true);
-                                assert.strictEqual(metadata.keyMaps
-                                    .get(bucketName)
-                                    .has(objectKey2), true);
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest1,
+                undefined, log, () => {
+                    objectPut(authInfo, testPutObjectRequest2,
+                        undefined, log, () => {
+                            assert.strictEqual(metadata.keyMaps
+                                .get(bucketName)
+                                .has(objectKey1), true);
+                            assert.strictEqual(metadata.keyMaps
+                                .get(bucketName)
+                                .has(objectKey2), true);
+                            done();
+                        });
+                });
+        });
     });
 
     it('should successfully get object metadata and then ' +

--- a/tests/unit/api/multipartDelete.js
+++ b/tests/unit/api/multipartDelete.js
@@ -24,7 +24,6 @@ const bucketPutRequest = {
     namespace,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
-    post: '',
 };
 const objectKey = 'testObject';
 const initiateRequest = {
@@ -41,9 +40,14 @@ function _createAndAbortMpu(usEastSetting, fakeUploadID, locationConstraint,
     callback) {
     config.locationConstraints['us-east-1'].legacyAwsBehavior =
         usEastSetting;
+    const post = '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${locationConstraint}</LocationConstraint>` +
+        '</CreateBucketConfiguration>';
+    const testBucketPutRequest = Object.assign({ post }, bucketPutRequest);
     async.waterfall([
-        next => bucketPut(authInfo, bucketPutRequest, locationConstraint, log,
-            next),
+        next => bucketPut(authInfo, testBucketPutRequest, log, next),
         (corsHeaders, next) =>
             initiateMultipartUpload(authInfo, initiateRequest, log, next),
         (result, corsHeaders, next) => parseString(result, next),

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -30,11 +30,7 @@ const bucketPutRequest = {
     namespace,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
-    post: '<?xml version="1.0" encoding="UTF-8"?>' +
-        '<CreateBucketConfiguration ' +
-        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-        '<LocationConstraint>scality-us-west-1</LocationConstraint>' +
-        '</CreateBucketConfiguration>',
+    post: '',
 };
 const objectKey = 'testObject';
 const initiateRequest = {

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -30,9 +30,12 @@ const bucketPutRequest = {
     namespace,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
-    post: '',
+    post: '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        '<LocationConstraint>scality-us-west-1</LocationConstraint>' +
+        '</CreateBucketConfiguration>',
 };
-const locationConstraint = 'scality-us-west-1';
 const objectKey = 'testObject';
 const initiateRequest = {
     bucketName,
@@ -50,7 +53,7 @@ describe('Multipart Upload API', () => {
 
 
     it('should initiate a multipart upload', done => {
-        bucketPut(authInfo, bucketPutRequest, locationConstraint, log, () => {
+        bucketPut(authInfo, bucketPutRequest, log, () => {
             initiateMultipartUpload(authInfo, initiateRequest,
                 log, (err, result) => {
                     assert.strictEqual(err, null);
@@ -72,8 +75,7 @@ describe('Multipart Upload API', () => {
 
     it('should upload a part', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => {
@@ -138,8 +140,7 @@ describe('Multipart Upload API', () => {
     it('should upload a part even if the client sent a base 64 ETag ' +
     '(and the stored ETag in metadata should be hex)', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -187,8 +188,7 @@ describe('Multipart Upload API', () => {
 
     it('should return an error if too many parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -224,8 +224,7 @@ describe('Multipart Upload API', () => {
 
     it('should return an error if part number is not an integer', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -264,8 +263,7 @@ describe('Multipart Upload API', () => {
         // by setting a large content-length.  It is not actually putting a
         // large file.  Functional tests will test actual large data.
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -305,8 +303,7 @@ describe('Multipart Upload API', () => {
 
     it('should upload two parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -388,8 +385,7 @@ describe('Multipart Upload API', () => {
         initiateRequest.headers['x-amz-meta-stuff'] =
             'I am some user metadata';
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -475,8 +471,7 @@ describe('Multipart Upload API', () => {
             'I am some user metadata';
         async.waterfall([
             function waterfall1(next) {
-                bucketPut(authInfo, bucketPutRequest,
-                    locationConstraint, log, next);
+                bucketPut(authInfo, bucketPutRequest, log, next);
             },
             function waterfall2(corsHeaders, next) {
                 initiateMultipartUpload(
@@ -556,8 +551,7 @@ describe('Multipart Upload API', () => {
     it('should return an error if a complete multipart upload' +
     ' request contains malformed xml', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -609,8 +603,7 @@ describe('Multipart Upload API', () => {
     'multipart upload request contains xml that ' +
     'does not conform to the AWS spec', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -662,8 +655,7 @@ describe('Multipart Upload API', () => {
     'multipart upload request contains xml with ' +
     'a part list that is not in numerical order', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -739,8 +731,7 @@ describe('Multipart Upload API', () => {
     it('should return InvalidPart error if the complete ' +
     'multipart upload request contains xml with a missing part', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -797,8 +788,7 @@ describe('Multipart Upload API', () => {
     + 'contains xml with a part ETag that does not match the md5 for '
     + 'the part that was actually sent', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -871,8 +861,7 @@ describe('Multipart Upload API', () => {
     'other than the last part that is less than 5MB ' +
     'in size', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -953,8 +942,7 @@ describe('Multipart Upload API', () => {
 
     it('should aggregate the sizes of the parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1056,8 +1044,7 @@ describe('Multipart Upload API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1159,8 +1146,7 @@ describe('Multipart Upload API', () => {
         };
 
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1246,8 +1232,7 @@ describe('Multipart Upload API', () => {
 
     it('should abort/delete a multipart upload', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1292,8 +1277,7 @@ describe('Multipart Upload API', () => {
     it('should return no error if attempt to abort/delete ' +
         'a multipart upload that does not exist', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => {
@@ -1344,8 +1328,7 @@ describe('Multipart Upload API', () => {
         const fullSizedPart = crypto.randomBytes(5 * 1024 * 1024);
         const partBody = Buffer.from('I am a part\n', 'utf8');
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, locationConstraint,
-                log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1483,8 +1466,7 @@ describe('Multipart Upload API', () => {
         let uploadId;
 
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest, locationConstraint,
-                log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),
@@ -1558,7 +1540,7 @@ describe('Multipart Upload API', () => {
             },
         }, postBody);
 
-        bucketPut(authInfo, bucketPutRequest, locationConstraint, log, () =>
+        bucketPut(authInfo, bucketPutRequest, log, () =>
           objectPutPart(authInfo, partRequest, undefined, log, err => {
               assert.strictEqual(err, errors.NoSuchUpload);
               done();
@@ -1569,8 +1551,7 @@ describe('Multipart Upload API', () => {
     it('should complete an MPU with fewer parts than were originally ' +
         'put and delete data from left out parts', done => {
         async.waterfall([
-            next => bucketPut(authInfo, bucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,
                 initiateRequest, log, next),
             (result, corsHeaders, next) => parseString(result, next),

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -17,11 +17,10 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = Buffer.from('I am a body', 'utf8');
 const objectKey = 'objectName';
-const locationConstraint = 'us-east-1';
 
 function testAuth(bucketOwner, authUser, bucketPutReq, objPutReq, objDelReq,
     log, cb) {
-    bucketPut(bucketOwner, bucketPutReq, locationConstraint, log, () => {
+    bucketPut(bucketOwner, bucketPutReq, log, () => {
         bucketPutACL(bucketOwner, bucketPutReq, log, err => {
             assert.strictEqual(err, undefined);
             objectPut(bucketOwner, objPutReq, undefined, log, err => {
@@ -75,21 +74,20 @@ describe('objectDelete API', () => {
     });
 
     it('should delete an object', done => {
-        bucketPut(authInfo, testBucketPutRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest,
-                    undefined, log, () => {
-                        objectDelete(authInfo, testDeleteRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            objectGet(authInfo, testGetObjectRequest,
-                                log, err => {
-                                    assert.deepStrictEqual(err,
-                                        errors.NoSuchKey);
-                                    done();
-                                });
-                        });
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest,
+                undefined, log, () => {
+                    objectDelete(authInfo, testDeleteRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        objectGet(authInfo, testGetObjectRequest,
+                            log, err => {
+                                assert.deepStrictEqual(err,
+                                    errors.NoSuchKey);
+                                done();
+                            });
                     });
-            });
+                });
+        });
     });
 
     it('should delete a 0 bytes object', done => {
@@ -100,23 +98,22 @@ describe('objectDelete API', () => {
             headers: {},
             url: `/${bucketName}/${objectKey}`,
         }, '');
-        bucketPut(authInfo, testBucketPutRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest,
-                    undefined, log, () => {
-                        objectDelete(authInfo, testDeleteRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            objectGet(authInfo, testGetObjectRequest,
-                                log, err => {
-                                    const expected =
-                                    Object.assign({}, errors.NoSuchKey);
-                                    const received = Object.assign({}, err);
-                                    assert.deepStrictEqual(received, expected);
-                                    done();
-                                });
-                        });
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest,
+                undefined, log, () => {
+                    objectDelete(authInfo, testDeleteRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        objectGet(authInfo, testGetObjectRequest,
+                            log, err => {
+                                const expected =
+                                Object.assign({}, errors.NoSuchKey);
+                                const received = Object.assign({}, err);
+                                assert.deepStrictEqual(received, expected);
+                                done();
+                            });
                     });
-            });
+                });
+        });
     });
 
     it('should prevent anonymous user deleteObject API access', done => {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -19,7 +19,6 @@ const namespace = 'default';
 const bucketName = 'bucketname';
 const objectName = 'objectName';
 const postBody = Buffer.from('I am a body', 'utf8');
-const locationConstraint = 'us-east-1';
 
 describe('objectGet API', () => {
     let testPutObjectRequest;
@@ -57,43 +56,41 @@ describe('objectGet API', () => {
     };
 
     it('should get the object metadata', done => {
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined,
-                    log, (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectGet(authInfo, testGetRequest,
-                            log, (err, result, responseMetaHeaders) => {
-                                assert.strictEqual(responseMetaHeaders
-                                    [userMetadataKey],
-                                    userMetadataValue);
-                                assert.strictEqual(responseMetaHeaders.ETag,
-                                    `"${correctMD5}"`);
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined,
+                log, (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectGet(authInfo, testGetRequest,
+                        log, (err, result, responseMetaHeaders) => {
+                            assert.strictEqual(responseMetaHeaders
+                                [userMetadataKey],
+                                userMetadataValue);
+                            assert.strictEqual(responseMetaHeaders.ETag,
+                                `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
     });
 
     it('should get the object data retrieval info', done => {
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectGet(authInfo, testGetRequest, log,
-                            (err, dataGetInfo) => {
-                                assert.deepStrictEqual(dataGetInfo,
-                            [{
-                                key: 1,
-                                start: 0,
-                                size: 12,
-                                dataStoreName: 'dataMem',
-                            }]);
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectGet(authInfo, testGetRequest, log,
+                        (err, dataGetInfo) => {
+                            assert.deepStrictEqual(dataGetInfo,
+                        [{
+                            key: 1,
+                            start: 0,
+                            size: 12,
+                            dataStoreName: 'dataMem',
+                        }]);
+                            done();
+                        });
+                });
+        });
     });
 
     it('should get the object data retrieval info for an object put by MPU',
@@ -107,8 +104,7 @@ describe('objectGet API', () => {
                 url: `/${objectName}?uploads`,
             };
             async.waterfall([
-                next => bucketPut(authInfo, testPutBucketRequest,
-                    locationConstraint, log, next),
+                next => bucketPut(authInfo, testPutBucketRequest, log, next),
                 (corsHeaders, next) => initiateMultipartUpload(authInfo,
                     initiateRequest, log, next),
                 (result, corsHeaders, next) => parseString(result, next),
@@ -222,21 +218,20 @@ describe('objectGet API', () => {
             url: `/${bucketName}/${objectName}`,
             calculatedHash: 'd41d8cd98f00b204e9800998ecf8427e',
         }, postBody);
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectGet(authInfo, testGetRequest,
-                        log, (err, result, responseMetaHeaders) => {
-                            assert.strictEqual(result, null);
-                            assert.strictEqual(responseMetaHeaders
-                                [userMetadataKey], userMetadataValue);
-                            assert.strictEqual(responseMetaHeaders.ETag,
-                                `"${correctMD5}"`);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectGet(authInfo, testGetRequest,
+                    log, (err, result, responseMetaHeaders) => {
+                        assert.strictEqual(result, null);
+                        assert.strictEqual(responseMetaHeaders
+                            [userMetadataKey], userMetadataValue);
+                        assert.strictEqual(responseMetaHeaders.ETag,
+                            `"${correctMD5}"`);
+                        done();
                     });
-            });
+                });
+        });
     });
 });

--- a/tests/unit/api/objectGetACL.js
+++ b/tests/unit/api/objectGetACL.js
@@ -21,7 +21,6 @@ const otherAccountCanonicalID = otherAccountAuthInfo.getCanonicalID();
 const namespace = 'default';
 const bucketName = 'bucketname';
 const postBody = Buffer.from('I am a body', 'utf8');
-const locationConstraint = 'us-east-1';
 
 describe('objectGetACL API', () => {
     beforeEach(() => {
@@ -58,8 +57,7 @@ describe('objectGetACL API', () => {
             post: postBody,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {
@@ -81,13 +79,12 @@ describe('objectGetACL API', () => {
 
     it('should return an error if try to get an ACL ' +
         'for a nonexistent object', done => {
-        bucketPut(authInfo, testBucketPutRequest,
-            locationConstraint, log, () => {
-                objectGetACL(authInfo, testGetACLRequest, log, err => {
-                    assert.deepStrictEqual(err, errors.NoSuchKey);
-                    done();
-                });
+        bucketPut(authInfo, testBucketPutRequest, log, () => {
+            objectGetACL(authInfo, testGetACLRequest, log, err => {
+                assert.deepStrictEqual(err, errors.NoSuchKey);
+                done();
             });
+        });
     });
 
     it('should get a canned public-read ACL', done => {
@@ -99,8 +96,7 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {
@@ -136,8 +132,7 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {
@@ -180,8 +175,7 @@ describe('objectGetACL API', () => {
             url: `/${bucketName}/${objectName}`,
         }, postBody);
         async.waterfall([
-            next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+            next => bucketPut(authInfo, testBucketPutRequest, log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {
@@ -222,7 +216,7 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next =>
                 bucketPut(otherAccountAuthInfo, testBucketPutRequest,
-                    locationConstraint, log, next),
+                    log, next),
             (corsHeaders, next) => objectPut(
                 authInfo, testPutObjectRequest, undefined, log, next),
             (result, corsHeaders, next) => {
@@ -262,7 +256,7 @@ describe('objectGetACL API', () => {
         async.waterfall([
             next =>
                 bucketPut(otherAccountAuthInfo, testBucketPutRequest,
-                    locationConstraint, log, next),
+                    log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {
@@ -312,7 +306,7 @@ describe('objectGetACL API', () => {
         }, postBody);
         async.waterfall([
             next => bucketPut(authInfo, testBucketPutRequest,
-                locationConstraint, log, next),
+                log, next),
             (corsHeaders, next) => objectPut(authInfo, testPutObjectRequest,
                 undefined, log, next),
             (result, corsHeaders, next) => {

--- a/tests/unit/api/objectHead.js
+++ b/tests/unit/api/objectHead.js
@@ -27,7 +27,6 @@ const testPutBucketRequest = {
 };
 const userMetadataKey = 'x-amz-meta-test';
 const userMetadataValue = 'some metadata';
-const locationConstraint = 'us-east-1';
 
 let testPutObjectRequest;
 
@@ -55,17 +54,16 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectHead(authInfo, testGetRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.NotModified);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectHead(authInfo, testGetRequest, log, err => {
+                        assert.deepStrictEqual(err, errors.NotModified);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return PreconditionFailed if request header ' +
@@ -78,18 +76,17 @@ describe('objectHead API', () => {
             headers: { 'if-unmodified-since': earlierDate },
             url: `/${bucketName}/${objectName}`,
         };
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectHead(authInfo, testGetRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                errors.PreconditionFailed);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectHead(authInfo, testGetRequest, log, err => {
+                        assert.deepStrictEqual(err,
+                            errors.PreconditionFailed);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return PreconditionFailed if request header ' +
@@ -103,18 +100,17 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectHead(authInfo, testGetRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                errors.PreconditionFailed);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectHead(authInfo, testGetRequest, log, err => {
+                        assert.deepStrictEqual(err,
+                            errors.PreconditionFailed);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return NotModified if request header ' +
@@ -128,17 +124,16 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectHead(authInfo, testGetRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.NotModified);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectHead(authInfo, testGetRequest, log, err => {
+                        assert.deepStrictEqual(err, errors.NotModified);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should get the object metadata', done => {
@@ -150,20 +145,19 @@ describe('objectHead API', () => {
             url: `/${bucketName}/${objectName}`,
         };
 
-        bucketPut(authInfo, testPutBucketRequest,
-            locationConstraint, log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectHead(authInfo, testGetRequest, log,
-                            (err, success) => {
-                                assert.strictEqual(success[userMetadataKey],
-                        userMetadataValue);
-                                assert
-                                .strictEqual(success.ETag, `"${correctMD5}"`);
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectHead(authInfo, testGetRequest, log,
+                        (err, success) => {
+                            assert.strictEqual(success[userMetadataKey],
+                    userMetadataValue);
+                            assert
+                            .strictEqual(success.ETag, `"${correctMD5}"`);
+                            done();
+                        });
+                });
+        });
     });
 });

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -22,14 +22,13 @@ const testPutBucketRequest = new DummyRequest({
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
 });
-const locationConstraint = 'us-east-1';
 
 const objectName = 'objectName';
 
 let testPutObjectRequest;
 
 function testAuth(bucketOwner, authUser, bucketPutReq, log, cb) {
-    bucketPut(bucketOwner, bucketPutReq, locationConstraint, log, () => {
+    bucketPut(bucketOwner, bucketPutReq, log, () => {
         bucketPutACL(bucketOwner, testPutBucketRequest, log, err => {
             assert.strictEqual(err, undefined);
             objectPut(authUser, testPutObjectRequest, undefined,
@@ -63,7 +62,7 @@ describe('objectPut API', () => {
 
     it('should return an error if user is not authorized', done => {
         const putAuthInfo = makeAuthInfo('accessKey2');
-        bucketPut(putAuthInfo, testPutBucketRequest, locationConstraint,
+        bucketPut(putAuthInfo, testPutBucketRequest,
             log, () => {
                 objectPut(authInfo, testPutObjectRequest,
                     undefined, log, err => {
@@ -108,20 +107,19 @@ describe('objectPut API', () => {
             calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        metadata.getObjectMD(bucketName, objectName,
-                            {}, log, (err, md) => {
-                                assert(md);
-                                assert
-                                .strictEqual(md['content-md5'], correctMD5);
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    metadata.getObjectMD(bucketName, objectName,
+                        {}, log, (err, md) => {
+                            assert(md);
+                            assert
+                            .strictEqual(md['content-md5'], correctMD5);
+                            done();
+                        });
+                });
+        });
     });
 
     it('should successfully put an object with user metadata', done => {
@@ -143,24 +141,23 @@ describe('objectPut API', () => {
             calculatedHash: 'vnR+tLdVF79rPPfF+7YvOg==',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        metadata.getObjectMD(bucketName, objectName, {}, log,
-                            (err, md) => {
-                                assert(md);
-                                assert.strictEqual(md['x-amz-meta-test'],
-                                'some metadata');
-                                assert.strictEqual(md['x-amz-meta-test2'],
-                                           'some more metadata');
-                                assert.strictEqual(md['x-amz-meta-test3'],
-                                           'even more metadata');
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    metadata.getObjectMD(bucketName, objectName, {}, log,
+                        (err, md) => {
+                            assert(md);
+                            assert.strictEqual(md['x-amz-meta-test'],
+                            'some metadata');
+                            assert.strictEqual(md['x-amz-meta-test2'],
+                                       'some more metadata');
+                            assert.strictEqual(md['x-amz-meta-test3'],
+                                       'even more metadata');
+                            done();
+                        });
+                });
+        });
     });
 
     it('should put an object with user metadata but no data', done => {
@@ -181,26 +178,25 @@ describe('objectPut API', () => {
             calculatedHash: 'd41d8cd98f00b204e9800998ecf8427e',
         }, postBody);
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        assert.deepStrictEqual(ds, []);
-                        metadata.getObjectMD(bucketName, objectName, {}, log,
-                            (err, md) => {
-                                assert(md);
-                                assert.strictEqual(md.location, null);
-                                assert.strictEqual(md['x-amz-meta-test'],
-                                'some metadata');
-                                assert.strictEqual(md['x-amz-meta-test2'],
-                                           'some more metadata');
-                                assert.strictEqual(md['x-amz-meta-test3'],
-                                           'even more metadata');
-                                done();
-                            });
-                    });
-            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    assert.deepStrictEqual(ds, []);
+                    metadata.getObjectMD(bucketName, objectName, {}, log,
+                        (err, md) => {
+                            assert(md);
+                            assert.strictEqual(md.location, null);
+                            assert.strictEqual(md['x-amz-meta-test'],
+                            'some metadata');
+                            assert.strictEqual(md['x-amz-meta-test2'],
+                                       'some more metadata');
+                            assert.strictEqual(md['x-amz-meta-test3'],
+                                       'even more metadata');
+                            done();
+                        });
+                });
+        });
     });
 
     it('should not leave orphans in data when overwriting an object', done => {
@@ -212,26 +208,25 @@ describe('objectPut API', () => {
             url: `/${bucketName}/${objectName}`,
         }, Buffer.from('I am another body', 'utf8'));
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest,
-                    undefined, log, () => {
-                        objectPut(authInfo, testPutObjectRequest2, undefined,
-                            log,
-                        () => {
-                            // orphan objects don't get deleted
-                            // until the next tick
-                            // in memory
-                            process.nextTick(() => {
-                                // Data store starts at index 1
-                                assert.strictEqual(ds[0], undefined);
-                                assert.strictEqual(ds[1], undefined);
-                                assert.deepStrictEqual(ds[2].value,
-                                    Buffer.from('I am another body', 'utf8'));
-                                done();
-                            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest,
+                undefined, log, () => {
+                    objectPut(authInfo, testPutObjectRequest2, undefined,
+                        log,
+                    () => {
+                        // orphan objects don't get deleted
+                        // until the next tick
+                        // in memory
+                        process.nextTick(() => {
+                            // Data store starts at index 1
+                            assert.strictEqual(ds[0], undefined);
+                            assert.strictEqual(ds[1], undefined);
+                            assert.deepStrictEqual(ds[2].value,
+                                Buffer.from('I am another body', 'utf8'));
+                            done();
                         });
                     });
-            });
+                });
+        });
     });
 });

--- a/tests/unit/api/objectPutACL.js
+++ b/tests/unit/api/objectPutACL.js
@@ -34,7 +34,6 @@ const testPutBucketRequest = new DummyRequest({
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
 });
-const locationConstraint = 'us-east-1';
 let testPutObjectRequest;
 
 describe('putObjectACL API', () => {
@@ -59,18 +58,17 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert
-                                .deepStrictEqual(err, errors.InvalidArgument);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert
+                            .deepStrictEqual(err, errors.InvalidArgument);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should set a canned public-read-write ACL', done => {
@@ -83,22 +81,21 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, {},
-                            log, (err, md) => {
-                                assert.strictEqual(md.acl.Canned,
-                                'public-read-write');
-                                done();
-                            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        metadata.getObjectMD(bucketName, objectName, {},
+                        log, (err, md) => {
+                            assert.strictEqual(md.acl.Canned,
+                            'public-read-write');
+                            done();
                         });
                     });
-            });
+                });
+        });
     });
 
     it('should set a canned public-read ACL followed by'
@@ -121,32 +118,31 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest1, log, err => {
-                            assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, {},
-                            log, (err, md) => {
-                                assert.strictEqual(md.acl.Canned,
-                                'public-read');
-                                objectPutACL(authInfo, testObjACLRequest2, log,
-                                    err => {
-                                        assert.strictEqual(err, null);
-                                        metadata.getObjectMD(bucketName,
-                                            objectName, {}, log, (err, md) => {
-                                                assert.strictEqual(md
-                                                       .acl.Canned,
-                                                       'authenticated-read');
-                                                done();
-                                            });
-                                    });
-                            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest1, log, err => {
+                        assert.strictEqual(err, null);
+                        metadata.getObjectMD(bucketName, objectName, {},
+                        log, (err, md) => {
+                            assert.strictEqual(md.acl.Canned,
+                            'public-read');
+                            objectPutACL(authInfo, testObjACLRequest2, log,
+                                err => {
+                                    assert.strictEqual(err, null);
+                                    metadata.getObjectMD(bucketName,
+                                        objectName, {}, log, (err, md) => {
+                                            assert.strictEqual(md
+                                                   .acl.Canned,
+                                                   'authenticated-read');
+                                            done();
+                                        });
+                                });
                         });
                     });
-            });
+                });
+        });
     });
 
     it('should set ACLs provided in request headers', done => {
@@ -165,32 +161,31 @@ describe('putObjectACL API', () => {
             url: `/${bucketName}/${objectName}?acl`,
             query: { acl: '' },
         };
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        metadata.getObjectMD(bucketName, objectName, {},
+                        log, (err, md) => {
                             assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, {},
-                            log, (err, md) => {
-                                assert.strictEqual(err, null);
-                                const acls = md.acl;
-                                assert.strictEqual(acls.READ[0],
-                                    constants.logId);
-                                assert(acls.FULL_CONTROL[0]
-                                   .indexOf(ownerID) > -1);
-                                assert(acls.FULL_CONTROL[1]
-                                   .indexOf(anotherID) > -1);
-                                assert(acls.READ_ACP[0]
-                                    .indexOf(ownerID) > -1);
-                                assert(acls.WRITE_ACP[0]
-                                    .indexOf(anotherID) > -1);
-                                done();
-                            });
+                            const acls = md.acl;
+                            assert.strictEqual(acls.READ[0],
+                                constants.logId);
+                            assert(acls.FULL_CONTROL[0]
+                               .indexOf(ownerID) > -1);
+                            assert(acls.FULL_CONTROL[1]
+                               .indexOf(anotherID) > -1);
+                            assert(acls.READ_ACP[0]
+                                .indexOf(ownerID) > -1);
+                            assert(acls.WRITE_ACP[0]
+                                .indexOf(anotherID) > -1);
+                            done();
                         });
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if invalid email ' +
@@ -208,18 +203,17 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err,
-                                errors.UnresolvableGrantByEmailAddress);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err,
+                            errors.UnresolvableGrantByEmailAddress);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should set ACLs provided in request body', done => {
@@ -240,28 +234,27 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined,
-                    log, (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, {},
-                            log, (err, md) => {
-                                assert.strictEqual(md
-                                    .acl.FULL_CONTROL[0], ownerID);
-                                assert.strictEqual(md
-                                    .acl.READ[0], constants.publicId);
-                                assert.strictEqual(md
-                                    .acl.WRITE_ACP[0], ownerID);
-                                assert.strictEqual(md
-                                    .acl.READ_ACP[0], anotherID);
-                                done();
-                            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined,
+                log, (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        metadata.getObjectMD(bucketName, objectName, {},
+                        log, (err, md) => {
+                            assert.strictEqual(md
+                                .acl.FULL_CONTROL[0], ownerID);
+                            assert.strictEqual(md
+                                .acl.READ[0], constants.publicId);
+                            assert.strictEqual(md
+                                .acl.WRITE_ACP[0], ownerID);
+                            assert.strictEqual(md
+                                .acl.READ_ACP[0], anotherID);
+                            done();
                         });
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if wrong owner ID ' +
@@ -277,17 +270,16 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    () => {
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                errors.AccessDenied);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                () => {
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.deepStrictEqual(err,
+                            errors.AccessDenied);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should ignore if WRITE ACL permission is ' +
@@ -306,29 +298,28 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err, null);
-                            metadata.getObjectMD(bucketName, objectName, {},
-                            log, (err, md) => {
-                                assert.strictEqual(md.acl.Canned, '');
-                                assert.strictEqual(md.acl.FULL_CONTROL[0],
-                                    ownerID);
-                                assert.strictEqual(md.acl.WRITE, undefined);
-                                assert.strictEqual(md.acl.READ[0], undefined);
-                                assert.strictEqual(md.acl.WRITE_ACP[0],
-                                    undefined);
-                                assert.strictEqual(md.acl.READ_ACP[0],
-                                    undefined);
-                                done();
-                            });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err, null);
+                        metadata.getObjectMD(bucketName, objectName, {},
+                        log, (err, md) => {
+                            assert.strictEqual(md.acl.Canned, '');
+                            assert.strictEqual(md.acl.FULL_CONTROL[0],
+                                ownerID);
+                            assert.strictEqual(md.acl.WRITE, undefined);
+                            assert.strictEqual(md.acl.READ[0], undefined);
+                            assert.strictEqual(md.acl.WRITE_ACP[0],
+                                undefined);
+                            assert.strictEqual(md.acl.READ_ACP[0],
+                                undefined);
+                            done();
                         });
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if invalid email ' +
@@ -346,18 +337,17 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.strictEqual(err,
-                                errors.UnresolvableGrantByEmailAddress);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.strictEqual(err,
+                            errors.UnresolvableGrantByEmailAddress);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if xml provided does not match s3 ' +
@@ -377,18 +367,17 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.deepStrictEqual(err,
-                                errors.MalformedACLError);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.deepStrictEqual(err,
+                            errors.MalformedACLError);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if malformed xml provided', done => {
@@ -407,17 +396,16 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.MalformedXML);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.deepStrictEqual(err, errors.MalformedXML);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if invalid group ' +
@@ -436,17 +424,16 @@ describe('putObjectACL API', () => {
         };
 
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.InvalidArgument);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.deepStrictEqual(err, errors.InvalidArgument);
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('should return an error if invalid group uri ' +
@@ -465,16 +452,15 @@ describe('putObjectACL API', () => {
             query: { acl: '' },
         };
 
-        bucketPut(authInfo, testPutBucketRequest, locationConstraint,
-            log, () => {
-                objectPut(authInfo, testPutObjectRequest, undefined, log,
-                    (err, result) => {
-                        assert.strictEqual(result, correctMD5);
-                        objectPutACL(authInfo, testObjACLRequest, log, err => {
-                            assert.deepStrictEqual(err, errors.InvalidArgument);
-                            done();
-                        });
+        bucketPut(authInfo, testPutBucketRequest, log, () => {
+            objectPut(authInfo, testPutObjectRequest, undefined, log,
+                (err, result) => {
+                    assert.strictEqual(result, correctMD5);
+                    objectPutACL(authInfo, testObjACLRequest, log, err => {
+                        assert.deepStrictEqual(err, errors.InvalidArgument);
+                        done();
                     });
-            });
+                });
+        });
     });
 });

--- a/tests/unit/api/serviceGet.js
+++ b/tests/unit/api/serviceGet.js
@@ -14,7 +14,6 @@ const namespace = 'default';
 const bucketName1 = 'bucketname1';
 const bucketName2 = 'bucketname2';
 const bucketName3 = 'bucketname3';
-const locationConstraint = 'us-east-1';
 
 describe('serviceGet API', () => {
     beforeEach(() => {
@@ -48,16 +47,13 @@ describe('serviceGet API', () => {
         };
         async.waterfall([
             function waterfall1(next) {
-                bucketPut(authInfo, testbucketPutRequest1, locationConstraint,
-                    log, next);
+                bucketPut(authInfo, testbucketPutRequest1, log, next);
             },
             function waterfall2(corsHeaders, next) {
-                bucketPut(authInfo, testbucketPutRequest2, locationConstraint,
-                    log, next);
+                bucketPut(authInfo, testbucketPutRequest2, log, next);
             },
             function waterfall3(corsHeaders, next) {
-                bucketPut(authInfo, testbucketPutRequest3, locationConstraint,
-                    log, next);
+                bucketPut(authInfo, testbucketPutRequest3, log, next);
             },
             function waterfall4(corsHeaders, next) {
                 serviceGet(authInfo, serviceGetRequest, log, next);

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -83,7 +83,7 @@ describe('transient bucket handling', () => {
 
     it('putBucket request should complete creation of transient bucket if ' +
         'request is from same account that originally put', done => {
-        bucketPut(authInfo, baseTestRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, baseTestRequest, log, err => {
             assert.ifError(err);
             serviceGet(authInfo, serviceGetRequest, log, (err, data) => {
                 parseString(data, (err, result) => {
@@ -99,18 +99,17 @@ describe('transient bucket handling', () => {
 
     it('putBucket request should return error if ' +
         'transient bucket created by different account', done => {
-        bucketPut(otherAccountAuthInfo, baseTestRequest, locationConstraint,
-            log, err => {
-                assert.deepStrictEqual(err, errors.BucketAlreadyExists);
-                serviceGet(otherAccountAuthInfo, serviceGetRequest,
-                    log, (err, data) => {
-                        parseString(data, (err, result) => {
-                            assert.strictEqual(result.ListAllMyBucketsResult
-                            .Buckets[0], '');
-                            done();
-                        });
+        bucketPut(otherAccountAuthInfo, baseTestRequest, log, err => {
+            assert.deepStrictEqual(err, errors.BucketAlreadyExists);
+            serviceGet(otherAccountAuthInfo, serviceGetRequest,
+                log, (err, data) => {
+                    parseString(data, (err, result) => {
+                        assert.strictEqual(result.ListAllMyBucketsResult
+                        .Buckets[0], '');
+                        done();
                     });
-            });
+                });
+        });
     });
 
     it('ACLs from clean up putBucket request should overwrite ACLs from ' +
@@ -118,7 +117,7 @@ describe('transient bucket handling', () => {
         const alteredRequest = createAlteredRequest({
             'x-amz-acl': 'public-read' }, 'headers',
             baseTestRequest, baseTestRequest.headers);
-        bucketPut(authInfo, alteredRequest, locationConstraint, log, err => {
+        bucketPut(authInfo, alteredRequest, log, err => {
             assert.ifError(err);
             metadata.getBucket(bucketName, log, (err, data) => {
                 assert.strictEqual(data._transient, false);


### PR DESCRIPTION
Add a listener for the 'checkContinue' event. 

Send a `HTTP/1.1 100 Continue` message to the client if requester is

- from a public user
- request is V4 streaming authentication
- when a V2/V4(non-streaming) request is authenticated by Arsenal.

Fix #510