### PR TITLE
FIX: Limit bucket deletion blocking for mpu

### DIFF
--- a/lib/api/apiUtils/bucket/bucketDeletion.js
+++ b/lib/api/apiUtils/bucket/bucketDeletion.js
@@ -129,8 +129,11 @@ export function deleteBucket(bucketMD, bucketName, canonicalID, log, cb) {
         // delete a bucket even if there are ongoing multipart uploads.
         function deleteMPUbucketStep(next) {
             const MPUBucketName = `${constants.mpuBucketPrefix}${bucketName}`;
+            // check to see if there are any mpu overview objects (so ignore
+            // any orphaned part objects)
             return metadata.listObject(MPUBucketName,
-                { maxKeys: 1 }, log, (err, objectsListRes) => {
+                { maxKeys: 1, prefix: 'overview' }, log,
+                (err, objectsListRes) => {
                     // If no shadow bucket ever created, no ongoing MPU's, so
                     // continue with deletion
                     if (err && err.NoSuchBucket) {

--- a/tests/unit/api/bucketDelete.js
+++ b/tests/unit/api/bucketDelete.js
@@ -1,11 +1,18 @@
 import { errors } from 'arsenal';
 import assert from 'assert';
+import crypto from 'crypto';
+
+import async from 'async';
+import { parseString } from 'xml2js';
 
 import bucketDelete from '../../../lib/api/bucketDelete';
 import bucketPut from '../../../lib/api/bucketPut';
 import constants from '../../../constants';
+import initiateMultipartUpload from '../../../lib/api/initiateMultipartUpload';
 import metadata from '../metadataswitch';
+import * as metadataMem from '../../../lib/metadata/in_memory/metadata';
 import objectPut from '../../../lib/api/objectPut';
+import objectPutPart from '../../../lib/api/objectPutPart';
 import { cleanup, DummyRequestLogger, makeAuthInfo } from '../helpers';
 import DummyRequest from '../DummyRequest';
 
@@ -30,8 +37,16 @@ describe('bucketDelete API', () => {
         url: `/${bucketName}`,
     };
 
+    const objectName = 'objectName';
+    const initiateRequest = {
+        bucketName,
+        namespace,
+        objectKey: objectName,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: `/${objectName}?uploads`,
+    };
+
     it('should return an error if the bucket is not empty', done => {
-        const objectName = 'objectName';
         const testPutObjectRequest = new DummyRequest({
             bucketName,
             headers: {},
@@ -56,6 +71,68 @@ describe('bucketDelete API', () => {
                                 done();
                             });
                     });
+                });
+            });
+        });
+    });
+
+    it('should return an error if the bucket has an initiated mpu', done => {
+        bucketPut(authInfo, testRequest, locationConstraint, log, err => {
+            assert.strictEqual(err, null);
+            initiateMultipartUpload(authInfo, initiateRequest, log, err => {
+                assert.strictEqual(err, null);
+                bucketDelete(authInfo, testRequest, log, err => {
+                    assert.deepStrictEqual(err, errors.MPUinProgress);
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should delete a bucket if only part object (and no overview ' +
+        'objects) is in mpu shadow bucket', done => {
+        const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
+        const postBody = Buffer.from('I am a body', 'utf8');
+        async.waterfall([
+            next => bucketPut(authInfo, testRequest,
+                locationConstraint, log, next),
+            (corsHeaders, next) => initiateMultipartUpload(authInfo,
+                initiateRequest, log, next),
+            (result, corsHeaders, next) => {
+                parseString(result, next);
+            },
+        ],
+        (err, json) => {
+            const testUploadId = json.InitiateMultipartUploadResult.UploadId[0];
+            const md5Hash = crypto.createHash('md5');
+            const bufferBody = Buffer.from(postBody);
+            md5Hash.update(bufferBody);
+            const calculatedHash = md5Hash.digest('hex');
+            const partRequest = new DummyRequest({
+                bucketName,
+                objectKey: objectName,
+                namespace,
+                url: `/${objectName}?partNumber=1&uploadId=${testUploadId}`,
+                headers: { host: `${bucketName}.s3.amazonaws.com` },
+                query: {
+                    partNumber: '1',
+                    uploadId: testUploadId,
+                },
+                calculatedHash,
+            }, postBody);
+            objectPutPart(authInfo, partRequest, undefined, log, err => {
+                assert.strictEqual(err, null);
+                const mpuBucketKeyMap =
+                    metadataMem.metadata.keyMaps.get(mpuBucket);
+                assert.strictEqual(mpuBucketKeyMap.size, 2);
+                const overviewKey = `overview${constants.splitter}` +
+                    `${objectName}${constants.splitter}${testUploadId}`;
+                // remove overview key from in mem mpu bucket
+                mpuBucketKeyMap.delete(overviewKey);
+                assert.strictEqual(mpuBucketKeyMap.size, 1);
+                bucketDelete(authInfo, testRequest, log, err => {
+                    assert.strictEqual(err, null);
+                    done();
                 });
             });
         });


### PR DESCRIPTION
Only block the deletion of a bucket if there is an
overview object in the mpu shadow bucket. If there are
orphan part objects, proceed with the deletion.