### PR TITLE
FIX: Aws sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ioctl": "2.0.0"
   },
   "devDependencies": {
-    "aws-sdk": "^2.2.11",
+    "aws-sdk": "2.28.0",
     "babel-cli": "^6.2.0",
     "babel-eslint": "^6.0.0",
     "bluebird": "^3.3.1",


### PR DESCRIPTION
Since aws sdk new version introduce a format change in some returns
(at least Content-Length, previously a string, now a number). An
amount of tests are currently failing. Fixing to the previous aws
version for now until we change tests / aws sdk rollback on this.

Version introducing the bug https://github.com/aws/aws-sdk-js/blob/master/CHANGELOG.md#2290