### PR TITLE
Tiduster/no root

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -6,6 +6,7 @@
   * [Using Docker Volume in production](#using-docker-volume-in-production)
   * [Adding modifying or deleting accounts or users credentials](#adding-modifying-or-deleting-accounts-or-users-credentials)
   * [Specifying your own host name](#specifying-your-own-host-name)
+  * [Running as an unprivileged user](#running-as-an-unprivileged-user)
 
 ## For continuous integration with Docker
 
@@ -154,3 +155,26 @@ docker run -v $(pwd)/config.json:/usr/src/app/config.json -p 8000:8000 -d scalit
 
 Your local `config.json` file will override the default one through a docker
 file mapping.
+
+### Running as an unprivileged user
+
+S3 Server runs as root by default.
+
+You can change that by modifing the dockerfile and specifying a user before the entrypoint.
+
+The user needs to exist within the container,
+and own the folder **/usr/src/app** for Scality S3 Server to run properly.
+
+For instance, you can modify these lines in the dockerfile:
+
+```shell
+...
+&& groupadd -r -g 1001 scality \
+&& useradd -u 1001 -g 1001 -d /usr/src/app -r scality \
+&& chown -R scality:scality /usr/src/app
+
+...
+
+USER scality
+ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . /usr/src/app
 RUN apt-get update \
     && apt-get install -y python git build-essential --no-install-recommends \
     && npm install --production \
-    && apt-get autoremove -y python build-essential \
+    && apt-get autoremove --purge -y python git build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && npm cache clear \
     && rm -rf ~/.node-gyp \


### PR DESCRIPTION
Hi !
Just some thoughts about the Dockerfile.

First, git is installed and not removed. Maybe this is intentional ? But I couldn't find any use case for this package.
I also added the --purge option. The docker image is reduced from 369MB to 312MB.

Then, as we move to production usage, we didn't want Scality to run as root user.
This is just a proposition, there is a lot of different ways to do that.
On our infrastructure, scality run as user scality, and we didn't see any side effect.

Best regards,

