### PR TITLE
bf/Handle dataFile and datatMem backend names

### DIFF
--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -14,10 +14,10 @@ let implName;
 
 if (config.backends.data === 'mem') {
     client = inMemory;
-    implName = 'dataMem';
+    implName = 'mem';
 } else if (config.backends.data === 'file') {
     client = file;
-    implName = 'dataFile';
+    implName = 'file';
 } else if (config.backends.data === 'multiple') {
     client = multipleBackendGateway;
     implName = 'multipleBackends';

--- a/locationConfig.json
+++ b/locationConfig.json
@@ -25,19 +25,21 @@
     "us-east-1": {
         "type": "file",
         "legacyAwsBehavior": true,
-        "details": {
-        }
+        "details": {}
     },
     "file": {
         "type": "file",
         "legacyAwsBehavior": false,
-        "details": {
-        }
+        "details": {}
+    },
+    "dataFile": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
     },
     "mem": {
         "type": "mem",
         "legacyAwsBehavior": false,
-        "details": {
-        }
+        "details": {}
     }
 }

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -85,7 +85,7 @@ describe('objectGet API', () => {
                             key: 1,
                             start: 0,
                             size: 12,
-                            dataStoreName: 'dataMem',
+                            dataStoreName: 'mem',
                         }]);
                             done();
                         });
@@ -188,13 +188,13 @@ describe('objectGet API', () => {
                     assert.deepStrictEqual(dataGetInfo,
                         [{
                             key: 1,
-                            dataStoreName: 'dataMem',
+                            dataStoreName: 'mem',
                             size: 5242880,
                             start: 0,
                         },
                         {
                             key: 2,
-                            dataStoreName: 'dataMem',
+                            dataStoreName: 'mem',
                             size: 12,
                             start: 5242880,
                         }]);


### PR DESCRIPTION
If a server was started with multiple backends after having put an object on a server started with file backend, the object would be unretrievable. This PR fixes that