### PR TITLE
S3 c 182/fix/missing error handler

### DIFF
--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -128,11 +128,17 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
         }
         services.getMPUBucket(destinationBucket, bucketName, log,
             (err, MPUbucket) => {
+                if (err) {
+                    log.trace('error getting MPUbucket', {
+                        error: err,
+                    });
+                    return callback(err);
+                }
                 // BACKWARD: Remove to remove the old splitter
                 if (MPUbucket.getMdBucketModelVersion() < 2) {
                     metadataStoreParams.splitter = constants.oldSplitter;
                 }
-                services.metadataStoreMPObject(MPUbucket.getName(),
+                return services.metadataStoreMPObject(MPUbucket.getName(),
                     cipherBundle, metadataStoreParams,
                     log, err => {
                         if (err) {

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -70,6 +70,14 @@ describe('Multipart Upload API', () => {
         });
     });
 
+    it('should return an error on an initiate multipart upload call if ' +
+        'no destination bucket', done => {
+        initiateMultipartUpload(authInfo, initiateRequest,
+            log, err => {
+                assert.deepStrictEqual(err, errors.NoSuchBucket);
+                done();
+            });
+    });
 
     it('should upload a part', done => {
         async.waterfall([

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -70,6 +70,7 @@ describe('Multipart Upload API', () => {
         });
     });
 
+
     it('should upload a part', done => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest,


### PR DESCRIPTION
I am unable to add a test for the added error handler without a lot of refactoring so I am just making the fix for now. In a separate commit, I added an error handling initiate mpu test to test an error that is returned earlier but was not tested.