### PR TITLE
DEV: Use fog-aws metagem

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ dependencies:
     - wget http://launchpadlibrarian.net/222422124/s3cmd_1.6.0-2_all.deb
     - sudo dpkg -i s3cmd*.deb
     # fog and ruby testing dependencies
-    - gem install fog
+    - gem install fog-aws
     - gem install mime-types
     - gem install rspec
     - gem install json

--- a/tests/functional/fog/tests.rb
+++ b/tests/functional/fog/tests.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/aws"
 require "digest/md5"
 require "json"
 require "securerandom"


### PR DESCRIPTION
Prevent wait in CircleCI that causes a timeout
```
[...]
fog's executable "fog" conflicts with fog-digitalocean
Overwrite the executable? [yN]  
command gem install fog took more than 10 minutes since last output
```

Currently all fog providers are getting separated into metagems to lower the load time and dependency count. Thus we should be using `fog-aws` instead of requiring the full fog collection to avoid unnecessary dependencies. (See Dependency Notice section of https://github.com/fog/fog.)