### PR TITLE
FT: Pass requestUID to vaultclient

### DIFF
--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -31,6 +31,12 @@ if (config.backends.auth === 'mem') {
         });
         client = new vaultclient.Client(host, port);
     }
+    if (config.log) {
+        client.setLoggerConfig({
+            level: config.log.logLevel,
+            dump: config.log.dumpLevel,
+        });
+    }
 }
 
 /** vaultSignatureCb parses message from Vault and instantiates
@@ -167,11 +173,7 @@ function authenticateV4Request(params, requestContexts, callback) {
 function getCanonicalIds(emailAddresses, log, callback) {
     log.trace('getting canonicalIDs from Vault based on emailAddresses',
         { emailAddresses });
-    client.getCanonicalIds(emailAddresses,
-        {
-            reqUid: log.getSerializedUids(),
-            logger: log,
-        },
+    client.getCanonicalIds(emailAddresses, { reqUid: log.getSerializedUids() },
         (err, info) => {
             if (err) {
                 log.error('received error message from vault',
@@ -206,11 +208,7 @@ function getCanonicalIds(emailAddresses, log, callback) {
 function getEmailAddresses(canonicalIDs, log, callback) {
     log.trace('getting emailAddresses from Vault based on canonicalIDs',
         { canonicalIDs });
-    client.getEmailAddresses(canonicalIDs,
-        {
-            reqUid: log.getSerializedUids(),
-            logger: log,
-        },
+    client.getEmailAddresses(canonicalIDs, { reqUid: log.getSerializedUids() },
         (err, info) => {
             if (err) {
                 log.error('received error message from vault',
@@ -248,20 +246,17 @@ function getEmailAddresses(canonicalIDs, log, callback) {
 */
 function checkPolicies(requestContextParams, userArn, log, callback) {
     log.trace('sending request context params to vault to evaluate policies');
-    client.checkPolicies(requestContextParams, userArn,
-        {
-            reqUid: log.getSerializedUids(),
-            logger: log,
-        },
-        (err, info) => {
-            if (err) {
-                log.error('received error message from vault',
-                    { error: err });
-                return callback(err);
-            }
-            const result = info.message.body;
-            return callback(null, result);
-        });
+    client.checkPolicies(requestContextParams, userArn, {
+        reqUid: log.getSerializedUids(),
+    }, (err, info) => {
+        if (err) {
+            log.error('received error message from vault',
+                { error: err });
+            return callback(err);
+        }
+        const result = info.message.body;
+        return callback(null, result);
+    });
 }
 
 function checkHealth(log, callback) {
@@ -270,7 +265,7 @@ function checkHealth(log, callback) {
         defResp[implName] = { code: 200, message: 'OK' };
         return callback(null, defResp);
     }
-    return client.healthcheck(log, (err, obj) => {
+    return client.healthcheck(log.getSerializedUids(), (err, obj) => {
         const respBody = {};
         if (err) {
             log.error(`error from ${implName}`, { error: err });


### PR DESCRIPTION
Depends on https://github.com/scality/vaultclient/pull/136.

Since vaultclient creates its own request Logger using the requestUID, we just pass the requestUID. We also allow the log and dump level to be configured based on the `log` field of Config.js.