### PR TITLE
FIX: Handle account-level metrics listing

### DIFF
--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -59,10 +59,10 @@ function _listMetrics(host,
         });
     });
     // TODO: cleanup with refactor of generateV4Headers
-    request.path = '/buckets';
+    request.path = `/${metric}`;
     auth.client.generateV4Headers(request, { Action: 'ListMetrics' },
         accessKey, secretKey, 's3');
-    request.path = '/buckets?Action=ListMetrics';
+    request.path = `/${metric}?Action=ListMetrics`;
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
     }


### PR DESCRIPTION
Query params sent to the arsenal auth method currently only handle bucket-level metrics. Since the listing binary supports account-level metrics, we also need to be able to send the correct path for account-level listings. This also prepares the route for remaining metric levels: to be introduced in https://github.com/scality/S3/pull/536