### PR TITLE
ft: proper versioning action for Vault

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -1,6 +1,9 @@
 import { policies } from 'arsenal';
-const RequestContext = policies.RequestContext;
 
+const RequestContext = policies.RequestContext;
+let apiMethodAfterVersionCheck;
+const apiMethodWithVersion = { objectGetACL: true, objectPutACL: true,
+objectGet: true, objectDelete: true };
 
 /**
  * Prepares the requestContexts array to send to Vault for authorization
@@ -25,16 +28,23 @@ export default function prepareRequestContexts(apiMethod, request, sourceBucket,
     if (apiMethod === 'multiObjectDelete' || apiMethod === 'bucketPut') {
         return null;
     }
+    if (apiMethodWithVersion[apiMethod] && request.query &&
+      request.query.versionId) {
+        apiMethodAfterVersionCheck = `${apiMethod}Version`;
+    } else {
+        apiMethodAfterVersionCheck = apiMethod;
+    }
     const requestContexts = [];
-    if (apiMethod === 'objectCopy' || apiMethod === 'objectPutCopyPart') {
-        // TODO: Categorize objectCopy requests with copy source version
-        // ids as 'objectGetVersion' action (after related PR is merged)
+    if (apiMethodAfterVersionCheck === 'objectCopy' ||
+    apiMethodAfterVersionCheck === 'objectPutCopyPart') {
+        const objectGetAction = sourceVersionId ? 'objectGetVersion' :
+          'objectGet';
         const reqQuery = Object.assign({}, request.query,
             { versionId: sourceVersionId });
         const getRequestContext = new RequestContext(request.headers,
             reqQuery, sourceBucket, sourceObject,
             request.socket.remoteAddress, request.connection.encrypted,
-            'objectGet', 's3');
+            objectGetAction, 's3');
         const putRequestContext = new RequestContext(request.headers,
             request.query, request.bucketName, request.objectKey,
             request.socket.remoteAddress, request.connection.encrypted,
@@ -44,7 +54,7 @@ export default function prepareRequestContexts(apiMethod, request, sourceBucket,
         const requestContext = new RequestContext(request.headers,
             request.query, request.bucketName, request.objectKey,
             request.socket.remoteAddress, request.connection.encrypted,
-            apiMethod, 's3');
+            apiMethodAfterVersionCheck, 's3');
         requestContexts.push(requestContext);
     }
     return requestContexts;


### PR DESCRIPTION
S3C-156
For requests that have version id's use correct "action" when sending requestContext to vault.