### PR TITLE
Flush write stream buffers before fsync()

### DIFF
--- a/lib/data/file/backend.js
+++ b/lib/data/file/backend.js
@@ -43,31 +43,39 @@ export const backend = {
                 log.error('error opening filePath', { error: err });
                 return callback(errors.InternalError);
             }
-            const fileStream = fs.createWriteStream(filePath, { fd });
-
-            request.resume();
-            request.pipe(fileStream, { end: false }).on('error', err => {
-                log.error('error streaming data from request on write',
-                    { error: err });
-                return callback(errors.InternalError);
-            });
-            request.on('error', err => {
-                log.error('error streaming data from request on read',
-                    { error: err });
-                // close fileStream
-                return fs.close(fd, () => callback(errors.InternalError));
-            }).on('end', () => {
+            // disable autoClose so that we can close(fd) only after
+            // fsync() has been called
+            const fileStream = fs.createWriteStream(filePath,
+                                                    { fd,
+                                                      autoClose: false });
+            fileStream.on('finish', () => {
                 fs.fsync(fd, err => {
-                    fileStream.end();
+                    fs.close(fd);
                     if (err) {
                         log.error('error streaming data from request on fsync',
-                            { error: err });
+                                  { error: err });
                         return callback(errors.InternalError);
                     }
                     log.debug('finished writing data', { key });
                     return callback(null, key);
                 });
                 return undefined;
+            }).on('error', err => {
+                log.error('error streaming data from request on write',
+                          { error: err });
+                // destroying the write stream forces a close(fd)
+                fileStream.destroy();
+                return callback(errors.InternalError);
+            });
+
+            request.resume();
+            request.pipe(fileStream);
+            request.on('error', err => {
+                log.error('error streaming data from request on read',
+                    { error: err });
+                // destroying the write stream forces a close(fd)
+                fileStream.destroy();
+                return callback(errors.InternalError);
             });
             return undefined;
         });


### PR DESCRIPTION
This should fix corruption issue when shutting down the power, by
forcing fsync() to be called after all user-space buffers have been
flushed to the OS.

Credits to @RemiCardona for spotting the root cause of the issue

fixes #662