### PR TITLE
Make sproxyd path customizable

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -28,6 +28,11 @@ export function sproxydAssert(configSproxyd) {
             'bad config: sproxyd.chordCos must be a 2hex-chars string');
         sproxydFields.push('chordCos');
     }
+    if (configSproxyd.path !== undefined) {
+        assert(typeof configSproxyd.path === 'string',
+            'bad config: sproxyd.path must be a string');
+        sproxydFields.push('path');
+    }
     return sproxydFields;
 }
 
@@ -66,6 +71,12 @@ export function locationConstraintAssert(locationConstraints) {
             }
         });
     });
+}
+
+export function cosParse(chordCos) {
+    // Cos number should only be first digit of config value
+    const firstDigit = chordCos[0];
+    return Number.parseInt(firstDigit, 16);
 }
 /**
  * Reads from a config file and returns the content as a config object
@@ -128,16 +139,23 @@ class Config {
                             details.connector.sproxyd.bootstrap) &&
                             details.connector.sproxyd.bootstrap.every(e =>
                                 typeof e === 'string'),
-                                'bad config: sproxyd.bootstrap must be an ' +
-                                'array of strings');
+                                'assignment error: sproxyd.bootstrap must be ' +
+                                'an array of strings');
                     }
                     if (fields.indexOf('chordCos') > -1) {
                         details.connector.sproxyd.chordCos =
-                            Number.parseInt(locationConfig[l].details.
-                                connector.sproxyd.chordCos, 16);
+                            cosParse(locationConfig[l].details.connector.
+                                sproxyd.chordCos);
                         assert(typeof details.connector.sproxyd.chordCos ===
-                            'number', 'error parsing: chordCos must be a ' +
+                            'number', 'assignment error: chordCos must be a ' +
                             'number');
+                    }
+                    if (fields.indexOf('path') > -1) {
+                        details.connector.sproxyd.chordCos =
+                            locationConfig[l].details.connector.sproxyd.path;
+                        assert(typeof details.connector.sproxyd.chordCos ===
+                            'string', 'assignment error: sproxyd path must ' +
+                            'be a string');
                     }
                 }
             }

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -24,6 +24,9 @@ export default function parseLC() {
                 // Might be undefined which is ok since there is a default
                 // set in sproxydclient if chordCos is undefined
                 chordCos: locationObj.details.connector.sproxyd.chordCos,
+                // Might also be undefined, but there is a default path set
+                // in sproxydclient as well
+                path: locationObj.details.connector.sproxyd.path,
             });
             clients[location].clientType = 'scality';
         }

--- a/locationConfig.json
+++ b/locationConfig.json
@@ -16,7 +16,8 @@
         "details": {
             "connector": {
                 "sproxyd": {
-                    "bootstrap": ["localhost:8182"]
+                    "bootstrap": ["localhost:8182"],
+                    "path": "/proxy/arc/"
                 }
             }
         }

--- a/tests/unit/testConfigs/cosParse.js
+++ b/tests/unit/testConfigs/cosParse.js
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import { cosParse } from '../../../lib/Config';
+
+const dummyChordCos = '20';
+
+describe('cosParse', () => {
+    it('should return the first digit of a string number as an integer', () => {
+        const parsed = cosParse(dummyChordCos);
+        assert.strictEqual(parsed, 2);
+    });
+});

--- a/tests/unit/testConfigs/sproxydAssert.js
+++ b/tests/unit/testConfigs/sproxydAssert.js
@@ -1,41 +1,82 @@
 import assert from 'assert';
 import { sproxydAssert } from '../../../lib/Config';
 
-const dummySproxydConfBoot = {
-    sproxyd: {
-        bootstrap: ['localhost:8181'],
-    },
-};
-
-const dummySproxydConfChord = {
-    sproxyd: {
-        chordCos: '20',
-    },
-};
-
-const dummySproxydConfBoth = {
-    sproxyd: {
-        bootstrap: ['localhost:8181'],
-        chordCos: '20',
-    },
-};
+function makeSproxydConf(bootstrap, chordCos, sproxydPath) {
+    const conf = {
+        sproxyd: {},
+    };
+    if (bootstrap) {
+        conf.sproxyd.bootstrap = bootstrap;
+    }
+    if (chordCos) {
+        conf.sproxyd.chordCos = chordCos;
+    }
+    if (sproxydPath) {
+        conf.sproxyd.path = sproxydPath;
+    }
+    return conf.sproxyd;
+}
 
 describe('sproxydAssert', () => {
+    it('should throw an error if bootstrap list is not an array', () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf('localhost:8181'));
+        },
+        /bad config: sproxyd.bootstrap must be an array of strings/);
+    });
+    it('should throw an error if bootstrap array does not contain strings',
+    () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf([8181]));
+        },
+        /bad config: sproxyd.bootstrap must be an array of strings/);
+    });
+    it('should throw an error if chordCos is not a string', () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf(null, 20));
+        },
+        /bad config: sproxyd.chordCos must be a string/);
+    });
+    it('should throw an error if chordCos is more than 2 digits', () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf(null, '200'));
+        },
+        /bad config: sproxyd.chordCos must be a 2hex-chars string/);
+    });
+    it('should throw an error if chordCos includes non-hex digit', () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf(null, '2z'));
+        },
+        /bad config: sproxyd.chordCos must be a 2hex-chars string/);
+    });
+    it('should throw an error if path is not a string', () => {
+        assert.throws(() => {
+            sproxydAssert(makeSproxydConf(null, null, 20));
+        }, /bad config: sproxyd.path must be a string/);
+    });
+
     it('should return array containing "bootstrap" if config ' +
         'contains bootstrap', () => {
-        const sproxydArray = sproxydAssert(dummySproxydConfBoot.sproxyd);
+        const sproxydArray = sproxydAssert(makeSproxydConf(['localhost:8181']));
         assert.strictEqual(sproxydArray.indexOf('bootstrap'), 0);
     });
     it('should return array containing "chordCos" if config contains chordCos',
         () => {
-            const sproxydArray = sproxydAssert(dummySproxydConfChord.sproxyd);
+            const sproxydArray = sproxydAssert(makeSproxydConf(null, '20'));
             assert.strictEqual(sproxydArray.indexOf('chordCos'), 0);
         });
-    it('should return array of "bootstrap" and "chordCos" if config ' +
-        'contains both fields', () => {
-        const sproxydArray = sproxydAssert(dummySproxydConfBoth.sproxyd);
-        assert.strictEqual(sproxydArray.length, 2);
+    it('should return array containing "path" if config contains path', () => {
+        const sproxydArray = sproxydAssert(
+            makeSproxydConf(null, null, '/proxy/arc'));
+        assert.strictEqual(sproxydArray.indexOf('path'), 0);
+    });
+    it('should return array of "bootstrap", "chordCos", and "path" if config ' +
+        'contains all fields', () => {
+        const sproxydArray = sproxydAssert(
+            makeSproxydConf(['localhost:8181'], '20', '/proxy/arc'));
+        assert.strictEqual(sproxydArray.length, 3);
         assert.strictEqual(sproxydArray.indexOf('bootstrap') > -1, true);
         assert.strictEqual(sproxydArray.indexOf('chordCos') > -1, true);
+        assert.strictEqual(sproxydArray.indexOf('path') > -1, true);
     });
 });


### PR DESCRIPTION
Gives user ability to set custom sproxyd path in bootstrap array and fixes chordCos parsing.
Goes with https://github.com/scality/sproxydclient/pull/118