### PR TITLE
BF: get empty object with valid/invalid range

### DIFF
--- a/lib/api/apiUtils/object/validRangeOnEmptyFile.js
+++ b/lib/api/apiUtils/object/validRangeOnEmptyFile.js
@@ -1,0 +1,35 @@
+/**
+ * validRangeForEmptyFile - Validate range request header on empty object
+ * @param {string} rangeHeader - range header from request
+ * which should be in form bytes=0-9
+ * @return {bool} object true if valid range, false if not
+ */
+export function validRangeOnEmptyFile(rangeHeader) {
+    if (rangeHeader.startsWith('bytes=') && rangeHeader.indexOf('-') > -1) {
+        const rangePortion = rangeHeader.replace('bytes=', '').split('-');
+        if (rangePortion.length === 2) {
+            const start = parseInt(rangePortion[0], 10);
+            const end = parseInt(rangePortion[1], 10);
+            // if start value only, value has to be a positive integer
+            const isValidStart = rangePortion[0] !== '' &&
+              rangePortion[1] === '' && !Number.isNaN(start);
+            if (isValidStart) {
+                return true;
+            }
+            // if end value only, value has to be 0
+            const isValidEnd = rangePortion[0] === '' && end === 0;
+            if (isValidEnd) {
+                return true;
+            }
+            // if start and end values, both values have to be positive
+            // integer and end value superior or equal to start value
+            const isValidStartAndEnd =
+              rangePortion[0] !== '' && rangePortion[1] !== '' &&
+              !Number.isNaN(start) && !Number.isNaN(end) && end >= start;
+            if (isValidStartAndEnd) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -6,6 +6,8 @@ import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import services from '../services';
 import validateHeaders from '../utilities/validateHeaders';
 import { pushMetric } from '../utapi/utilities';
+import { validRangeOnEmptyFile } from
+'./apiUtils/object/validRangeOnEmptyFile';
 
 /**
  * GET Object - Get an object
@@ -46,7 +48,11 @@ function objectGet(authInfo, request, log, callback) {
         const responseMetaHeaders = collectResponseHeaders(objMD, corsHeaders);
         // 0 bytes file
         if (objMD.location === null) {
-            if (request.headers.range) {
+            const range = request.headers.range;
+            // aws returns the empty object if there is an invalid range but
+            // sends an invalidRange error if the range is valid on an empty
+            // object
+            if (range && validRangeOnEmptyFile(range)) {
                 return callback(errors.InvalidRange, null, corsHeaders);
             }
             pushMetric('getObject', log, {

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -5,6 +5,29 @@ import constants from '../../constants';
 import { metadata } from '../../lib/metadata/in_memory/metadata';
 import { resetCount, ds } from '../../lib/data/in_memory/backend';
 
+
+export const testsRangeOnEmptyFile = [
+    { range: 'bytes=0-9', valid: true },
+    { range: 'bytes=1-9', valid: true },
+    { range: 'bytes=1-999', valid: true },
+    { range: 'bytes=0-', valid: true },
+    { range: 'bytes=1-', valid: true },
+    { range: 'bytes=0-0', valid: true },
+    { range: 'bytes=00-0000', valid: true },
+    { range: 'bytes=1-1', valid: true },
+    { range: 'bytes=-0', valid: true },
+    { range: 'bytes=-000', valid: true },
+    { range: '0-1', valid: false },
+    { range: 'b=0-1', valid: false },
+    { range: 'byte=0-1', valid: false },
+    { range: 'bytes=-1', valid: false },
+    { range: 'bytes=0--1', valid: false },
+    { range: 'bytes=-1-0', valid: false },
+    { range: 'bytes=a-9', valid: false },
+    { range: 'bytes=10-9', valid: false },
+    { range: 'bytes=a-a', valid: false },
+];
+
 export function makeid(size) {
     let text = '';
     const possible =

--- a/tests/unit/utils/validateRange.js
+++ b/tests/unit/utils/validateRange.js
@@ -3,12 +3,28 @@ import assert from 'assert';
 import { parseRange } from
     '../../../lib/api/apiUtils/object/parseRange';
 
+import { validRangeOnEmptyFile } from
+        '../../../lib/api/apiUtils/object/validRangeOnEmptyFile';
+
+import { testsRangeOnEmptyFile } from '../helpers';
+
 function checkRange(rangeHeader, totalLength, expectedRange) {
     const { range, error } =
         parseRange(rangeHeader, totalLength);
     assert.ifError(error);
     assert.deepStrictEqual(range, expectedRange);
 }
+
+describe('validRangeOnEmptyFile function', () => {
+    testsRangeOnEmptyFile.forEach(test => {
+        const validText = test.valid ? 'be valid' : 'not be valid';
+        it(`this range should ${validText}: ${test.range}`, () => {
+            assert.strictEqual(validRangeOnEmptyFile(test.range),
+            test.valid, test.range);
+        });
+    });
+});
+
 
 describe('parseRange function', () => {
     it('should return an array with the start and end if range is '


### PR DESCRIPTION
FIXES: #660 

AWS returns the empty object if there is an invalid range but sends an invalidRange error if the range is valid on an empty object