### PR TITLE
FT: Push user-level utapi metrics

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -182,20 +182,21 @@ export function listMetrics(metricType) {
  * @return {function} - `utapi.pushMetric`
  */
 export function pushMetric(action, log, metricObj) {
-    let accountId = undefined;
-    // If `authInfo` is included by the API, get the account's canonical ID for
-    // account-level metrics.
-    if (metricObj.authInfo) {
-        accountId = metricObj.authInfo.getCanonicalID();
-    }
-    const { bucket, byteLength, newByteLength, oldByteLength,
-        numberOfObjects } = metricObj;
-    return utapi.pushMetric(action, log.getSerializedUids(), {
+    const { bucket, byteLength, newByteLength, oldByteLength, numberOfObjects,
+        authInfo } = metricObj;
+    const utapiObj = {
         bucket,
-        accountId,
         byteLength,
         newByteLength,
         oldByteLength,
         numberOfObjects,
-    });
+    };
+    // If `authInfo` is included by the API, get the account's canonical ID for
+    // account-level metrics and the shortId for user-level metrics.
+    if (authInfo) {
+        utapiObj.accountId = authInfo.getCanonicalID();
+        utapiObj.userId = authInfo.isRequesterAnIAMUser() ?
+            authInfo.getShortid() : undefined;
+    }
+    return utapi.pushMetric(action, log.getSerializedUids(), utapiObj);
 }


### PR DESCRIPTION
If a user is performing an action, include the userId in the object to track user-level metrics.