### PR TITLE
S3C-35 Refactoring of bucketfile

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,5 +36,9 @@
     },
     "healthChecks": {
         "allowFrom": ["127.0.0.1/8", "::1"]
+    },
+    "metadataDaemon": {
+        "host": "localhost",
+        "port": 9990
     }
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -269,6 +269,20 @@ class Config {
             }
         }
 
+        if (config.metadataDaemon) {
+            this.metadataDaemon = {};
+            assert.strictEqual(
+                typeof config.metadataDaemon.host, 'string',
+                'bad config: metadata daemon host must be a string');
+            this.metadataDaemon.host = config.metadataDaemon.host;
+
+            assert(Number.isInteger(config.metadataDaemon.port)
+                   && config.metadataDaemon.port > 0,
+                   'bad config: metadata daemon port must be a ' +
+                   'positive integer');
+            this.metadataDaemon.port = config.metadataDaemon.port;
+        }
+
         if (process.env.ENABLE_LOCAL_CACHE) {
             this.localCache = defaultLocalCache;
         }

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -1,12 +1,5 @@
-import net from 'net';
-import fs from 'fs';
 import cluster from 'cluster';
-import events from 'events';
-import assert from 'assert';
 
-import level from 'level';
-import multilevel from 'multilevel';
-import sublevel from 'level-sublevel';
 import arsenal from 'arsenal';
 
 import { logger } from '../../utilities/logger';
@@ -15,12 +8,8 @@ import constants from '../../../constants';
 import config from '../../Config';
 
 const errors = arsenal.errors;
+const MetadataClient = arsenal.storage.metadata.client;
 
-const METADATA_PORT = 9990;
-const METADATA_PATH = `${config.filePaths.metadataPath}/`;
-const MANIFEST_JSON = 'manifest.json';
-const MANIFEST_JSON_TMP = 'manifest.json.tmp';
-const ROOT_DB = 'rootDB';
 const METASTORE = '__metastore';
 const OPTIONS = { sync: true };
 
@@ -28,153 +17,36 @@ class BucketFileInterface {
 
     constructor() {
         this.logger = logger;
+        this.mdClient = new MetadataClient(
+            { metadataHost: 'localhost',
+              metadataPort: config.metadataDaemon.port,
+              log: config.log });
+        this.mdDB = this.mdClient.openDB();
+        // the metastore sublevel is used to store bucket attributes
+        this.metastore = this.mdDB.openSub(METASTORE);
         if (cluster.isMaster) {
-            this.startServer();
-        } else {
-            this.refcnt = 0;
-            this.waitreco = 0;
-            this.realReConnect();
-            this.notifier = new events.EventEmitter();
+            this.setupMetadataServer();
         }
     }
 
-    /**
-     * Start the server
-     * @return {undefined}
-     */
-    startServer() {
-        const rootDB = level(METADATA_PATH + ROOT_DB);
-        const sub = sublevel(rootDB);
-        sub.methods = sub.methods || {};
-        sub.methods.createSub = { type: 'async' };
-        sub.createSub = (subName, cb) => {
-            try {
-                sub.sublevel(subName);
-                multilevel.writeManifest(sub,
-                                         METADATA_PATH +
-                                         MANIFEST_JSON_TMP);
-                fs.renameSync(METADATA_PATH + MANIFEST_JSON_TMP,
-                              METADATA_PATH + MANIFEST_JSON);
-                cb();
-            } catch (err) {
-                cb(err);
-            }
-        };
-        const metastore = sub.sublevel(METASTORE);
+    setupMetadataServer() {
         /* Since the bucket creation API is expecting the
            usersBucket to have attributes, we pre-create the
-           usersBucket here */
-        sub.sublevel(constants.usersBucket);
+           usersBucket attributes here */
+        this.mdClient.logger.debug('setting up metadata server');
         const usersBucketAttr = new BucketInfo(constants.usersBucket,
             'admin', 'admin', new Date().toJSON(),
             BucketInfo.currentModelVersion());
-        metastore.put(constants.usersBucket, usersBucketAttr.serialize());
-        const stream = metastore.createKeyStream();
-        stream
-            .on('data', e => {
-                // automatically recreate existing sublevels
-                sub.sublevel(e);
-            })
-            .on('error', err => {
-                this.logger.fatal('error listing metastore', { error: err });
-                throw (errors.InternalError);
-            })
-            .on('end', () => {
-                multilevel.writeManifest(sub, METADATA_PATH + MANIFEST_JSON);
-                this.logger.info('starting metadata file backend server');
-                /* We start a server that will server the sublevel
-                   capable rootDB to clients */
-                net.createServer(con => {
-                    con.pipe(multilevel.server(sub)).pipe(con);
-                }).listen(METADATA_PORT);
+        this.metastore.put(
+            constants.usersBucket,
+            usersBucketAttr.serialize(), err => {
+                if (err) {
+                    this.logger.fatal('error writing usersBucket ' +
+                                      'attributes to metadata',
+                                      { error: err });
+                    throw (errors.InternalError);
+                }
             });
-    }
-
-    /**
-     * Reconnect to the server
-     * @return {undefined}
-     */
-    realReConnect() {
-        if (this.client !== undefined) {
-            this.client.close();
-        }
-        delete require.cache[require.resolve(METADATA_PATH + MANIFEST_JSON)];
-        const manifest = require(METADATA_PATH + MANIFEST_JSON);
-        this.client = multilevel.client(manifest);
-        const con = net.connect(METADATA_PORT);
-        con.pipe(this.client.createRpcStream()).pipe(con);
-        this.metastore = this.client.sublevel(METASTORE);
-    }
-
-    /**
-     * Wait for reconnect do be done
-     * @param {function} cb - callback()
-     * @return {undefined}
-     */
-    reConnect(cb) {
-        if (this.refcnt === this.waitreco) {
-            /* Either we are alone waiting for reconnect or all
-               operations are waiting for reconnect, then force
-               a reco and notify others */
-            this.realReConnect();
-            if (this.waitreco > 1) {
-                this.notifier.emit('recodone');
-            }
-            return cb();
-        }
-        /* We need to wait for somebody to wake us up either by
-           recodone or refdecr */
-        let cbDone = false;
-
-        if (this.notifier.listeners('recodone').length > 0 ||
-            this.notifier.listeners('refdecr').length > 0) {
-            setTimeout(() => {
-                this.reConnect(cb);
-            }, 50);
-            return undefined;
-        }
-        this.notifier.once('recodone', () => {
-            if (cbDone) {
-                return undefined;
-            }
-            cbDone = true;
-            return cb();
-        });
-        this.notifier.once('refdecr', () => {
-            /* We need to recheck for the condition as
-               somebody might issue a command before we
-               get the notification */
-            if (cbDone) {
-                return undefined;
-            }
-            cbDone = true;
-            process.nextTick(() => {
-                this.reConnect(cb);
-            });
-            return undefined;
-        });
-        return undefined;
-    }
-
-    /**
-     * Take a reference on the client
-     * @return {undefined}
-     */
-    ref() {
-        this.refcnt++;
-    }
-
-    /**
-     * Unreference the client
-     * @return {undefined}
-     */
-    unRef() {
-        this.refcnt--;
-        assert(this.refcnt >= 0);
-        if (this.waitreco > 0) {
-            /* give a change to wake up waiters */
-            this.notifier.emit('refdecr');
-        }
     }
 
     /**
@@ -184,104 +56,52 @@ class BucketFileInterface {
      * @param {function} cb - callback(err, db, attr)
      * @return {undefined}
      */
-    loadDBIfExistsNoRef(bucketName, log, cb) {
-        this.getBucketAttributesNoRef(bucketName, log, (err, attr) => {
-            if (err) {
-                return cb(err, null);
-            }
-            let db;
-            try {
-                db = this.client.sublevel(bucketName);
-                return cb(null, db, attr);
-            } catch (err) {
-                /* if the bucket is newly created the
-                   client cannot create sublevels without
-                   re-reading the manifest */
-                this.waitreco++;
-                this.reConnect(() => {
-                    this.waitreco--;
-                    try {
-                        db = this.client.sublevel(bucketName);
-                    } catch (err) {
-                        log.error('cannot make sublevel usable',
-                                  { error: err.stack });
-                        return cb(errors.InternalError, null);
-                    }
-                    return cb(null, db, attr);
-                });
-                return undefined;
-            }
-        });
-        return undefined;
-    }
-
     loadDBIfExists(bucketName, log, cb) {
-        this.ref();
-        this.loadDBIfExistsNoRef(bucketName, log, (err, db, attr) => {
+        this.getBucketAttributes(bucketName, log, (err, attr) => {
             if (err) {
-                this.unRef();
                 return cb(err);
             }
-            // we hold a ref here
-            return cb(err, db, attr);
+            try {
+                const db = this.mdDB.openSub(bucketName);
+                return cb(null, db, attr);
+            } catch (err) {
+                return cb(errors.InternalError);
+            }
         });
         return undefined;
     }
 
     createBucket(bucketName, bucketMD, log, cb) {
-        this.ref();
-        this.getBucketAttributesNoRef(bucketName, log, err => {
+        this.getBucketAttributes(bucketName, log, err => {
             if (err && err !== errors.NoSuchBucket) {
-                this.unRef();
                 return cb(err);
             }
             if (err === undefined) {
-                this.unRef();
                 return cb(errors.BucketAlreadyExists);
             }
-            this.client.createSub(bucketName, err => {
-                if (err) {
-                    log.error('error creating sublevel', { error: err });
-                    this.unRef();
-                    return cb(errors.InternalError);
-                }
-                // we hold a ref here
-                this.putBucketAttributesNoRef(bucketName,
-                                              bucketMD,
-                                              log,
-                                              err => {
-                                                  this.unRef();
-                                                  return cb(err);
-                                              });
-                return undefined;
-            });
+            this.putBucketAttributes(bucketName,
+                                     bucketMD,
+                                     log, cb);
             return undefined;
         });
-        return undefined;
     }
 
-    getBucketAttributesNoRef(bucketName, log, cb) {
+    getBucketAttributes(bucketName, log, cb) {
         this.metastore.get(bucketName, (err, data) => {
             if (err) {
                 if (err.notFound) {
                     return cb(errors.NoSuchBucket);
                 }
-                log.error('error getting db attributes',
-                          { error: err });
-                return cb(errors.InternalError, null);
+                const logObj = {
+                    rawError: err,
+                    error: err.message,
+                    errorStack: err.stack,
+                };
+                log.error('error getting db attributes', logObj);
+                return cb(errors.InternalError);
             }
             return cb(null, BucketInfo.deSerialize(data));
         });
-        return undefined;
-    }
-
-    getBucketAttributes(bucketName, log, cb) {
-        this.ref();
-        this.getBucketAttributesNoRef(bucketName, log,
-                                      (err, data) => {
-                                          this.unRef();
-                                          return cb(err, data);
-                                      });
         return undefined;
     }
 
@@ -291,14 +111,18 @@ class BucketFileInterface {
                 return cb(err);
             }
             db.get(objName, (err, objAttr) => {
-                this.unRef();
                 if (err) {
                     if (err.notFound) {
                         return cb(null, {
                             bucket: bucketAttr.serialize(),
                         });
                     }
-                    log.error('error getting object', { error: err });
+                    const logObj = {
+                        rawError: err,
+                        error: err.message,
+                        errorStack: err.stack,
+                    };
+                    log.error('error getting object', logObj);
                     return cb(errors.InternalError);
                 }
                 return cb(null, {
@@ -311,13 +135,18 @@ class BucketFileInterface {
         return undefined;
     }
 
-    putBucketAttributesNoRef(bucketName, bucketMD, log, cb) {
+    putBucketAttributes(bucketName, bucketMD, log, cb) {
         this.metastore.put(bucketName, bucketMD.serialize(),
                            OPTIONS,
                            err => {
                                if (err) {
+                                   const logObj = {
+                                       rawError: err,
+                                       error: err.message,
+                                       errorStack: err.stack,
+                                   };
                                    log.error('error putting db attributes',
-                                             { error: err });
+                                             logObj);
                                    return cb(errors.InternalError);
                                }
                                return cb();
@@ -325,25 +154,17 @@ class BucketFileInterface {
         return undefined;
     }
 
-    putBucketAttributes(bucketName, bucketMD, log, cb) {
-        this.ref();
-        this.putBucketAttributesNoRef(bucketName, bucketMD, log,
-                                      err => {
-                                          this.unRef();
-                                          return cb(err);
-                                      });
-        return undefined;
-    }
-
     deleteBucket(bucketName, log, cb) {
-        // we could remove bucket from manifest but it is not a problem
-        this.ref();
         this.metastore.del(bucketName,
                            err => {
-                               this.unRef();
                                if (err) {
+                                   const logObj = {
+                                       rawError: err,
+                                       error: err.message,
+                                       errorStack: err.stack,
+                                   };
                                    log.error('error deleting bucket',
-                                             { error: err });
+                                             logObj);
                                    return cb(errors.InternalError);
                                }
                                return cb();
@@ -358,12 +179,16 @@ class BucketFileInterface {
             }
             db.put(objName, JSON.stringify(objVal),
                    OPTIONS, err => {
-                       this.unRef();
                        // TODO: implement versioning for file backend
                        const data = undefined;
                        if (err) {
+                           const logObj = {
+                               rawError: err,
+                               error: err.message,
+                               errorStack: err.stack,
+                           };
                            log.error('error putting object',
-                                     { error: err });
+                                     logObj);
                            return cb(errors.InternalError);
                        }
                        return cb(err, data);
@@ -378,13 +203,16 @@ class BucketFileInterface {
                 return cb(err);
             }
             db.get(objName, (err, data) => {
-                this.unRef();
                 if (err) {
                     if (err.notFound) {
                         return cb(errors.NoSuchKey);
                     }
-                    log.error('error getting object',
-                              { error: err });
+                    const logObj = {
+                        rawError: err,
+                        error: err.message,
+                        errorStack: err.stack,
+                    };
+                    log.error('error getting object', logObj);
                     return cb(errors.InternalError);
                 }
                 return cb(null, JSON.parse(data));
@@ -399,10 +227,13 @@ class BucketFileInterface {
                 return cb(err);
             }
             db.del(objName, OPTIONS, err => {
-                this.unRef();
                 if (err) {
-                    log.error('error deleting object',
-                              { error: err });
+                    const logObj = {
+                        rawError: err,
+                        error: err.message,
+                        errorStack: err.stack,
+                    };
+                    log.error('error deleting object', logObj);
                     return cb(errors.InternalError);
                 }
                 return cb();
@@ -429,31 +260,38 @@ class BucketFileInterface {
                 return cb(err);
             }
             let cbDone = false;
-            const stream = db.createReadStream(requestParams);
-            stream
-                .on('data', e => {
-                    if (extension.filter(e) < 0) {
-                        stream.emit('end');
-                        stream.destroy();
-                    }
-                })
-                .on('error', err => {
-                    if (!cbDone) {
-                        this.unRef();
-                        cbDone = true;
-                        log.error('error listing objects',
-                                  { error: err });
-                        cb(errors.InternalError);
-                    }
-                })
-                .on('end', () => {
-                    if (!cbDone) {
-                        this.unRef();
-                        cbDone = true;
-                        const data = extension.result();
-                        cb(null, data);
-                    }
-                });
+            db.createReadStream(requestParams, (err, stream) => {
+                if (err) {
+                    return cb(err);
+                }
+                stream
+                    .on('data', e => {
+                        if (extension.filter(e) < 0) {
+                            stream.emit('end');
+                            stream.destroy();
+                        }
+                    })
+                    .on('error', err => {
+                        if (!cbDone) {
+                            cbDone = true;
+                            const logObj = {
+                                rawError: err,
+                                error: err.message,
+                                errorStack: err.stack,
+                            };
+                            log.error('error listing objects', logObj);
+                            cb(errors.InternalError);
+                        }
+                    })
+                    .on('end', () => {
+                        if (!cbDone) {
+                            cbDone = true;
+                            const data = extension.result();
+                            cb(null, data);
+                        }
+                    });
+                return undefined;
+            });
             return undefined;
         });
     }

--- a/mdserver.js
+++ b/mdserver.js
@@ -1,0 +1,14 @@
+'use strict'; // eslint-disable-line strict
+require('babel-core/register');
+
+const config = require('./lib/Config.js').default;
+const MetadataServer = require('arsenal').storage.metadata.server;
+
+if (config.backends.metadata === 'file') {
+    const mdServer = new MetadataServer(
+        { metadataPath: config.filePaths.metadataPath,
+          metadataPort: config.metadataDaemon.port,
+          log: config.log });
+    mdServer.startServer();
+}
+

--- a/package.json
+++ b/package.json
@@ -28,10 +28,8 @@
     "bucketclient": "scality/bucketclient",
     "commander": "^2.9.0",
     "ioredis": "2.4.0",
-    "level": "^1.4.0",
-    "level-sublevel": "^6.5.4",
-    "multilevel": "^7.3.0",
     "node-uuid": "^1.4.3",
+    "npm-run-all": "~4.0.2",
     "ready-set-stream": "1.0.7",
     "sproxydclient": "scality/sproxydclient",
     "utapi": "scality/utapi",
@@ -39,9 +37,6 @@
     "vaultclient": "scality/vaultclient",
     "werelogs": "scality/werelogs",
     "xml2js": "~0.4.16"
-  },
-  "optionalDependencies": {
-    "ioctl": "2.0.0"
   },
   "devDependencies": {
     "aws-sdk": "2.28.0",
@@ -72,7 +67,9 @@
     "lint_md": "mdlint $(git ls-files '*.md')",
     "mem_backend": "S3BACKEND=mem node index.js",
     "perf": "mocha --compilers js:babel-core/register tests/performance/s3standard.js",
-    "start": "node init.js && node index.js",
+    "start": "node init.js && npm-run-all --parallel start_mdserver start_s3server",
+    "start_mdserver": "node mdserver.js",
+    "start_s3server": "node index.js",
     "start_utapi": "node utapiServer.js",
     "utapi_replay": "node utapiReplay.js",
     "test": "S3BACKEND=mem mocha --compilers js:babel-core/register --recursive tests/unit",


### PR DESCRIPTION
    The changes allow bucketfile to use a new API in Arsenal to
    communicate with a remote leveldb database, containing sublevels for
    bucket storage. Metadata is still stored on a local levelDB server,
    but it should now be easy to move the storage logic in a new daemon
    running on a remote server, and it should be robust.
    
    Instead of relying on the existing implementation of multilevel, it
    uses client/server wrappers around a new level-net communication
    protocol and API in Arsenal based on socket.io to exchange messages.
    
    It shall be compatible with the existing metadata since it still uses
    the core sublevel module for the storage logic, only the RPC procotol
    has changed.
    
    Test done:
    
     - put a few 100s of files in different S3 subdirectories
     - list directories and subdirectories
     - get/delete files
     - multi-part upload
     - introduce random connection errors (tcpkill) to check robustness
       and automatic reconnection
