### PR TITLE
rf: change encoding of version ids [S3C-184]

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -11,7 +11,7 @@ import { dataStore } from './storeObject';
 import locationConstraintCheck from './locationConstraintCheck';
 import { versioningPreprocessing } from './versioning';
 import removeAWSChunked from './removeAWSChunked';
-import { decryptVersionId } from './versioning';
+import { decodeVersionId } from './versioning';
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
     metadataStoreParams, dataToDelete, deleteLog, callback) {
@@ -93,15 +93,15 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         dataToDelete = Array.isArray(objMD.location) ?
             objMD.location : [objMD.location];
     }
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return callback(decryptVidResult);
+        return callback(decodedVidResult);
     }
-    const reqVersionId = decryptVidResult;
+    const reqVersionId = decodedVidResult;
 
     const backendInfoObj =
         locationConstraintCheck(request, null, bucketMD, log);

--- a/lib/api/apiUtils/object/parseCopySource.js
+++ b/lib/api/apiUtils/object/parseCopySource.js
@@ -2,7 +2,7 @@ import { errors } from 'arsenal';
 
 import url from 'url';
 import querystring from 'querystring';
-import { decryptVersionId } from './versioning';
+import { decodeVersionId } from './versioning';
 
 /** parseCopySource - parse objectCopy or objectPutCopyPart copy source header
  * @param {string} apiMethod - api method
@@ -27,7 +27,7 @@ export default function parseCopySource(apiMethod, copySourceHeader) {
     const sourceBucket = source.slice(0, slashSeparator);
     const sourceObject = source.slice(slashSeparator + 1);
     const sourceVersionId =
-        decryptVersionId(query ? querystring.parse(query) : undefined);
+        decodeVersionId(query ? querystring.parse(query) : undefined);
     if (sourceVersionId instanceof Error) {
         const err = sourceVersionId;
         return { parsingError: err };

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -7,14 +7,13 @@ const versionIdUtils = versioning.VersionID;
 // that was created before bucket versioning was enabled
 const nonVersionedObjId = versionIdUtils.VID_INF;
 
-
-/** decryptVersionId - parse and decrypt the version id from a query object
+/** decodedVidResult - decode the version id from a query object
  * @param {object} [reqQuery] - request query object
  * @param {string} [reqQuery.versionId] - version ID sent in request query
  * @return {(Error|string|undefined)} - return Invalid Argument if decryption
- * fails due to improper format, otherwise undefined or the decrypted string
+ * fails due to improper format, otherwise undefined or the decoded version id
  */
-export function decryptVersionId(reqQuery) {
+export function decodeVersionId(reqQuery) {
     if (!reqQuery || !reqQuery.versionId) {
         return undefined;
     }
@@ -22,9 +21,8 @@ export function decryptVersionId(reqQuery) {
     if (versionId === 'null') {
         return versionId;
     }
-    try {
-        versionId = versionIdUtils.decrypt(versionId);
-    } catch (exception) {
+    versionId = versionIdUtils.decode(versionId);
+    if (versionId instanceof Error) {
         return errors.InvalidArgument
             .customizeDescription('Invalid version id specified');
     }
@@ -42,7 +40,7 @@ export function getVersionIdResHeader(verCfg, objectMD) {
         if (objectMD.isNull || (objectMD && !objectMD.versionId)) {
             return 'null';
         }
-        return versionIdUtils.encrypt(objectMD.versionId);
+        return versionIdUtils.encode(objectMD.versionId);
     }
     return undefined;
 }

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -104,7 +104,7 @@ function processVersions(bucketName, listParams, list) {
     xmlParams.forEach(p => {
         if (p.value) {
             const val = p.tag !== 'NextVersionIdMarker' || p.value === 'null' ?
-                p.value : versionIdUtils.encrypt(p.value);
+                p.value : versionIdUtils.encode(p.value);
             xml.push(`<${p.tag}>${escapeXmlFn(val)}</${p.tag}>`);
         }
     });
@@ -120,7 +120,7 @@ function processVersions(bucketName, listParams, list) {
             `<Key>${objectKey}</Key>`,
             '<VersionId>',
             (v.isNull || v.versionId === undefined) ?
-                'null' : versionIdUtils.encrypt(v.versionId),
+                'null' : versionIdUtils.encode(v.versionId),
             '</VersionId>',
             `<IsLatest>${isLatest}</IsLatest>`,
             `<LastModified>${v['last-modified']}</LastModified>`,
@@ -255,7 +255,7 @@ export default function bucketGet(authInfo, request, log, callback) {
             delete listParams.marker;
             listParams.keyMarker = params['key-marker'];
             listParams.versionIdMarker = params['version-id-marker'] ?
-                versionIdUtils.decrypt(params['version-id-marker']) : undefined;
+                versionIdUtils.decode(params['version-id-marker']) : undefined;
         }
         return services.getObjectListing(bucketName, listParams, log,
         (err, list) => {

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -448,7 +448,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         }
         if (generatedVersionId) {
             resHeaders['x-amz-version-id'] =
-                versionIdUtils.encrypt(generatedVersionId);
+                versionIdUtils.encode(generatedVersionId);
         }
         xmlParams.ETag = `"${aggregateETag}"`;
         const xml = _convertToXml(xmlParams);

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -157,12 +157,13 @@ function _parseXml(xmlToParse, next) {
             }
             const object = { key: item.Key[0] };
             if (item.VersionId) {
-                try {
-                    object.versionId = item.VersionId[0];
-                    object.decryptedVid = item.VersionId[0] === 'null' ?
-                        'null' : versionIdUtils.decrypt(item.VersionId[0]);
-                } catch (exception) {
+                object.versionId = item.VersionId[0];
+                const decodedVid = item.VersionId[0] === 'null' ?
+                    'null' : versionIdUtils.decode(item.VersionId[0]);
+                if (decodedVid instanceof Error) {
                     itemError = errors.NoSuchVersion;
+                } else {
+                    object.decodedVid = decodedVid;
                 }
             }
             if (itemError) {
@@ -211,7 +212,7 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
             // for obj deletes, no need to check acl's at object level
             // (authority is at the bucket level for obj deletes)
             callback => metadataGetObject(bucketName, entry.key,
-                entry.decryptedVid, log, (err, objMD) => {
+                entry.decodedVid, log, (err, objMD) => {
                     // if general error from metadata return error
                     if (err && !err.NoSuchKey) {
                         return callback(err);
@@ -224,7 +225,7 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
                         // TODO: Look into AWS behavior for whether to create
                         // a delete marker if request is trying to delete a
                         // version that does not exist.
-                        if (verCfg && !entry.decryptedVid) {
+                        if (verCfg && !entry.decodedVid) {
                             log.debug('trying to delete specific version ' +
                             ' that does not exist');
                             return callback(null, objMD);
@@ -238,7 +239,7 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
                     return callback(null, objMD);
                 }),
             (objMD, callback) => preprocessingVersioningDelete(bucketName,
-                bucket, objMD, entry.decryptedVid, log,
+                bucket, objMD, entry.decodedVid, log,
                 (err, options) => callback(err, options, objMD)),
             (options, objMD, callback) => {
                 const deleteInfo = {};

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -401,11 +401,11 @@ function objectCopy(authInfo, request, sourceBucket,
         }
         if (sourceVersionId) {
             additionalHeaders['x-amz-copy-source-version-id'] =
-                versionIdUtils.encrypt(sourceVersionId);
+                versionIdUtils.encode(sourceVersionId);
         }
         if (storingNewMdResult && storingNewMdResult.versionId) {
             additionalHeaders['x-amz-version-id'] =
-                versionIdUtils.encrypt(storingNewMdResult.versionId);
+                versionIdUtils.encode(storingNewMdResult.versionId);
         }
         pushMetric('copyObject', log, {
             authInfo,

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -6,7 +6,7 @@ import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
 import { pushMetric } from '../utapi/utilities';
 import createAndStoreObject from './apiUtils/object/createAndStoreObject';
-import { decryptVersionId,
+import { decodeVersionId,
     preprocessingVersioningDelete } from './apiUtils/object/versioning';
 import { metadataValidateBucketAndObj } from
 '../metadata/metadataUtils';
@@ -32,15 +32,15 @@ export default function objectDelete(authInfo, request, log, cb) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
 
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return cb(decryptVidResult);
+        return cb(decodedVidResult);
     }
-    const reqVersionId = decryptVidResult;
+    const reqVersionId = decodedVidResult;
 
     const valParams = {
         authInfo,
@@ -138,7 +138,7 @@ export default function objectDelete(authInfo, request, log, cb) {
             if (result.versionId) {
                 resHeaders['x-amz-delete-marker'] = true;
                 resHeaders['x-amz-version-id'] = result.versionId === 'null' ?
-                    result.versionId : versionIdUtils.encrypt(result.versionId);
+                    result.versionId : versionIdUtils.encode(result.versionId);
             }
             // TODO metric should be 'deleteObject', not 'putObject',
             // but number of objects should be incremented since putting a new
@@ -150,7 +150,7 @@ export default function objectDelete(authInfo, request, log, cb) {
             // return the version id in the response headers
             if (reqVersionId) {
                 resHeaders['x-amz-version-id'] = reqVersionId === 'null' ?
-                    reqVersionId : versionIdUtils.encrypt(reqVersionId);
+                    reqVersionId : versionIdUtils.encode(reqVersionId);
                 if (deleteInfo.removeDeleteMarker) {
                     resHeaders['x-amz-delete-marker'] = true;
                 }

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -1,7 +1,7 @@
 import { errors } from 'arsenal';
 
 import { parseRange } from './apiUtils/object/parseRange';
-import { decryptVersionId } from './apiUtils/object/versioning';
+import { decodeVersionId } from './apiUtils/object/versioning';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import validateHeaders from '../utilities/validateHeaders';
@@ -26,15 +26,15 @@ function objectGet(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
 
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return callback(decryptVidResult);
+        return callback(decodedVidResult);
     }
-    const versionId = decryptVidResult;
+    const versionId = decodedVidResult;
 
     const mdValParams = {
         authInfo,

--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -6,7 +6,7 @@ import aclUtils from '../utilities/aclUtils';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import { pushMetric } from '../utapi/utilities';
-import { decryptVersionId, getVersionIdResHeader }
+import { decodeVersionId, getVersionIdResHeader }
     from './apiUtils/object/versioning';
 import vault from '../auth/vault';
 import { metadataValidateBucketAndObj } from
@@ -46,15 +46,15 @@ export default function objectGetACL(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
 
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return callback(decryptVidResult);
+        return callback(decodedVidResult);
     }
-    const versionId = decryptVidResult;
+    const versionId = decodedVidResult;
 
     const metadataValParams = {
         authInfo,

--- a/lib/api/objectHead.js
+++ b/lib/api/objectHead.js
@@ -1,6 +1,6 @@
 import { errors } from 'arsenal';
 
-import { decryptVersionId } from './apiUtils/object/versioning';
+import { decodeVersionId } from './apiUtils/object/versioning';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import collectResponseHeaders from '../utilities/collectResponseHeaders';
 import validateHeaders from '../utilities/validateHeaders';
@@ -24,15 +24,15 @@ export default function objectHead(authInfo, request, log, callback) {
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
 
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return callback(decryptVidResult);
+        return callback(decodedVidResult);
     }
-    const versionId = decryptVidResult;
+    const versionId = decodedVidResult;
 
     const mdValParams = {
         authInfo,

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -104,7 +104,7 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             if (vcfg && vcfg.Status === 'Enabled') {
                 if (storingResult && storingResult.versionId) {
                     responseHeaders['x-amz-version-id'] =
-                        versionIdUtils.encrypt(storingResult.versionId);
+                        versionIdUtils.encode(storingResult.versionId);
                 }
             }
             return callback(null, responseHeaders);

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -7,7 +7,7 @@ import { pushMetric } from '../utapi/utilities';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import vault from '../auth/vault';
-import { decryptVersionId,
+import { decodeVersionId,
     getVersionIdResHeader } from './apiUtils/object/versioning';
 import { metadataValidateBucketAndObj } from
 '../metadata/metadataUtils';
@@ -64,15 +64,15 @@ export default function objectPutACL(authInfo, request, log, cb) {
         constants.logId,
     ];
 
-    const decryptVidResult = decryptVersionId(request.query);
-    if (decryptVidResult instanceof Error) {
+    const decodedVidResult = decodeVersionId(request.query);
+    if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
             versionId: request.query.versionId,
-            error: decryptVidResult,
+            error: decodedVidResult,
         });
-        return cb(decryptVidResult);
+        return cb(decodedVidResult);
     }
-    const reqVersionId = decryptVidResult;
+    const reqVersionId = decodedVidResult;
 
     const metadataValParams = {
         authInfo,

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -155,7 +155,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             sourceVerId = 'null';
                         } else {
                             sourceVerId =
-                                versionIdUtils.encrypt(sourceObjMD.versionId);
+                                versionIdUtils.encode(sourceObjMD.versionId);
                         }
                     }
                     return next(null, copyLocator.dataLocator, destBucketMD,

--- a/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
@@ -5,10 +5,8 @@ import getConfig from '../../test/support/config';
 const config = getConfig('default', { signatureVersion: 'v4' });
 const s3 = new S3(config);
 
-export const constants = {
-    versioningEnabled: { Status: 'Enabled' },
-    versioningSuspended: { Status: 'Suspended' },
-};
+export const versioningEnabled = { Status: 'Enabled' };
+export const versioningSuspended = { Status: 'Suspended' };
 
 function _deleteVersionList(versionList, bucket, callback) {
     if (versionList === undefined || versionList.length === 0) {

--- a/tests/functional/aws-node-sdk/test/object/completeMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMPU.js
@@ -2,8 +2,9 @@ import assert from 'assert';
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
 import {
-    constants,
     removeAllVersions,
+    versioningEnabled,
+    versioningSuspended,
 } from '../../lib/utility/versioning-util.js';
 
 const date = Date.now();
@@ -106,7 +107,7 @@ describe('Complete MPU', () => {
             let eTag;
 
             beforeEach(() => s3.putBucketVersioningAsync({ Bucket: bucket,
-                    VersioningConfiguration: constants.versioningEnabled })
+                    VersioningConfiguration: versioningEnabled })
                 .then(() => _initiateMpuAndPutOnePart())
                 .then(result => {
                     uploadId = result.uploadId;
@@ -125,7 +126,7 @@ describe('Complete MPU', () => {
             let eTag;
 
             beforeEach(() => s3.putBucketVersioningAsync({ Bucket: bucket,
-                    VersioningConfiguration: constants.versioningSuspended })
+                    VersioningConfiguration: versioningSuspended })
                 .then(() => _initiateMpuAndPutOnePart())
                 .then(result => {
                     uploadId = result.uploadId;

--- a/tests/functional/aws-node-sdk/test/versioning/listObjectMasterVersions.js
+++ b/tests/functional/aws-node-sdk/test/versioning/listObjectMasterVersions.js
@@ -1,8 +1,10 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
 
-import getConfig from '../support/config';
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+import { removeAllVersions } from '../../lib/utility/versioning-util';
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
@@ -11,351 +13,332 @@ const testing = process.env.VERSIONING === 'no' ?
 
 testing('listObject - Delimiter master', function testSuite() {
     this.timeout(600000);
-    let s3 = undefined;
 
-    function _deleteVersionList(versionList, bucket, callback) {
-        async.each(versionList, (versionInfo, cb) => {
-            const versionId = versionInfo.VersionId;
-            const params = { Bucket: bucket, Key: versionInfo.Key,
-            VersionId: versionId };
-            s3.deleteObject(params, cb);
-        }, callback);
-    }
-    function _removeAllVersions(bucket, callback) {
-        return s3.listObjectVersions({ Bucket: bucket }, (err, data) => {
-            if (err && err.NoSuchBucket) {
-                return callback();
-            } else if (err) {
-                return callback(err);
-            }
-            return _deleteVersionList(data.DeleteMarkers, bucket, err => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+
+        // setup test
+        before(done => {
+            s3.createBucket({ Bucket: bucket }, done);
+        });
+
+        // delete bucket after testing
+        after(done => {
+            removeAllVersions({ Bucket: bucket }, err => {
                 if (err) {
-                    return callback(err);
+                    return done(err);
                 }
-                return _deleteVersionList(data.Versions, bucket, callback);
-            });
-        });
-    }
-
-    // setup test
-    before(done => {
-        const config = getConfig('default', { signatureVersion: 'v4' });
-        s3 = new S3(config);
-        s3.createBucket({ Bucket: bucket }, done);
-    });
-
-    // delete bucket after testing
-    after(done => {
-        _removeAllVersions(bucket, err => {
-            if (err) {
-                return done(err);
-            }
-            return s3.deleteBucket({ Bucket: bucket }, err => {
-                assert.strictEqual(err, null,
-                    `Error deleting bucket: ${err}`);
-                return done();
-            });
-        });
-    });
-
-    let versioning = false;
-
-    const objects = [
-        { name: 'notes/summer/august/1.txt', value: 'foo', isNull: true },
-        { name: 'notes/year.txt', value: 'foo', isNull: true },
-        { name: 'notes/yore.rs', value: 'foo', isNull: true },
-        { name: 'notes/zaphod/Beeblebrox.txt', value: 'foo', isNull: true },
-        { name: 'Pâtisserie=中文-español-English', value: 'foo' },
-        { name: 'Pâtisserie=中文-español-English', value: 'bar' },
-        { name: 'notes/spring/1.txt', value: 'qux' },
-        { name: 'notes/spring/1.txt', value: 'foo' },
-        { name: 'notes/spring/1.txt', value: 'bar' },
-        { name: 'notes/spring/2.txt', value: 'foo' },
-        { name: 'notes/spring/2.txt', value: null },
-        { name: 'notes/spring/march/1.txt', value: 'foo' },
-        { name: 'notes/spring/march/1.txt', value: 'bar', isNull: true },
-        { name: 'notes/summer/1.txt', value: 'foo' },
-        { name: 'notes/summer/1.txt', value: 'bar' },
-        { name: 'notes/summer/2.txt', value: 'bar' },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/444.txt', value: null },
-        { name: 'notes/summer/44444.txt', value: null },
-    ];
-
-    it('put objects inside bucket', done => {
-        async.eachSeries(objects, (obj, next) => {
-            async.waterfall([
-                next => {
-                    if (!versioning && obj.isNull !== true) {
-                        const params = {
-                            Bucket: bucket,
-                            VersioningConfiguration: {
-                                Status: 'Enabled',
-                            },
-                        };
-                        versioning = true;
-                        return s3.putBucketVersioning(params, err => next(err));
-                    } else if (versioning && obj.isNull === true) {
-                        const params = {
-                            Bucket: bucket,
-                            VersioningConfiguration: {
-                                Status: 'Suspended',
-                            },
-                        };
-                        versioning = false;
-                        return s3.putBucketVersioning(params, err => next(err));
-                    }
-                    return next();
-                },
-                next => {
-                    if (obj.value === null) {
-                        return s3.deleteObject({
-                            Bucket: bucket,
-                            Key: obj.name,
-                        }, function test(err) {
-                            const headers = this.httpResponse.headers;
-                            assert.strictEqual(headers['x-amz-delete-marker'],
-                                'true');
-                            return next(err);
-                        });
-                    }
-                    return s3.putObject({
-                        Bucket: bucket,
-                        Key: obj.name,
-                        Body: obj.value,
-                    }, err => next(err));
-                },
-            ], err => next(err));
-        }, err => done(err));
-    });
-
-    [
-        {
-            name: 'basic listing',
-            params: {},
-            expectedResult: [
-                'Pâtisserie=中文-español-English',
-                'notes/spring/1.txt',
-                'notes/spring/march/1.txt',
-                'notes/summer/1.txt',
-                'notes/summer/2.txt',
-                'notes/summer/august/1.txt',
-                'notes/year.txt',
-                'notes/yore.rs',
-                'notes/zaphod/Beeblebrox.txt',
-            ],
-            commonPrefix: [],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with valid marker',
-            params: { Marker: 'notes/summer/1.txt' },
-            expectedResult: [
-                'notes/summer/2.txt',
-                'notes/summer/august/1.txt',
-                'notes/year.txt',
-                'notes/yore.rs',
-                'notes/zaphod/Beeblebrox.txt',
-            ],
-            commonPrefix: [],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with bad marker',
-            params: { Marker: 'zzzz', Delimiter: '/' },
-            expectedResult: [],
-            commonPrefix: [],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with maxKeys',
-            params: { MaxKeys: 3 },
-            expectedResult: [
-                'Pâtisserie=中文-español-English',
-                'notes/spring/1.txt',
-                'notes/spring/march/1.txt',
-            ],
-            commonPrefix: [],
-            isTruncated: true,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with big maxKeys',
-            params: { MaxKeys: 15000 },
-            expectedResult: [
-                'Pâtisserie=中文-español-English',
-                'notes/spring/1.txt',
-                'notes/spring/march/1.txt',
-                'notes/summer/1.txt',
-                'notes/summer/2.txt',
-                'notes/summer/august/1.txt',
-                'notes/year.txt',
-                'notes/yore.rs',
-                'notes/zaphod/Beeblebrox.txt',
-            ],
-            commonPrefix: [],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with delimiter',
-            params: { Delimiter: '/' },
-            expectedResult: [
-                'Pâtisserie=中文-español-English',
-            ],
-            commonPrefix: ['notes/'],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'with long delimiter',
-            params: { Delimiter: 'notes/summer' },
-            expectedResult: [
-                'Pâtisserie=中文-español-English',
-                'notes/spring/1.txt',
-                'notes/spring/march/1.txt',
-                'notes/year.txt',
-                'notes/yore.rs',
-                'notes/zaphod/Beeblebrox.txt',
-            ],
-            commonPrefix: ['notes/summer'],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'bad marker and good prefix',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/summer/',
-                Marker: 'notes/summer0',
-            },
-            expectedResult: [],
-            commonPrefix: [],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'delimiter and prefix (related to #147)',
-            params: { Delimiter: '/', Prefix: 'notes/' },
-            expectedResult: [
-                'notes/year.txt',
-                'notes/yore.rs',
-            ],
-            commonPrefix: [
-                'notes/spring/',
-                'notes/summer/',
-                'notes/zaphod/',
-            ],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'delimiter, prefix and marker (related to #147)',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/year.txt',
-            },
-            expectedResult: ['notes/yore.rs'],
-            commonPrefix: ['notes/zaphod/'],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-        {
-            name: 'all parameters 1/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/spring/'],
-            isTruncated: true,
-            nextMarker: 'notes/spring/',
-        },
-        {
-            name: 'all parameters 2/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/spring/',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/summer/'],
-            isTruncated: true,
-            nextMarker: 'notes/summer/',
-        },
-        {
-            name: 'all parameters 3/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/summer/',
-                MaxKeys: 1,
-            },
-            expectedResult: ['notes/year.txt'],
-            commonPrefix: [],
-            isTruncated: true,
-            nextMarker: 'notes/year.txt',
-        },
-        {
-            name: 'all parameters 4/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/year.txt',
-                MaxKeys: 1,
-            },
-            expectedResult: ['notes/yore.rs'],
-            commonPrefix: [],
-            isTruncated: true,
-            nextMarker: 'notes/yore.rs',
-        },
-        {
-            name: 'all parameters 5/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                Marker: 'notes/yore.rs',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/zaphod/'],
-            isTruncated: false,
-            nextMarker: undefined,
-        },
-    ].forEach(test => {
-        it(test.name, done => {
-            const expectedResult = test.expectedResult;
-            s3.listObjects(Object.assign({ Bucket: bucket }, test.params),
-                (err, res) => {
-                    if (err) {
-                        return done(err);
-                    }
-                    res.Contents.forEach(result => {
-                        if (!expectedResult.find(key => key === result.Key)) {
-                            throw new Error(
-                                `listing fail, unexpected key ${result.Key}`);
-                        }
-                    });
-                    res.CommonPrefixes.forEach(cp => {
-                        if (!test.commonPrefix.find(
-                            item => item === cp.Prefix)) {
-                            throw new Error(
-                                `listing fail, unexpected prefix ${cp.Prefix}`);
-                        }
-                    });
-                    assert.strictEqual(res.IsTruncated, test.isTruncated);
-                    assert.strictEqual(res.NextMarker, test.nextMarker);
+                return s3.deleteBucket({ Bucket: bucket }, err => {
+                    assert.strictEqual(err, null,
+                        `Error deleting bucket: ${err}`);
                     return done();
                 });
+            });
+        });
+
+        let versioning = false;
+
+        const objects = [
+            { name: 'notes/summer/august/1.txt', value: 'foo', isNull: true },
+            { name: 'notes/year.txt', value: 'foo', isNull: true },
+            { name: 'notes/yore.rs', value: 'foo', isNull: true },
+            { name: 'notes/zaphod/Beeblebrox.txt', value: 'foo', isNull: true },
+            { name: 'Pâtisserie=中文-español-English', value: 'foo' },
+            { name: 'Pâtisserie=中文-español-English', value: 'bar' },
+            { name: 'notes/spring/1.txt', value: 'qux' },
+            { name: 'notes/spring/1.txt', value: 'foo' },
+            { name: 'notes/spring/1.txt', value: 'bar' },
+            { name: 'notes/spring/2.txt', value: 'foo' },
+            { name: 'notes/spring/2.txt', value: null },
+            { name: 'notes/spring/march/1.txt', value: 'foo' },
+            { name: 'notes/spring/march/1.txt', value: 'bar', isNull: true },
+            { name: 'notes/summer/1.txt', value: 'foo' },
+            { name: 'notes/summer/1.txt', value: 'bar' },
+            { name: 'notes/summer/2.txt', value: 'bar' },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/444.txt', value: null },
+            { name: 'notes/summer/44444.txt', value: null },
+        ];
+
+        it('put objects inside bucket', done => {
+            async.eachSeries(objects, (obj, next) => {
+                async.waterfall([
+                    next => {
+                        if (!versioning && obj.isNull !== true) {
+                            const params = {
+                                Bucket: bucket,
+                                VersioningConfiguration: {
+                                    Status: 'Enabled',
+                                },
+                            };
+                            versioning = true;
+                            return s3.putBucketVersioning(params, err =>
+                                next(err));
+                        } else if (versioning && obj.isNull === true) {
+                            const params = {
+                                Bucket: bucket,
+                                VersioningConfiguration: {
+                                    Status: 'Suspended',
+                                },
+                            };
+                            versioning = false;
+                            return s3.putBucketVersioning(params, err =>
+                                next(err));
+                        }
+                        return next();
+                    },
+                    next => {
+                        if (obj.value === null) {
+                            return s3.deleteObject({
+                                Bucket: bucket,
+                                Key: obj.name,
+                            }, function test(err) {
+                                const headers = this.httpResponse.headers;
+                                assert.strictEqual(
+                                    headers['x-amz-delete-marker'], 'true');
+                                return next(err);
+                            });
+                        }
+                        return s3.putObject({
+                            Bucket: bucket,
+                            Key: obj.name,
+                            Body: obj.value,
+                        }, err => next(err));
+                    },
+                ], err => next(err));
+            }, err => done(err));
+        });
+
+        [
+            {
+                name: 'basic listing',
+                params: {},
+                expectedResult: [
+                    'Pâtisserie=中文-español-English',
+                    'notes/spring/1.txt',
+                    'notes/spring/march/1.txt',
+                    'notes/summer/1.txt',
+                    'notes/summer/2.txt',
+                    'notes/summer/august/1.txt',
+                    'notes/year.txt',
+                    'notes/yore.rs',
+                    'notes/zaphod/Beeblebrox.txt',
+                ],
+                commonPrefix: [],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with valid marker',
+                params: { Marker: 'notes/summer/1.txt' },
+                expectedResult: [
+                    'notes/summer/2.txt',
+                    'notes/summer/august/1.txt',
+                    'notes/year.txt',
+                    'notes/yore.rs',
+                    'notes/zaphod/Beeblebrox.txt',
+                ],
+                commonPrefix: [],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with bad marker',
+                params: { Marker: 'zzzz', Delimiter: '/' },
+                expectedResult: [],
+                commonPrefix: [],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with maxKeys',
+                params: { MaxKeys: 3 },
+                expectedResult: [
+                    'Pâtisserie=中文-español-English',
+                    'notes/spring/1.txt',
+                    'notes/spring/march/1.txt',
+                ],
+                commonPrefix: [],
+                isTruncated: true,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with big maxKeys',
+                params: { MaxKeys: 15000 },
+                expectedResult: [
+                    'Pâtisserie=中文-español-English',
+                    'notes/spring/1.txt',
+                    'notes/spring/march/1.txt',
+                    'notes/summer/1.txt',
+                    'notes/summer/2.txt',
+                    'notes/summer/august/1.txt',
+                    'notes/year.txt',
+                    'notes/yore.rs',
+                    'notes/zaphod/Beeblebrox.txt',
+                ],
+                commonPrefix: [],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with delimiter',
+                params: { Delimiter: '/' },
+                expectedResult: [
+                    'Pâtisserie=中文-español-English',
+                ],
+                commonPrefix: ['notes/'],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'with long delimiter',
+                params: { Delimiter: 'notes/summer' },
+                expectedResult: [
+                    'Pâtisserie=中文-español-English',
+                    'notes/spring/1.txt',
+                    'notes/spring/march/1.txt',
+                    'notes/year.txt',
+                    'notes/yore.rs',
+                    'notes/zaphod/Beeblebrox.txt',
+                ],
+                commonPrefix: ['notes/summer'],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'bad marker and good prefix',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/summer/',
+                    Marker: 'notes/summer0',
+                },
+                expectedResult: [],
+                commonPrefix: [],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'delimiter and prefix (related to #147)',
+                params: { Delimiter: '/', Prefix: 'notes/' },
+                expectedResult: [
+                    'notes/year.txt',
+                    'notes/yore.rs',
+                ],
+                commonPrefix: [
+                    'notes/spring/',
+                    'notes/summer/',
+                    'notes/zaphod/',
+                ],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'delimiter, prefix and marker (related to #147)',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/year.txt',
+                },
+                expectedResult: ['notes/yore.rs'],
+                commonPrefix: ['notes/zaphod/'],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+            {
+                name: 'all parameters 1/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/spring/'],
+                isTruncated: true,
+                nextMarker: 'notes/spring/',
+            },
+            {
+                name: 'all parameters 2/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/spring/',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/summer/'],
+                isTruncated: true,
+                nextMarker: 'notes/summer/',
+            },
+            {
+                name: 'all parameters 3/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/summer/',
+                    MaxKeys: 1,
+                },
+                expectedResult: ['notes/year.txt'],
+                commonPrefix: [],
+                isTruncated: true,
+                nextMarker: 'notes/year.txt',
+            },
+            {
+                name: 'all parameters 4/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/year.txt',
+                    MaxKeys: 1,
+                },
+                expectedResult: ['notes/yore.rs'],
+                commonPrefix: [],
+                isTruncated: true,
+                nextMarker: 'notes/yore.rs',
+            },
+            {
+                name: 'all parameters 5/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    Marker: 'notes/yore.rs',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/zaphod/'],
+                isTruncated: false,
+                nextMarker: undefined,
+            },
+        ].forEach(test => {
+            it(test.name, done => {
+                const expectedResult = test.expectedResult;
+                s3.listObjects(Object.assign({ Bucket: bucket }, test.params),
+                    (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        res.Contents.forEach(result => {
+                            if (!expectedResult
+                                .find(key => key === result.Key)) {
+                                throw new Error('listing fail, ' +
+                                `unexpected key ${result.Key}`);
+                            }
+                        });
+                        res.CommonPrefixes.forEach(cp => {
+                            if (!test.commonPrefix
+                                .find(item => item === cp.Prefix)) {
+                                throw new Error('listing fail, ' +
+                                `unexpected prefix ${cp.Prefix}`);
+                            }
+                        });
+                        assert.strictEqual(res.IsTruncated, test.isTruncated);
+                        assert.strictEqual(res.NextMarker, test.nextMarker);
+                        return done();
+                    });
+            });
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/listObjectVersions.js
+++ b/tests/functional/aws-node-sdk/test/versioning/listObjectVersions.js
@@ -1,8 +1,10 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
 
-import getConfig from '../support/config';
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+import { removeAllVersions } from '../../lib/utility/versioning-util';
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
@@ -11,389 +13,371 @@ const testing = process.env.VERSIONING === 'no' ?
 
 testing('listObject - Delimiter version', function testSuite() {
     this.timeout(600000);
-    let s3 = undefined;
 
-    function _deleteVersionList(versionList, bucket, callback) {
-        async.each(versionList, (versionInfo, cb) => {
-            const versionId = versionInfo.VersionId;
-            const params = { Bucket: bucket, Key: versionInfo.Key,
-            VersionId: versionId };
-            s3.deleteObject(params, cb);
-        }, callback);
-    }
-    function _removeAllVersions(bucket, callback) {
-        return s3.listObjectVersions({ Bucket: bucket }, (err, data) => {
-            if (err && err.NoSuchBucket) {
-                return callback();
-            } else if (err) {
-                return callback(err);
-            }
-            return _deleteVersionList(data.DeleteMarkers, bucket, err => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+
+        // setup test
+        before(done => {
+            s3.createBucket({ Bucket: bucket }, done);
+        });
+
+        // delete bucket after testing
+        after(done => {
+            removeAllVersions({ Bucket: bucket }, err => {
                 if (err) {
-                    return callback(err);
+                    return done(err);
                 }
-                return _deleteVersionList(data.Versions, bucket, callback);
-            });
-        });
-    }
-
-    // setup test
-    before(done => {
-        const config = getConfig('default', { signatureVersion: 'v4' });
-        s3 = new S3(config);
-        s3.createBucket({ Bucket: bucket }, done);
-    });
-
-    // delete bucket after testing
-    after(done => {
-        _removeAllVersions(bucket, err => {
-            if (err) {
-                return done(err);
-            }
-            return s3.deleteBucket({ Bucket: bucket }, err => {
-                assert.strictEqual(err, null,
-                    `Error deleting bucket: ${err}`);
-                return done();
-            });
-        });
-    });
-
-    let versioning = false;
-
-    const objects = [
-        { name: 'notes/summer/august/1.txt', value: 'foo', isNull: true },
-        { name: 'notes/year.txt', value: 'foo', isNull: true },
-        { name: 'notes/yore.rs', value: 'foo', isNull: true },
-        { name: 'notes/zaphod/Beeblebrox.txt', value: 'foo', isNull: true },
-        { name: 'Pâtisserie=中文-español-English', value: 'foo' },
-        { name: 'Pâtisserie=中文-español-English', value: 'bar' },
-        { name: 'notes/spring/1.txt', value: 'qux' },
-        { name: 'notes/spring/1.txt', value: 'foo' },
-        { name: 'notes/spring/1.txt', value: 'bar' },
-        { name: 'notes/spring/2.txt', value: 'foo' },
-        { name: 'notes/spring/2.txt', value: null },
-        { name: 'notes/spring/march/1.txt', value: 'foo' },
-        { name: 'notes/spring/march/1.txt', value: 'bar', isNull: true },
-        { name: 'notes/summer/1.txt', value: 'foo' },
-        { name: 'notes/summer/1.txt', value: 'bar' },
-        { name: 'notes/summer/2.txt', value: 'bar' },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/4.txt', value: null },
-        { name: 'notes/summer/444.txt', value: null },
-        { name: 'notes/summer/44444.txt', value: null },
-    ];
-
-    it('put objects inside bucket', done => {
-        async.eachSeries(objects, (obj, next) => {
-            async.waterfall([
-                next => {
-                    if (!versioning && obj.isNull !== true) {
-                        const params = {
-                            Bucket: bucket,
-                            VersioningConfiguration: {
-                                Status: 'Enabled',
-                            },
-                        };
-                        versioning = true;
-                        return s3.putBucketVersioning(params, err => next(err));
-                    } else if (versioning && obj.isNull === true) {
-                        const params = {
-                            Bucket: bucket,
-                            VersioningConfiguration: {
-                                Status: 'Suspended',
-                            },
-                        };
-                        versioning = false;
-                        return s3.putBucketVersioning(params, err => next(err));
-                    }
-                    return next();
-                },
-                next => {
-                    if (obj.value === null) {
-                        return s3.deleteObject({
-                            Bucket: bucket,
-                            Key: obj.name,
-                        }, function test(err) {
-                            const headers = this.httpResponse.headers;
-                            assert.strictEqual(headers['x-amz-delete-marker'],
-                                'true');
-                            // eslint-disable-next-line no-param-reassign
-                            obj.versionId = headers['x-amz-version-id'];
-                            return next(err);
-                        });
-                    }
-                    return s3.putObject({
-                        Bucket: bucket,
-                        Key: obj.name,
-                        Body: obj.value,
-                    }, (err, res) => {
-                        if (err) {
-                            return next(err);
-                        }
-                        // eslint-disable-next-line no-param-reassign
-                        obj.versionId = res.VersionId || 'null';
-                        return next();
-                    });
-                },
-            ], err => next(err));
-        }, err => done(err));
-    });
-
-    [
-        {
-            name: 'basic listing',
-            params: {},
-            expectedResult: objects,
-            commonPrefix: [],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'with valid key marker',
-            params: { KeyMarker: 'notes/spring/1.txt' },
-            expectedResult: [
-                objects[0],
-                objects[1],
-                objects[2],
-                objects[3],
-                objects[9],
-                objects[10],
-                objects[11],
-                objects[12],
-                objects[13],
-                objects[14],
-                objects[15],
-                objects[16],
-                objects[17],
-                objects[18],
-                objects[19],
-                objects[20],
-            ],
-            commonPrefix: [],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'with bad key marker',
-            params: { KeyMarker: 'zzzz', Delimiter: '/' },
-            expectedResult: [],
-            commonPrefix: [],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'with maxKeys',
-            params: { MaxKeys: 3 },
-            expectedResult: [
-                objects[4],
-                objects[5],
-                objects[8],
-            ],
-            commonPrefix: [],
-            isTruncated: true,
-            nextKeyMarker: objects[8].name,
-            nextVersionIdMarker: objects[8],
-        },
-        {
-            name: 'with big maxKeys',
-            params: { MaxKeys: 15000 },
-            expectedResult: objects,
-            commonPrefix: [],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'with delimiter',
-            params: { Delimiter: '/' },
-            expectedResult: objects.slice(4, 6),
-            commonPrefix: ['notes/'],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'with long delimiter',
-            params: { Delimiter: 'notes/summer' },
-            expectedResult: objects.filter(obj =>
-                obj.name.indexOf('notes/summer') < 0),
-            commonPrefix: ['notes/summer'],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'bad key marker and good prefix',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/summer/',
-                KeyMarker: 'notes/summer0',
-            },
-            expectedResult: [],
-            commonPrefix: [],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'delimiter and prefix (related to #147)',
-            params: { Delimiter: '/', Prefix: 'notes/' },
-            expectedResult: [
-                objects[1],
-                objects[2],
-            ],
-            commonPrefix: [
-                'notes/spring/',
-                'notes/summer/',
-                'notes/zaphod/',
-            ],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'delimiter, prefix and marker (related to #147)',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/year.txt',
-            },
-            expectedResult: [objects[2]],
-            commonPrefix: ['notes/zaphod/'],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'all parameters 1/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/spring/'],
-            isTruncated: true,
-            nextKeyMarker: 'notes/spring/',
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'all parameters 2/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/spring/',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/summer/'],
-            isTruncated: true,
-            nextKeyMarker: 'notes/summer/',
-            nextVersionIdMarker: undefined,
-        },
-        {
-            name: 'all parameters 3/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/summer/',
-                MaxKeys: 1,
-            },
-            expectedResult: [objects[1]],
-            commonPrefix: [],
-            isTruncated: true,
-            nextKeyMarker: objects[1].name,
-            nextVersionIdMarker: objects[1],
-        },
-        {
-            name: 'all parameters 4/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/year.txt',
-                MaxKeys: 1,
-            },
-            expectedResult: [objects[2]],
-            commonPrefix: [],
-            isTruncated: true,
-            nextKeyMarker: objects[2].name,
-            nextVersionIdMarker: objects[2],
-        },
-        {
-            name: 'all parameters 5/5',
-            params: {
-                Delimiter: '/',
-                Prefix: 'notes/',
-                KeyMarker: 'notes/yore.rs',
-                MaxKeys: 1,
-            },
-            expectedResult: [],
-            commonPrefix: ['notes/zaphod/'],
-            isTruncated: false,
-            nextKeyMarker: undefined,
-            nextVersionIdMarker: undefined,
-        },
-    ].forEach(test => {
-        it(test.name, done => {
-            const expectedResult = test.expectedResult;
-            s3.listObjectVersions(
-                Object.assign({ Bucket: bucket }, test.params),
-                (err, res) => {
-                    if (err) {
-                        return done(err);
-                    }
-                    res.Versions.forEach(result => {
-                        const item = expectedResult.find(obj => {
-                            if (obj.name === result.Key &&
-                                obj.versionId === result.VersionId &&
-                                obj.value !== null) {
-                                return true;
-                            }
-                            return false;
-                        });
-                        if (!item) {
-                            throw new Error(
-                                `listing fail, unexpected key ${result.Key} ` +
-                                `with version ${result.VersionId}`);
-                        }
-                    });
-                    res.DeleteMarkers.forEach(result => {
-                        const item = expectedResult.find(obj => {
-                            if (obj.name === result.Key &&
-                                obj.versionId === result.VersionId &&
-                                obj.value === null) {
-                                return true;
-                            }
-                            return false;
-                        });
-                        if (!item) {
-                            throw new Error(
-                                `listing fail, unexpected key ${result.Key} ` +
-                                `with version ${result.VersionId}`);
-                        }
-                    });
-                    res.CommonPrefixes.forEach(cp => {
-                        if (!test.commonPrefix.find(
-                            item => item === cp.Prefix)) {
-                            throw new Error(
-                                `listing fail, unexpected prefix ${cp.Prefix}`);
-                        }
-                    });
-                    assert.strictEqual(res.IsTruncated, test.isTruncated);
-                    assert.strictEqual(res.NextKeyMarker, test.nextKeyMarker);
-                    if (!test.nextVersionIdMarker) {
-                        // eslint-disable-next-line no-param-reassign
-                        test.nextVersionIdMarker = {};
-                    }
-                    assert.strictEqual(res.NextVersionIdMarker,
-                        test.nextVersionIdMarker.versionId);
+                return s3.deleteBucket({ Bucket: bucket }, err => {
+                    assert.strictEqual(err, null,
+                        `Error deleting bucket: ${err}`);
                     return done();
                 });
+            });
+        });
+
+        let versioning = false;
+
+        const objects = [
+            { name: 'notes/summer/august/1.txt', value: 'foo', isNull: true },
+            { name: 'notes/year.txt', value: 'foo', isNull: true },
+            { name: 'notes/yore.rs', value: 'foo', isNull: true },
+            { name: 'notes/zaphod/Beeblebrox.txt', value: 'foo', isNull: true },
+            { name: 'Pâtisserie=中文-español-English', value: 'foo' },
+            { name: 'Pâtisserie=中文-español-English', value: 'bar' },
+            { name: 'notes/spring/1.txt', value: 'qux' },
+            { name: 'notes/spring/1.txt', value: 'foo' },
+            { name: 'notes/spring/1.txt', value: 'bar' },
+            { name: 'notes/spring/2.txt', value: 'foo' },
+            { name: 'notes/spring/2.txt', value: null },
+            { name: 'notes/spring/march/1.txt', value: 'foo' },
+            { name: 'notes/spring/march/1.txt', value: 'bar', isNull: true },
+            { name: 'notes/summer/1.txt', value: 'foo' },
+            { name: 'notes/summer/1.txt', value: 'bar' },
+            { name: 'notes/summer/2.txt', value: 'bar' },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/4.txt', value: null },
+            { name: 'notes/summer/444.txt', value: null },
+            { name: 'notes/summer/44444.txt', value: null },
+        ];
+
+        it('put objects inside bucket', done => {
+            async.eachSeries(objects, (obj, next) => {
+                async.waterfall([
+                    next => {
+                        if (!versioning && obj.isNull !== true) {
+                            const params = {
+                                Bucket: bucket,
+                                VersioningConfiguration: {
+                                    Status: 'Enabled',
+                                },
+                            };
+                            versioning = true;
+                            return s3.putBucketVersioning(params,
+                                err => next(err));
+                        } else if (versioning && obj.isNull === true) {
+                            const params = {
+                                Bucket: bucket,
+                                VersioningConfiguration: {
+                                    Status: 'Suspended',
+                                },
+                            };
+                            versioning = false;
+                            return s3.putBucketVersioning(params,
+                                err => next(err));
+                        }
+                        return next();
+                    },
+                    next => {
+                        if (obj.value === null) {
+                            return s3.deleteObject({
+                                Bucket: bucket,
+                                Key: obj.name,
+                            }, function test(err) {
+                                const headers = this.httpResponse.headers;
+                                assert.strictEqual(
+                                    headers['x-amz-delete-marker'],
+                                    'true');
+                                // eslint-disable-next-line no-param-reassign
+                                obj.versionId = headers['x-amz-version-id'];
+                                return next(err);
+                            });
+                        }
+                        return s3.putObject({
+                            Bucket: bucket,
+                            Key: obj.name,
+                            Body: obj.value,
+                        }, (err, res) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            // eslint-disable-next-line no-param-reassign
+                            obj.versionId = res.VersionId || 'null';
+                            return next();
+                        });
+                    },
+                ], err => next(err));
+            }, err => done(err));
+        });
+
+        [
+            {
+                name: 'basic listing',
+                params: {},
+                expectedResult: objects,
+                commonPrefix: [],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'with valid key marker',
+                params: { KeyMarker: 'notes/spring/1.txt' },
+                expectedResult: [
+                    objects[0],
+                    objects[1],
+                    objects[2],
+                    objects[3],
+                    objects[9],
+                    objects[10],
+                    objects[11],
+                    objects[12],
+                    objects[13],
+                    objects[14],
+                    objects[15],
+                    objects[16],
+                    objects[17],
+                    objects[18],
+                    objects[19],
+                    objects[20],
+                ],
+                commonPrefix: [],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'with bad key marker',
+                params: { KeyMarker: 'zzzz', Delimiter: '/' },
+                expectedResult: [],
+                commonPrefix: [],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'with maxKeys',
+                params: { MaxKeys: 3 },
+                expectedResult: [
+                    objects[4],
+                    objects[5],
+                    objects[8],
+                ],
+                commonPrefix: [],
+                isTruncated: true,
+                nextKeyMarker: objects[8].name,
+                nextVersionIdMarker: objects[8],
+            },
+            {
+                name: 'with big maxKeys',
+                params: { MaxKeys: 15000 },
+                expectedResult: objects,
+                commonPrefix: [],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'with delimiter',
+                params: { Delimiter: '/' },
+                expectedResult: objects.slice(4, 6),
+                commonPrefix: ['notes/'],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'with long delimiter',
+                params: { Delimiter: 'notes/summer' },
+                expectedResult: objects.filter(obj =>
+                    obj.name.indexOf('notes/summer') < 0),
+                commonPrefix: ['notes/summer'],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'bad key marker and good prefix',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/summer/',
+                    KeyMarker: 'notes/summer0',
+                },
+                expectedResult: [],
+                commonPrefix: [],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'delimiter and prefix (related to #147)',
+                params: { Delimiter: '/', Prefix: 'notes/' },
+                expectedResult: [
+                    objects[1],
+                    objects[2],
+                ],
+                commonPrefix: [
+                    'notes/spring/',
+                    'notes/summer/',
+                    'notes/zaphod/',
+                ],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'delimiter, prefix and marker (related to #147)',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/year.txt',
+                },
+                expectedResult: [objects[2]],
+                commonPrefix: ['notes/zaphod/'],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'all parameters 1/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/spring/'],
+                isTruncated: true,
+                nextKeyMarker: 'notes/spring/',
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'all parameters 2/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/spring/',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/summer/'],
+                isTruncated: true,
+                nextKeyMarker: 'notes/summer/',
+                nextVersionIdMarker: undefined,
+            },
+            {
+                name: 'all parameters 3/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/summer/',
+                    MaxKeys: 1,
+                },
+                expectedResult: [objects[1]],
+                commonPrefix: [],
+                isTruncated: true,
+                nextKeyMarker: objects[1].name,
+                nextVersionIdMarker: objects[1],
+            },
+            {
+                name: 'all parameters 4/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/year.txt',
+                    MaxKeys: 1,
+                },
+                expectedResult: [objects[2]],
+                commonPrefix: [],
+                isTruncated: true,
+                nextKeyMarker: objects[2].name,
+                nextVersionIdMarker: objects[2],
+            },
+            {
+                name: 'all parameters 5/5',
+                params: {
+                    Delimiter: '/',
+                    Prefix: 'notes/',
+                    KeyMarker: 'notes/yore.rs',
+                    MaxKeys: 1,
+                },
+                expectedResult: [],
+                commonPrefix: ['notes/zaphod/'],
+                isTruncated: false,
+                nextKeyMarker: undefined,
+                nextVersionIdMarker: undefined,
+            },
+        ].forEach(test => {
+            it(test.name, done => {
+                const expectedResult = test.expectedResult;
+                s3.listObjectVersions(
+                    Object.assign({ Bucket: bucket }, test.params),
+                    (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        res.Versions.forEach(result => {
+                            const item = expectedResult.find(obj => {
+                                if (obj.name === result.Key &&
+                                    obj.versionId === result.VersionId &&
+                                    obj.value !== null) {
+                                    return true;
+                                }
+                                return false;
+                            });
+                            if (!item) {
+                                throw new Error('listing fail, ' +
+                                    `unexpected key ${result.Key} ` +
+                                    `with version ${result.VersionId}`);
+                            }
+                        });
+                        res.DeleteMarkers.forEach(result => {
+                            const item = expectedResult.find(obj => {
+                                if (obj.name === result.Key &&
+                                    obj.versionId === result.VersionId &&
+                                    obj.value === null) {
+                                    return true;
+                                }
+                                return false;
+                            });
+                            if (!item) {
+                                throw new Error('listing fail, ' +
+                                    `unexpected key ${result.Key} ` +
+                                    `with version ${result.VersionId}`);
+                            }
+                        });
+                        res.CommonPrefixes.forEach(cp => {
+                            if (!test.commonPrefix.find(
+                                item => item === cp.Prefix)) {
+                                throw new Error('listing fail, ' +
+                                    `unexpected prefix ${cp.Prefix}`);
+                            }
+                        });
+                        assert.strictEqual(res.IsTruncated, test.isTruncated);
+                        assert.strictEqual(res.NextKeyMarker,
+                            test.nextKeyMarker);
+                        if (!test.nextVersionIdMarker) {
+                            // eslint-disable-next-line no-param-reassign
+                            test.nextVersionIdMarker = {};
+                        }
+                        assert.strictEqual(res.NextVersionIdMarker,
+                            test.nextVersionIdMarker.versionId);
+                        return done();
+                    });
+            });
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/multiObjectDelete.js
@@ -1,5 +1,7 @@
 import assert from 'assert';
 import async from 'async';
+
+import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
 
 const bucketName = `multi-object-delete-${Date.now()}`;
@@ -26,112 +28,113 @@ const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 
 testing('Multi-Object Versioning Delete Success', function success() {
     this.timeout(360000);
-    let bucketUtil;
-    let s3;
-    let objectsRes;
 
-    beforeEach(done => {
-        bucketUtil = new BucketUtility('default', {
-            signatureVersion: 'v4',
-        });
-        s3 = bucketUtil.s3;
-        async.waterfall([
-            next => s3.createBucket({ Bucket: bucketName }, err => next(err)),
-            next => s3.putBucketVersioning({
-                Bucket: bucketName,
-                VersioningConfiguration: {
-                    Status: 'Enabled',
-                },
-            }, err => next(err)),
-            next => {
-                const objects = [];
-                for (let i = 1; i < 1001; i ++) {
-                    objects.push(`${key}${i}`);
-                }
-                async.mapLimit(objects, 20, (key, next) => {
-                    s3.putObject({
-                        Bucket: bucketName,
-                        Key: key,
-                        Body: 'somebody',
-                    }, (err, res) => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let objectsRes;
+
+        beforeEach(done => {
+            async.waterfall([
+                next => s3.createBucket({ Bucket: bucketName },
+                    err => next(err)),
+                next => s3.putBucketVersioning({
+                    Bucket: bucketName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    },
+                }, err => next(err)),
+                next => {
+                    const objects = [];
+                    for (let i = 1; i < 1001; i ++) {
+                        objects.push(`${key}${i}`);
+                    }
+                    async.mapLimit(objects, 20, (key, next) => {
+                        s3.putObject({
+                            Bucket: bucketName,
+                            Key: key,
+                            Body: 'somebody',
+                        }, (err, res) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            // eslint-disable-next-line no-param-reassign
+                            res.Key = key;
+                            return next(null, res);
+                        });
+                    }, (err, results) => {
                         if (err) {
                             return next(err);
                         }
-                        // eslint-disable-next-line no-param-reassign
-                        res.Key = key;
-                        return next(null, res);
+                        objectsRes = results;
+                        return next();
                     });
-                }, (err, results) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    objectsRes = results;
-                    return next();
-                });
-            },
-        ], err => done(err));
-    });
-
-    afterEach(() => s3.deleteBucketAsync({ Bucket: bucketName }));
-
-    it('should batch delete 1000 objects quietly', () => {
-        const objects = objectsRes.slice(0, 1000).map(obj =>
-            ({ Key: obj.Key, VersionId: obj.VersionId }));
-        return s3.deleteObjectsAsync({
-            Bucket: bucketName,
-            Delete: {
-                Objects: objects,
-                Quiet: true,
-            },
-        }).then(res => {
-            assert.strictEqual(res.Deleted.length, 0);
-            assert.strictEqual(res.Errors.length, 0);
-        }).catch(err => {
-            checkNoError(err);
+                },
+            ], err => done(err));
         });
-    });
 
-    it('should batch delete 1000 objects', () => {
-        const objects = objectsRes.slice(0, 1000).map(obj =>
-            ({ Key: obj.Key, VersionId: obj.VersionId }));
-        return s3.deleteObjectsAsync({
-            Bucket: bucketName,
-            Delete: {
-                Objects: objects,
-                Quiet: false,
-            },
-        }).then(res => {
-            assert.strictEqual(res.Deleted.length, 1000);
-            // order of returned objects not sorted
-            assert.deepStrictEqual(sortList(res.Deleted), sortList(objects));
-            assert.strictEqual(res.Errors.length, 0);
-        }).catch(err => {
-            checkNoError(err);
-        });
-    });
+        afterEach(() => s3.deleteBucketAsync({ Bucket: bucketName }));
 
-    it('should not send back error if one versionId is invalid', () => {
-        const objects = objectsRes.slice(0, 1000).map(obj =>
-            ({ Key: obj.Key, VersionId: obj.VersionId }));
-        const prevVersion = objects[0].VersionId;
-        objects[0].VersionId = 'invalid-version-id';
-        return s3.deleteObjectsAsync({
-            Bucket: bucketName,
-            Delete: {
-                Objects: objects,
-            },
-        }).then(res =>
-            s3.deleteObjectAsync({
+        it('should batch delete 1000 objects quietly', () => {
+            const objects = objectsRes.slice(0, 1000).map(obj =>
+                ({ Key: obj.Key, VersionId: obj.VersionId }));
+            return s3.deleteObjectsAsync({
                 Bucket: bucketName,
-                Key: objects[0].Key,
-                VersionId: prevVersion,
-            }).then(() => {
-                assert.strictEqual(res.Deleted.length, 999);
-                assert.strictEqual(res.Errors.length, 1);
-                assert.strictEqual(res.Errors[0].Code, 'NoSuchVersion');
-            })
-        ).catch(err => {
-            checkNoError(err);
+                Delete: {
+                    Objects: objects,
+                    Quiet: true,
+                },
+            }).then(res => {
+                assert.strictEqual(res.Deleted.length, 0);
+                assert.strictEqual(res.Errors.length, 0);
+            }).catch(err => {
+                checkNoError(err);
+            });
+        });
+
+        it('should batch delete 1000 objects', () => {
+            const objects = objectsRes.slice(0, 1000).map(obj =>
+                ({ Key: obj.Key, VersionId: obj.VersionId }));
+            return s3.deleteObjectsAsync({
+                Bucket: bucketName,
+                Delete: {
+                    Objects: objects,
+                    Quiet: false,
+                },
+            }).then(res => {
+                assert.strictEqual(res.Deleted.length, 1000);
+                // order of returned objects not sorted
+                assert.deepStrictEqual(sortList(res.Deleted),
+                    sortList(objects));
+                assert.strictEqual(res.Errors.length, 0);
+            }).catch(err => {
+                checkNoError(err);
+            });
+        });
+
+        it('should not send back error if one versionId is invalid', () => {
+            const objects = objectsRes.slice(0, 1000).map(obj =>
+                ({ Key: obj.Key, VersionId: obj.VersionId }));
+            const prevVersion = objects[0].VersionId;
+            objects[0].VersionId = 'invalid-version-id';
+            return s3.deleteObjectsAsync({
+                Bucket: bucketName,
+                Delete: {
+                    Objects: objects,
+                },
+            }).then(res =>
+                s3.deleteObjectAsync({
+                    Bucket: bucketName,
+                    Key: objects[0].Key,
+                    VersionId: prevVersion,
+                }).then(() => {
+                    assert.strictEqual(res.Deleted.length, 999);
+                    assert.strictEqual(res.Errors.length, 1);
+                    assert.strictEqual(res.Errors[0].Code, 'NoSuchVersion');
+                })
+            ).catch(err => {
+                checkNoError(err);
+            });
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/objectACL.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectACL.js
@@ -1,275 +1,295 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
 import { versioning } from 'arsenal';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
 import {
     removeAllVersions,
-    constants,
+    versioningEnabled,
+    versioningSuspended,
 } from '../../lib/utility/versioning-util.js';
 
-import getConfig from '../support/config';
-
-const config = getConfig('default', { signatureVersion: 'v4' });
-const s3 = new S3(config);
 const counter = 100;
 let bucket;
 const key = '/';
-const fakeId = 'fakeId';
+const invalidId = 'invalidId';
 const VID_INF = versioning.VersionID.VID_INF;
 const nonExistingId = versioning.VersionID
-    .encrypt(`${VID_INF.slice(VID_INF.length - 1)}7`);
+    .encode(`${VID_INF.slice(VID_INF.length - 1)}7`);
 
 function _assertNoError(err, desc) {
     assert.strictEqual(err, null, `Unexpected err ${desc}: ${err}`);
 }
 
-// need a wrapper because sdk apparently does not include version id in
-// exposed data object for put/get acl methods
-function _wrapDataObject(method, params, callback) {
-    let request = undefined;
-    async.waterfall([
-        next => {
-            request = s3[method](params, next);
-        },
-        (data, next) => {
-            const responseHeaders = request.response.httpResponse.headers;
-            const dataObj = Object.assign({
-                VersionId: responseHeaders['x-amz-version-id'],
-            }, data);
-            return next(null, dataObj);
-        },
-    ], callback);
-}
-
-function _getObjectAcl(params, callback) {
-    _wrapDataObject('getObjectAcl', params, callback);
-}
-
-function _putObjectAcl(params, callback) {
-    _wrapDataObject('putObjectAcl', params, callback);
-}
-
-function _putAndGetAcl(cannedAcl, versionId, putResVerId, getResVerId, cb) {
-    const params = {
-        Bucket: bucket,
-        Key: key,
-        ACL: cannedAcl,
-    };
-    if (versionId) {
-        params.VersionId = versionId;
-    }
-    _putObjectAcl(params, (err, data) => {
-        _assertNoError(err, `putting object acl with version id: ${versionId}`);
-        assert.strictEqual(data.VersionId, putResVerId,
-            `expected version id '${putResVerId}' in putacl res headers, ` +
-            `got '${data.VersionId}' instead`);
-        delete params.ACL;
-        _getObjectAcl(params, (err, data) => {
-            _assertNoError(err,
-                `getting object acl with version id: ${versionId}`);
-            assert.strictEqual(data.VersionId, getResVerId,
-                `expected version id '${getResVerId}' in getacl res headers, ` +
-                `got '${data.VersionId}' instead`);
-            assert.strictEqual(data.Grants.length, 2);
-            cb();
-        });
-    });
-}
-
-function _testBehaviorVersioningEnabledOrSuspended(versionIds) {
-    it('non-version specific put and get ACL should target latest ' +
-    'version AND return version ID in response headers', done => {
-        const latestVersion = versionIds[versionIds.length - 1];
-        _putAndGetAcl('public-read', undefined, latestVersion,
-            latestVersion, done);
-    });
-
-    it('version specific put and get ACL should return version ID ' +
-    'in response headers', done => {
-        const firstVersion = versionIds[0];
-        _putAndGetAcl('public-read', firstVersion, firstVersion,
-            firstVersion, done);
-    });
-
-    it('version specific put and get ACL (version id = "null") ' +
-    'should return version ID ("null") in response headers', done => {
-        _putAndGetAcl('public-read', 'null', 'null', 'null', done);
-    });
-}
-
 const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 
-testing('put and get object acl with versioning', function testSuite() {
-    this.timeout(600000);
+testing('put and get object acl with versioning', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
 
-    beforeEach(done => {
-        bucket = `versioning-bucket-acl-${Date.now()}`;
-        s3.createBucket({ Bucket: bucket }, done);
-    });
+        // need a wrapper because sdk apparently does not include version id in
+        // exposed data object for put/get acl methods
+        function _wrapDataObject(method, params, callback) {
+            let request = undefined;
+            async.waterfall([
+                next => {
+                    request = s3[method](params, next);
+                },
+                (data, next) => {
+                    const responseHeaders = request.response
+                    .httpResponse.headers;
+                    const dataObj = Object.assign({
+                        VersionId: responseHeaders['x-amz-version-id'],
+                    }, data);
+                    return next(null, dataObj);
+                },
+            ], callback);
+        }
 
-    afterEach(done => {
-        removeAllVersions({ Bucket: bucket }, err => {
-            if (err) {
-                return done(err);
+        function _getObjectAcl(params, callback) {
+            _wrapDataObject('getObjectAcl', params, callback);
+        }
+
+        function _putObjectAcl(params, callback) {
+            _wrapDataObject('putObjectAcl', params, callback);
+        }
+
+        function _putAndGetAcl(cannedAcl, versionId, putResVerId,
+            getResVerId, cb) {
+            const params = {
+                Bucket: bucket,
+                Key: key,
+                ACL: cannedAcl,
+            };
+            if (versionId) {
+                params.VersionId = versionId;
             }
-            return s3.deleteBucket({ Bucket: bucket }, done);
-        });
-    });
-
-    describe('in a bucket without versioning configuration', () => {
-        beforeEach(done => {
-            s3.putObject({ Bucket: bucket, Key: key }, done);
-        });
-
-        it('should not return version id for non-version specific ' +
-        'put and get ACL', done => {
-            _putAndGetAcl('public-read', undefined, undefined, undefined, done);
-        });
-
-        it('should not return version id for version specific ' +
-        'put and get ACL (version id = "null")', done => {
-            _putAndGetAcl('public-read', 'null', undefined, undefined, done);
-        });
-
-        it('should return NoSuchVersion if attempting to put acl for ' +
-        'non-existing version', done => {
-            const params = { Bucket: bucket, Key: key, VersionId: nonExistingId,
-                ACL: 'private' };
-            s3.putObjectAcl(params, err => {
-                assert(err, 'Expected err but did not find one');
-                assert.strictEqual(err.code, 'NoSuchVersion');
-                assert.strictEqual(err.statusCode, 404);
-                done();
+            _putObjectAcl(params, (err, data) => {
+                _assertNoError(err, 'putting object acl with version id:' +
+                    `${versionId}`);
+                assert.strictEqual(data.VersionId, putResVerId,
+                    `expected version id '${putResVerId}' in ` +
+                    `putacl res headers, got '${data.VersionId}' instead`);
+                delete params.ACL;
+                _getObjectAcl(params, (err, data) => {
+                    _assertNoError(err,
+                        `getting object acl with version id: ${versionId}`);
+                    assert.strictEqual(data.VersionId, getResVerId,
+                        `expected version id '${getResVerId}' in ` +
+                        `getacl res headers, got '${data.VersionId}' instead`);
+                    assert.strictEqual(data.Grants.length, 2);
+                    cb();
+                });
             });
-        });
+        }
 
-        it('should return InvalidArgument if attempting to put acl for ' +
-        'invalid id', done => {
-            const params = { Bucket: bucket, Key: key, VersionId: fakeId,
-                ACL: 'private' };
-            s3.putObjectAcl(params, err => {
-                assert(err, 'Expected err but did not find one');
-                assert.strictEqual(err.code, 'InvalidArgument');
-                assert.strictEqual(err.statusCode, 400);
-                done();
+        function _testBehaviorVersioningEnabledOrSuspended(versionIds) {
+            it('non-version specific put and get ACL should target latest ' +
+            'version AND return version ID in response headers', done => {
+                const latestVersion = versionIds[versionIds.length - 1];
+                _putAndGetAcl('public-read', undefined, latestVersion,
+                    latestVersion, done);
             });
-        });
 
-        it('should return NoSuchVersion if attempting to get acl for ' +
-        'non-existing version', done => {
-            const params = { Bucket: bucket, Key: key,
-                VersionId: nonExistingId };
-            s3.getObjectAcl(params, err => {
-                assert(err, 'Expected err but did not find one');
-                assert.strictEqual(err.code, 'NoSuchVersion');
-                assert.strictEqual(err.statusCode, 404);
-                done();
+            it('version specific put and get ACL should return version ID ' +
+            'in response headers', done => {
+                const firstVersion = versionIds[0];
+                _putAndGetAcl('public-read', firstVersion, firstVersion,
+                    firstVersion, done);
             });
-        });
 
-        it('should return InvalidArgument if attempting to get acl for ' +
-        'invalid id', done => {
-            const params = { Bucket: bucket, Key: key, VersionId: fakeId };
-            s3.getObjectAcl(params, err => {
-                assert(err, 'Expected err but did not find one');
-                assert.strictEqual(err.code, 'InvalidArgument');
-                assert.strictEqual(err.statusCode, 400);
-                done();
+            it('version specific put and get ACL (version id = "null") ' +
+            'should return version ID ("null") in response headers', done => {
+                _putAndGetAcl('public-read', 'null', 'null', 'null', done);
             });
-        });
-    });
-
-    describe('on a version-enabled bucket with non-versioned object', () => {
-        const versionIds = [];
+        }
 
         beforeEach(done => {
-            const params = { Bucket: bucket, Key: key };
-            async.waterfall([
-                callback => s3.putObject(params, err => callback(err)),
-                callback => s3.putBucketVersioning({
-                    Bucket: bucket,
-                    VersioningConfiguration: constants.versioningEnabled,
-                }, err => callback(err)),
-            ], done);
+            bucket = `versioning-bucket-acl-${Date.now()}`;
+            s3.createBucket({ Bucket: bucket }, done);
         });
 
         afterEach(done => {
-            // cleanup versionIds just in case
-            versionIds.length = 0;
-            done();
-        });
-
-        describe('before putting new versions', () => {
-            it('non-version specific put and get ACL should now ' +
-            'return version ID ("null") in response headers', done => {
-                _putAndGetAcl('public-read', undefined, 'null', 'null', done);
+            removeAllVersions({ Bucket: bucket }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return s3.deleteBucket({ Bucket: bucket }, done);
             });
         });
 
-        describe('after putting new versions', () => {
+        describe('in a bucket without versioning configuration', () => {
             beforeEach(done => {
-                const params = { Bucket: bucket, Key: key };
-                async.timesSeries(counter, (i, next) =>
-                    s3.putObject(params, (err, data) => {
-                        _assertNoError(err, `putting version #${i}`);
-                        versionIds.push(data.VersionId);
-                        next(err);
-                    }), done);
+                s3.putObject({ Bucket: bucket, Key: key }, done);
             });
 
-            _testBehaviorVersioningEnabledOrSuspended(versionIds);
-        });
-    });
+            it('should not return version id for non-version specific ' +
+            'put and get ACL', done => {
+                _putAndGetAcl('public-read', undefined, undefined,
+                undefined, done);
+            });
 
-    describe('on version-suspended bucket with non-versioned object', () => {
-        const versionIds = [];
+            it('should not return version id for version specific ' +
+            'put and get ACL (version id = "null")', done => {
+                _putAndGetAcl('public-read', 'null', undefined,
+                undefined, done);
+            });
 
-        beforeEach(done => {
-            const params = { Bucket: bucket, Key: key };
-            async.waterfall([
-                callback => s3.putObject(params, err => callback(err)),
-                callback => s3.putBucketVersioning({
+            it('should return NoSuchVersion if attempting to put acl for ' +
+            'non-existing version', done => {
+                const params = {
                     Bucket: bucket,
-                    VersioningConfiguration: constants.versioningSuspended,
-                }, err => callback(err)),
-            ], done);
-        });
+                    Key: key,
+                    VersionId: nonExistingId,
+                    ACL: 'private',
+                };
+                s3.putObjectAcl(params, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'NoSuchVersion');
+                    assert.strictEqual(err.statusCode, 404);
+                    done();
+                });
+            });
 
-        afterEach(done => {
-            // cleanup versionIds just in case
-            versionIds.length = 0;
-            done();
-        });
+            it('should return InvalidArgument if attempting to put acl for ' +
+            'invalid hex string', done => {
+                const params = { Bucket: bucket, Key: key, VersionId: invalidId,
+                    ACL: 'private' };
+                s3.putObjectAcl(params, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
 
-        describe('before putting new versions', () => {
-            it('non-version specific put and get ACL should still ' +
-            'return version ID ("null") in response headers', done => {
-                _putAndGetAcl('public-read', undefined, 'null', 'null', done);
+            it('should return NoSuchVersion if attempting to get acl for ' +
+            'non-existing version', done => {
+                const params = { Bucket: bucket, Key: key,
+                    VersionId: nonExistingId };
+                s3.getObjectAcl(params, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'NoSuchVersion');
+                    assert.strictEqual(err.statusCode, 404);
+                    done();
+                });
+            });
+
+            it('should return InvalidArgument if attempting to get acl for ' +
+            'invalid id', done => {
+                const params = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: invalidId,
+                };
+                s3.getObjectAcl(params, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
             });
         });
 
-        describe('after putting new versions', () => {
+        describe('on a version-enabled bucket with non-versioned object',
+        () => {
+            const versionIds = [];
+
             beforeEach(done => {
                 const params = { Bucket: bucket, Key: key };
                 async.waterfall([
+                    callback => s3.putObject(params, err => callback(err)),
                     callback => s3.putBucketVersioning({
                         Bucket: bucket,
-                        VersioningConfiguration: constants.versioningEnabled,
-                    }, err => callback(err)),
-                    callback => async.timesSeries(counter, (i, next) =>
-                        s3.putObject(params, (err, data) => {
-                            _assertNoError(err, `putting version #${i}`);
-                            versionIds.push(data.VersionId);
-                            next(err);
-                        }), err => callback(err)),
-                    callback => s3.putBucketVersioning({
-                        Bucket: bucket,
-                        VersioningConfiguration: constants.versioningSuspended,
+                        VersioningConfiguration: versioningEnabled,
                     }, err => callback(err)),
                 ], done);
             });
 
-            _testBehaviorVersioningEnabledOrSuspended(versionIds);
+            afterEach(done => {
+                // cleanup versionIds just in case
+                versionIds.length = 0;
+                done();
+            });
+
+            describe('before putting new versions', () => {
+                it('non-version specific put and get ACL should now ' +
+                'return version ID ("null") in response headers', done => {
+                    _putAndGetAcl('public-read', undefined, 'null',
+                    'null', done);
+                });
+            });
+
+            describe('after putting new versions', () => {
+                beforeEach(done => {
+                    const params = { Bucket: bucket, Key: key };
+                    async.timesSeries(counter, (i, next) =>
+                        s3.putObject(params, (err, data) => {
+                            _assertNoError(err, `putting version #${i}`);
+                            versionIds.push(data.VersionId);
+                            next(err);
+                        }), done);
+                });
+
+                _testBehaviorVersioningEnabledOrSuspended(versionIds);
+            });
+        });
+
+        describe('on version-suspended bucket with non-versioned object',
+        () => {
+            const versionIds = [];
+
+            beforeEach(done => {
+                const params = { Bucket: bucket, Key: key };
+                async.waterfall([
+                    callback => s3.putObject(params, err => callback(err)),
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningSuspended,
+                    }, err => callback(err)),
+                ], done);
+            });
+
+            afterEach(done => {
+                // cleanup versionIds just in case
+                versionIds.length = 0;
+                done();
+            });
+
+            describe('before putting new versions', () => {
+                it('non-version specific put and get ACL should still ' +
+                'return version ID ("null") in response headers', done => {
+                    _putAndGetAcl('public-read', undefined, 'null',
+                    'null', done);
+                });
+            });
+
+            describe('after putting new versions', () => {
+                beforeEach(done => {
+                    const params = { Bucket: bucket, Key: key };
+                    async.waterfall([
+                        callback => s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningEnabled,
+                        }, err => callback(err)),
+                        callback => async.timesSeries(counter, (i, next) =>
+                            s3.putObject(params, (err, data) => {
+                                _assertNoError(err, `putting version #${i}`);
+                                versionIds.push(data.VersionId);
+                                next(err);
+                            }), err => callback(err)),
+                        callback => s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningSuspended,
+                        }, err => callback(err)),
+                    ], done);
+                });
+
+                _testBehaviorVersioningEnabledOrSuspended(versionIds);
+            });
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectCopy.js
@@ -93,7 +93,7 @@ testing('Object Version Copy', () => {
                 etag = res.ETag;
                 versionId = res.VersionId;
                 copySource = `${sourceBucketName}/${sourceObjName}` +
-                    `?versionId=${encodeURIComponent(versionId)}`;
+                    `?versionId=${versionId}`;
                 etagTrim = etag.substring(1, etag.length - 1);
                 return s3.headObjectAsync({
                     Bucket: sourceBucketName,
@@ -330,7 +330,7 @@ testing('Object Version Copy', () => {
                 Body: '', Metadata: originalMetadata }, (err, res) => {
                 checkNoError(err);
                 copySource = `${sourceBucketName}/${sourceObjName}` +
-                    `?versionId=${encodeURIComponent(res.VersionId)}`;
+                    `?versionId=${res.VersionId}`;
                 s3.copyObject({ Bucket: destBucketName, Key: destObjName,
                     CopySource: copySource,
                 },
@@ -354,7 +354,7 @@ testing('Object Version Copy', () => {
                 Body: '' }, (err, res) => {
                 checkNoError(err);
                 copySource = `${sourceBucketName}/${sourceObjName}` +
-                    `?versionId=${encodeURIComponent(res.VersionId)}`;
+                    `?versionId=${res.VersionId}`;
                 s3.copyObject({ Bucket: sourceBucketName, Key: sourceObjName,
                     CopySource: copySource,
                     StorageClass: 'REDUCED_REDUNDANCY',
@@ -617,7 +617,7 @@ testing('Object Version Copy', () => {
                     Bucket: destBucketName,
                     Key: destObjName,
                     CopySource: `${sourceBucketName}/${sourceObjName}` +
-                    `?versionId=${encodeURIComponent(deleteMarkerId)}`,
+                    `?versionId=${deleteMarkerId}`,
                 },
                 err => {
                     checkError(err, 'InvalidRequest');

--- a/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
@@ -1,113 +1,51 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
 
-import getConfig from '../support/config';
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
+import { removeAllVersions } from '../../lib/utility/versioning-util.js';
 
 const bucket = `versioning-bucket-${Date.now()}`;
 const key = 'anObject';
 
 const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 
-testing('aws-node-sdk test delete object', function testSuite() {
-    this.timeout(600000);
-    let s3 = undefined;
-    let versionIds = undefined;
+testing('aws-node-sdk test delete object', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let versionIds = undefined;
 
-    function _deleteVersionList(versionList, bucket, callback) {
-        async.each(versionList, (versionInfo, cb) => {
-            const versionId = versionInfo.VersionId;
-            const params = { Bucket: bucket, Key: versionInfo.Key,
-            VersionId: versionId };
-            s3.deleteObject(params, cb);
-        }, callback);
-    }
-    function _removeAllVersions(bucket, callback) {
-        return s3.listObjectVersions({ Bucket: bucket }, (err, data) => {
-            process.stdout.write(
-                'list object versions before deletion' +
-                `${JSON.stringify(data, undefined, '\t')}`);
-            if (err && err.NoSuchBucket) {
-                return callback();
-            } else if (err) {
-                return callback(err);
-            }
-            return _deleteVersionList(data.DeleteMarkers, bucket, err => {
-                if (err) {
-                    return callback(err);
-                }
-                return _deleteVersionList(data.Versions, bucket, callback);
-            });
+        // setup test
+        before(done => {
+            versionIds = [];
+            s3.createBucket({ Bucket: bucket }, done);
         });
-    }
 
-    // setup test
-    before(done => {
-        versionIds = [];
-        const config = getConfig('default', { signatureVersion: 'v4' });
-        s3 = new S3(config);
-        s3.createBucket({ Bucket: bucket }, done);
-    });
-
-    // delete bucket after testing
-    after(done => {
-        // TODO: remove conditional after listing is implemented
-        if (process.env.AWS_ON_AIR === 'true') {
-            return _removeAllVersions(bucket, err => {
-                if (err) {
-                    return done(err);
-                }
-                return s3.deleteBucket({ Bucket: bucket }, err => {
-                    assert.strictEqual(err, null,
-                        `Error deleting bucket: ${err}`);
-                    return done();
+        // delete bucket after testing
+        after(done => {
+            // TODO: remove conditional after listing is implemented
+            if (process.env.AWS_ON_AIR === 'true') {
+                return removeAllVersions(bucket, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    return s3.deleteBucket({ Bucket: bucket }, err => {
+                        assert.strictEqual(err, null,
+                            `Error deleting bucket: ${err}`);
+                        return done();
+                    });
                 });
-            });
-        }
-        return done();
-    });
-
-    it('delete non existent object should not create a delete marker',
-    done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: `${key}000`,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
             }
-            assert.strictEqual(res.DeleteMarker, undefined);
-            assert.strictEqual(res.VersionId, undefined);
             return done();
         });
-    });
 
-    it('creating non-versionned object', done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.equal(res.VersionId, undefined);
-            return done();
-        });
-    });
-
-    it('delete object in non-versioned bucket should not create delete marker',
-    done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.equal(res.VersionId, undefined);
-            return s3.deleteObject({
+        it('delete non existent object should not create a delete marker',
+        done => {
+            s3.deleteObject({
                 Bucket: bucket,
-                Key: `${key}2`,
+                Key: `${key}000`,
             }, (err, res) => {
                 if (err) {
                     return done(err);
@@ -117,390 +55,417 @@ testing('aws-node-sdk test delete object', function testSuite() {
                 return done();
             });
         });
-    });
 
-    it('enable versioning', done => {
-        const params = {
-            Bucket: bucket,
-            VersioningConfiguration: {
-                Status: 'Enabled',
-            },
-        };
-        s3.putBucketVersioning(params, done);
-    });
-
-    it('should not send back error for non-existing key (specific version)',
-        done => {
-            s3.deleteObject({
+        it('creating non-versioned object', done => {
+            s3.putObject({
                 Bucket: bucket,
-                Key: `${key}3`,
-                VersionId: 'null',
-            }, err => {
+                Key: key,
+            }, (err, res) => {
                 if (err) {
                     return done(err);
                 }
+                assert.equal(res.VersionId, undefined);
                 return done();
             });
         });
 
-    it('delete non existent object should create a delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: `${key}2`,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            assert.notEqual(res.VersionId, undefined);
-            return s3.deleteObject({
+        it('delete in non-versioned bucket should not create delete marker',
+        done => {
+            s3.putObject({
                 Bucket: bucket,
-                Key: `${key}2`,
-            }, (err, res2) => {
+                Key: key,
+            }, (err, res) => {
                 if (err) {
                     return done(err);
                 }
-                assert.strictEqual(res2.DeleteMarker, 'true');
-                assert.notEqual(res2.VersionId, res.VersionId);
+                assert.equal(res.VersionId, undefined);
                 return s3.deleteObject({
                     Bucket: bucket,
                     Key: `${key}2`,
-                    VersionId: res.VersionId,
+                }, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(res.DeleteMarker, undefined);
+                    assert.strictEqual(res.VersionId, undefined);
+                    return done();
+                });
+            });
+        });
+
+        it('enable versioning', done => {
+            const params = {
+                Bucket: bucket,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                },
+            };
+            s3.putBucketVersioning(params, done);
+        });
+
+        it('should not send back error for non-existing key (specific version)',
+            done => {
+                s3.deleteObject({
+                    Bucket: bucket,
+                    Key: `${key}3`,
+                    VersionId: 'null',
                 }, err => {
                     if (err) {
                         return done(err);
                     }
+                    return done();
+                });
+            });
+
+        it('delete non existent object should create a delete marker', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: `${key}2`,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.DeleteMarker, 'true');
+                assert.notEqual(res.VersionId, undefined);
+                return s3.deleteObject({
+                    Bucket: bucket,
+                    Key: `${key}2`,
+                }, (err, res2) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(res2.DeleteMarker, 'true');
+                    assert.notEqual(res2.VersionId, res.VersionId);
                     return s3.deleteObject({
                         Bucket: bucket,
                         Key: `${key}2`,
-                        VersionId: res2.VersionId,
+                        VersionId: res.VersionId,
+                    }, err => {
+                        if (err) {
+                            return done(err);
+                        }
+                        return s3.deleteObject({
+                            Bucket: bucket,
+                            Key: `${key}2`,
+                            VersionId: res2.VersionId,
+                        }, err => done(err));
+                    });
+                });
+            });
+        });
+
+        it('put a version to the object', done => {
+            s3.putObject({
+                Bucket: bucket,
+                Key: key,
+                Body: 'test',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                versionIds.push('null');
+                versionIds.push(res.VersionId);
+                assert.notEqual(res.VersionId, undefined);
+                return done();
+            });
+        });
+
+        it('should create a delete marker', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.DeleteMarker, 'true');
+                assert.strictEqual(
+                    versionIds.find(item => item === res.VersionId),
+                    undefined);
+                versionIds.push(res.VersionId);
+                return done();
+            });
+        });
+
+        it('should return 404 with a delete marker', done => {
+            s3.getObject({
+                Bucket: bucket,
+                Key: key,
+            }, function test(err) {
+                if (!err) {
+                    return done(new Error('should return 404'));
+                }
+                const headers = this.httpResponse.headers;
+                assert.strictEqual(headers['x-amz-delete-marker'], 'true');
+                return done();
+            });
+        });
+
+        it('should delete the null version', done => {
+            const version = versionIds.shift();
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: version,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, version);
+                assert.equal(res.DeleteMarker, undefined);
+                return done();
+            });
+        });
+
+        it('should delete the versionned object', done => {
+            const version = versionIds.shift();
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: version,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, version);
+                assert.equal(res.DeleteMarker, undefined);
+                return done();
+            });
+        });
+
+        it('should delete the delete-marker version', done => {
+            const version = versionIds.shift();
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: version,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, version);
+                assert.equal(res.DeleteMarker, 'true');
+                return done();
+            });
+        });
+
+        it('put a new version', done => {
+            s3.putObject({
+                Bucket: bucket,
+                Key: key,
+                Body: 'test',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                versionIds.push(res.VersionId);
+                assert.notEqual(res.VersionId, undefined);
+                return done();
+            });
+        });
+
+        it('get the null version', done => {
+            s3.getObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: 'null',
+            }, err => {
+                if (!err || err.code !== 'NoSuchVersion') {
+                    return done(err || 'should send back an error');
+                }
+                return done();
+            });
+        });
+
+        it('suspending versioning', done => {
+            const params = {
+                Bucket: bucket,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                },
+            };
+            s3.putBucketVersioning(params, done);
+        });
+
+        it('delete non existent object should create a delete marker', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: `${key}2`,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.DeleteMarker, 'true');
+                assert.notEqual(res.VersionId, undefined);
+                return s3.deleteObject({
+                    Bucket: bucket,
+                    Key: `${key}2`,
+                }, (err, res2) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(res2.DeleteMarker, 'true');
+                    assert.strictEqual(res2.VersionId, res.VersionId);
+                    return s3.deleteObject({
+                        Bucket: bucket,
+                        Key: `${key}2`,
+                        VersionId: res.VersionId,
                     }, err => done(err));
                 });
             });
         });
-    });
 
-    it('put a version to the object', done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-            Body: 'test',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            versionIds.push('null');
-            versionIds.push(res.VersionId);
-            assert.notEqual(res.VersionId, undefined);
-            return done();
-        });
-    });
-
-    it('should create a delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            assert.strictEqual(versionIds.find(item => item === res.VersionId),
-                undefined);
-            versionIds.push(res.VersionId);
-            return done();
-        });
-    });
-
-    it('should return 404 with a delete marker', done => {
-        s3.getObject({
-            Bucket: bucket,
-            Key: key,
-        }, function test(err) {
-            if (!err) {
-                return done(new Error('should return 404'));
-            }
-            const headers = this.httpResponse.headers;
-            assert.strictEqual(headers['x-amz-delete-marker'], 'true');
-            return done();
-        });
-    });
-
-    it('should delete the null version', done => {
-        const version = versionIds.shift();
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: version,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, version);
-            assert.equal(res.DeleteMarker, undefined);
-            return done();
-        });
-    });
-
-    it('should delete the versionned object', done => {
-        const version = versionIds.shift();
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: version,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, version);
-            assert.equal(res.DeleteMarker, undefined);
-            return done();
-        });
-    });
-
-    it('should delete the delete-marker version', done => {
-        const version = versionIds.shift();
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: version,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, version);
-            assert.equal(res.DeleteMarker, 'true');
-            return done();
-        });
-    });
-
-    it('put a new version', done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-            Body: 'test',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            versionIds.push(res.VersionId);
-            assert.notEqual(res.VersionId, undefined);
-            return done();
-        });
-    });
-
-    it('get the null version', done => {
-        s3.getObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: 'null',
-        }, err => {
-            if (!err || err.code !== 'NoSuchVersion') {
-                return done(err || 'should send back an error');
-            }
-            return done();
-        });
-    });
-
-    it('suspending versioning', done => {
-        const params = {
-            Bucket: bucket,
-            VersioningConfiguration: {
-                Status: 'Suspended',
-            },
-        };
-        s3.putBucketVersioning(params, done);
-    });
-
-    it('delete non existent object should create a delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: `${key}2`,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            assert.notEqual(res.VersionId, undefined);
-            return s3.deleteObject({
+        it('should put a new delete marker', done => {
+            s3.deleteObject({
                 Bucket: bucket,
-                Key: `${key}2`,
-            }, (err, res2) => {
+                Key: key,
+            }, (err, res) => {
                 if (err) {
                     return done(err);
                 }
-                assert.strictEqual(res2.DeleteMarker, 'true');
-                assert.strictEqual(res2.VersionId, res.VersionId);
-                return s3.deleteObject({
-                    Bucket: bucket,
-                    Key: `${key}2`,
-                    VersionId: res.VersionId,
-                }, err => done(err));
+                assert.strictEqual(res.DeleteMarker, 'true');
+                assert.strictEqual(res.VersionId, 'null');
+                return done();
             });
         });
-    });
 
-    it('should put a new delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            assert.strictEqual(res.VersionId, 'null');
-            return done();
+        it('enabling versioning', done => {
+            const params = {
+                Bucket: bucket,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                },
+            };
+            s3.putBucketVersioning(params, done);
         });
-    });
 
-    it('enabling versioning', done => {
-        const params = {
-            Bucket: bucket,
-            VersioningConfiguration: {
-                Status: 'Enabled',
-            },
-        };
-        s3.putBucketVersioning(params, done);
-    });
+        it('should get the null version', done => {
+            s3.getObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: 'null',
+            }, function test(err) {
+                const headers = this.httpResponse.headers;
+                assert.strictEqual(headers['x-amz-delete-marker'], 'true');
+                assert.strictEqual(headers['x-amz-version-id'], 'null');
+                if (err && err.code !== 'MethodNotAllowed') {
+                    return done(err);
+                } else if (err) {
+                    return done();
+                }
+                return done('should return an error');
+            });
+        });
 
-    it('should get the null version', done => {
-        s3.getObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: 'null',
-        }, function test(err) {
-            const headers = this.httpResponse.headers;
-            assert.strictEqual(headers['x-amz-delete-marker'], 'true');
-            assert.strictEqual(headers['x-amz-version-id'], 'null');
-            if (err && err.code !== 'MethodNotAllowed') {
-                return done(err);
-            } else if (err) {
+        it('put a new version to store the null version', done => {
+            s3.putObject({
+                Bucket: bucket,
+                Key: key,
+                Body: 'test',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                versionIds.push(res.VersionId);
                 return done();
-            }
-            return done('should return an error');
+            });
         });
-    });
 
-    it('put a new version to store the null version', done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-            Body: 'test',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            versionIds.push(res.VersionId);
-            return done();
+        it('suspending versioning', done => {
+            const params = {
+                Bucket: bucket,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                },
+            };
+            s3.putBucketVersioning(params, done);
         });
-    });
 
-    it('suspending versioning', done => {
-        const params = {
-            Bucket: bucket,
-            VersioningConfiguration: {
-                Status: 'Suspended',
-            },
-        };
-        s3.putBucketVersioning(params, done);
-    });
-
-    it('put null version', done => {
-        s3.putObject({
-            Bucket: bucket,
-            Key: key,
-            Body: 'test-null-version',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, undefined);
-            return done();
+        it('put null version', done => {
+            s3.putObject({
+                Bucket: bucket,
+                Key: key,
+                Body: 'test-null-version',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, undefined);
+                return done();
+            });
         });
-    });
 
-    it('enabling versioning', done => {
-        const params = {
-            Bucket: bucket,
-            VersioningConfiguration: {
-                Status: 'Enabled',
-            },
-        };
-        s3.putBucketVersioning(params, done);
-    });
-
-    it('should get the null version', done => {
-        s3.getObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.Body.toString(), 'test-null-version');
-            return done();
+        it('enabling versioning', done => {
+            const params = {
+                Bucket: bucket,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                },
+            };
+            s3.putBucketVersioning(params, done);
         });
-    });
 
-    it('should add a delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            versionIds.push(res.VersionId);
-            return done();
+        it('should get the null version', done => {
+            s3.getObject({
+                Bucket: bucket,
+                Key: key,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.Body.toString(), 'test-null-version');
+                return done();
+            });
         });
-    });
 
-    it('should get the null version', done => {
-        s3.getObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: 'null',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.Body.toString(), 'test-null-version');
-            return done();
+        it('should add a delete marker', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.DeleteMarker, 'true');
+                versionIds.push(res.VersionId);
+                return done();
+            });
         });
-    });
 
-    it('should add a delete marker', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.DeleteMarker, 'true');
-            assert.strictEqual(versionIds.find(item => item === res.VersionId),
-                undefined);
-            versionIds.push(res.VersionId);
-            return done();
+        it('should get the null version', done => {
+            s3.getObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: 'null',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.Body.toString(), 'test-null-version');
+                return done();
+            });
         });
-    });
 
-    it('should set the null version as master', done => {
-        let version = versionIds.pop();
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: version,
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, version);
-            assert.strictEqual(res.DeleteMarker, 'true');
-            version = versionIds.pop();
-            return s3.deleteObject({
+        it('should add a delete marker', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.DeleteMarker, 'true');
+                assert.strictEqual(
+                    versionIds.find(item => item === res.VersionId),
+                    undefined);
+                versionIds.push(res.VersionId);
+                return done();
+            });
+        });
+
+        it('should set the null version as master', done => {
+            let version = versionIds.pop();
+            s3.deleteObject({
                 Bucket: bucket,
                 Key: key,
                 VersionId: version,
@@ -510,6 +475,42 @@ testing('aws-node-sdk test delete object', function testSuite() {
                 }
                 assert.strictEqual(res.VersionId, version);
                 assert.strictEqual(res.DeleteMarker, 'true');
+                version = versionIds.pop();
+                return s3.deleteObject({
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: version,
+                }, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(res.VersionId, version);
+                    assert.strictEqual(res.DeleteMarker, 'true');
+                    return s3.getObject({
+                        Bucket: bucket,
+                        Key: key,
+                    }, (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.strictEqual(res.Body.toString(),
+                            'test-null-version');
+                        return done();
+                    });
+                });
+            });
+        });
+
+        it('should delete null version', done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: 'null',
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, 'null');
                 return s3.getObject({
                     Bucket: bucket,
                     Key: key,
@@ -517,56 +518,32 @@ testing('aws-node-sdk test delete object', function testSuite() {
                     if (err) {
                         return done(err);
                     }
-                    assert.strictEqual(res.Body.toString(),
-                        'test-null-version');
+                    assert.strictEqual(res.VersionId,
+                        versionIds[versionIds.length - 1]);
                     return done();
                 });
             });
         });
-    });
 
-    it('should delete null version', done => {
-        s3.deleteObject({
-            Bucket: bucket,
-            Key: key,
-            VersionId: 'null',
-        }, (err, res) => {
-            if (err) {
-                return done(err);
-            }
-            assert.strictEqual(res.VersionId, 'null');
-            return s3.getObject({
-                Bucket: bucket,
-                Key: key,
-            }, (err, res) => {
+        it('should be able to delete the bucket', done => {
+            async.eachSeries(versionIds, (id, next) => {
+                s3.deleteObject({
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: id,
+                }, (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    assert.strictEqual(res.VersionId, id);
+                    return next();
+                });
+            }, err => {
                 if (err) {
                     return done(err);
                 }
-                assert.strictEqual(res.VersionId,
-                    versionIds[versionIds.length - 1]);
-                return done();
+                return s3.deleteBucket({ Bucket: bucket }, err => done(err));
             });
-        });
-    });
-
-    it('should be able to delete the bucket', done => {
-        async.eachSeries(versionIds, (id, next) => {
-            s3.deleteObject({
-                Bucket: bucket,
-                Key: key,
-                VersionId: id,
-            }, (err, res) => {
-                if (err) {
-                    return next(err);
-                }
-                assert.strictEqual(res.VersionId, id);
-                return next();
-            });
-        }, err => {
-            if (err) {
-                return done(err);
-            }
-            return s3.deleteBucket({ Bucket: bucket }, err => done(err));
         });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/objectHead.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectHead.js
@@ -1,15 +1,15 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
 import {
     removeAllVersions,
-    constants,
+    versioningEnabled,
+    versioningSuspended,
 } from '../../lib/utility/versioning-util.js';
 
-import headConfig from '../support/config';
-
-const config = headConfig('default', { signatureVersion: 'v4' });
-const s3 = new S3(config);
 const data = ['foo1', 'foo2'];
 const counter = 100;
 let bucket;
@@ -25,352 +25,382 @@ const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 testing('put and head object with versioning', function testSuite() {
     this.timeout(600000);
 
-    beforeEach(done => {
-        bucket = `versioning-bucket-${Date.now()}`;
-        s3.createBucket({ Bucket: bucket }, done);
-    });
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
 
-    afterEach(done => {
-        removeAllVersions({ Bucket: bucket }, err => {
-            if (err) {
-                return done(err);
-            }
-            return s3.deleteBucket({ Bucket: bucket }, done);
-        });
-    });
-
-    it('should put and head a non-versioned object without including ' +
-    'version ids in response headers', done => {
-        const params = { Bucket: bucket, Key: key };
-        s3.putObject(params, (err, data) => {
-            _assertNoError(err, 'putting object');
-            assert.strictEqual(data.VersionId, undefined);
-            s3.headObject(params, (err, data) => {
-                _assertNoError(err, 'heading object');
-                assert.strictEqual(data.VersionId, undefined);
-                done();
-            });
-        });
-    });
-
-    it('version-specific head should still not return version id in ' +
-    'response header', done => {
-        const params = { Bucket: bucket, Key: key };
-        s3.putObject(params, (err, data) => {
-            _assertNoError(err, 'putting object');
-            assert.strictEqual(data.VersionId, undefined);
-            params.VersionId = 'null';
-            s3.headObject(params, (err, data) => {
-                _assertNoError(err, 'heading specific object version "null"');
-                assert.strictEqual(data.VersionId, undefined);
-                done();
-            });
-        });
-    });
-
-    describe('on a version-enabled bucket', () => {
         beforeEach(done => {
-            s3.putBucketVersioning({
-                Bucket: bucket,
-                VersioningConfiguration: constants.versioningEnabled,
-            }, done);
+            bucket = `versioning-bucket-${Date.now()}`;
+            s3.createBucket({ Bucket: bucket }, done);
         });
 
-        it('should create a new version for an object', done => {
+        afterEach(done => {
+            removeAllVersions({ Bucket: bucket }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return s3.deleteBucket({ Bucket: bucket }, done);
+            });
+        });
+
+        it('should put and head a non-versioned object without including ' +
+        'version ids in response headers', done => {
             const params = { Bucket: bucket, Key: key };
             s3.putObject(params, (err, data) => {
                 _assertNoError(err, 'putting object');
-                params.VersionId = data.VersionId;
+                assert.strictEqual(data.VersionId, undefined);
                 s3.headObject(params, (err, data) => {
                     _assertNoError(err, 'heading object');
-                    assert.strictEqual(params.VersionId, data.VersionId,
-                            'version ids are not equal');
+                    assert.strictEqual(data.VersionId, undefined);
                     done();
                 });
             });
         });
-    });
 
-    describe('on a version-enabled bucket with non-versioned object', () => {
-        const eTags = [];
-
-        beforeEach(done => {
-            s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
-                (err, data) => {
-                    if (err) {
-                        done(err);
-                    }
-                    eTags.push(data.ETag);
-                    s3.putBucketVersioning({
-                        Bucket: bucket,
-                        VersioningConfiguration: constants.versioningEnabled,
-                    }, done);
+        it('version-specific head should still not return version id in ' +
+        'response header', done => {
+            const params = { Bucket: bucket, Key: key };
+            s3.putObject(params, (err, data) => {
+                _assertNoError(err, 'putting object');
+                assert.strictEqual(data.VersionId, undefined);
+                params.VersionId = 'null';
+                s3.headObject(params, (err, data) => {
+                    _assertNoError(err, 'heading specific version "null"');
+                    assert.strictEqual(data.VersionId, undefined);
+                    done();
                 });
-        });
-
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
-
-        it('should head null version in versioning enabled bucket',
-        done => {
-            const paramsNull = { Bucket: bucket, Key: '/', VersionId: 'null' };
-            s3.headObject(paramsNull, err => {
-                _assertNoError(err, 'heading null version');
-                done();
             });
         });
 
-        it('should keep null version and create a new version for an object',
-        done => {
-            const params = { Bucket: bucket, Key: key, Body: data[1] };
-            s3.putObject(params, (err, data) => {
-                const newVersion = data.VersionId;
-                eTags.push(data.ETag);
-                s3.headObject({ Bucket: bucket, Key: key,
-                    VersionId: newVersion }, (err, data) => {
-                    assert.strictEqual(err, null);
-                    assert.strictEqual(data.VersionId, newVersion,
-                        'version ids are not equal');
-                    assert.strictEqual(data.ETag, eTags[1]);
-                    s3.headObject({ Bucket: bucket, Key: key,
-                    VersionId: 'null' }, (err, data) => {
-                        _assertNoError(err, 'heading null version');
-                        assert.strictEqual(data.VersionId, 'null');
-                        assert.strictEqual(data.ETag, eTags[0]);
+        describe('on a version-enabled bucket', () => {
+            beforeEach(done => {
+                s3.putBucketVersioning({
+                    Bucket: bucket,
+                    VersioningConfiguration: versioningEnabled,
+                }, done);
+            });
+
+            it('should create a new version for an object', done => {
+                const params = { Bucket: bucket, Key: key };
+                s3.putObject(params, (err, data) => {
+                    _assertNoError(err, 'putting object');
+                    params.VersionId = data.VersionId;
+                    s3.headObject(params, (err, data) => {
+                        _assertNoError(err, 'heading object');
+                        assert.strictEqual(params.VersionId, data.VersionId,
+                                'version ids are not equal');
                         done();
                     });
                 });
             });
         });
 
-        it('should create new versions but still keep nullVersionId',
-        done => {
-            const versionIds = [];
-            const params = { Bucket: bucket, Key: key };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            // create new versions
-            async.timesSeries(counter, (i, next) => s3.putObject(params,
-                (err, data) => {
-                    versionIds.push(data.VersionId);
-                    // head the 'null' version
-                    s3.headObject(paramsNull, (err, nullVerData) => {
-                        assert.strictEqual(err, null);
-                        assert.strictEqual(nullVerData.ETag, eTags[0]);
-                        assert.strictEqual(nullVerData.VersionId, 'null');
-                        next(err);
+        describe('on a version-enabled bucket w/ non-versioned object', () => {
+            const eTags = [];
+
+            beforeEach(done => {
+                s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
+                    (err, data) => {
+                        if (err) {
+                            done(err);
+                        }
+                        eTags.push(data.ETag);
+                        s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningEnabled,
+                        }, done);
                     });
-                }), done);
-        });
-    });
+            });
 
-    describe('on version-suspended bucket', () => {
-        beforeEach(done => {
-            s3.putBucketVersioning({
-                Bucket: bucket,
-                VersioningConfiguration: constants.versioningSuspended,
-            }, done);
-        });
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
+                done();
+            });
 
-        it('should not return version id for new object', done => {
-            const params = { Bucket: bucket, Key: key, Body: 'foo' };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            s3.putObject(params, (err, data) => {
-                const eTag = data.ETag;
-                _assertNoError(err, 'putting object');
-                assert.strictEqual(data.VersionId, undefined);
-                // heading null version should return object we just put
-                s3.headObject(paramsNull, (err, nullVerData) => {
+            it('should head null version in versioning enabled bucket',
+            done => {
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };
+                s3.headObject(paramsNull, err => {
                     _assertNoError(err, 'heading null version');
-                    assert.strictEqual(nullVerData.ETag, eTag);
-                    assert.strictEqual(nullVerData.VersionId, 'null');
                     done();
                 });
             });
-        });
 
-        it('should update null version if put object twice', done => {
-            const params = { Bucket: bucket, Key: key };
-            const params1 = { Bucket: bucket, Key: key, Body: data[0] };
-            const params2 = { Bucket: bucket, Key: key, Body: data[1] };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            const eTags = [];
-            async.waterfall([
-                callback => s3.putObject(params1, (err, data) => {
-                    _assertNoError(err, 'putting first object');
-                    assert.strictEqual(data.VersionId, undefined);
+            it('should keep null version and create a new version', done => {
+                const params = { Bucket: bucket, Key: key, Body: data[1] };
+                s3.putObject(params, (err, data) => {
+                    const newVersion = data.VersionId;
                     eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.headObject(params, (err, data) => {
-                    _assertNoError(err, 'heading master version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[0],
-                        'wrong object data');
-                    callback();
-                }),
-                callback => s3.putObject(params2, (err, data) => {
-                    _assertNoError(err, 'putting second object');
-                    assert.strictEqual(data.VersionId, undefined);
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.headObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'heading null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-            ], done);
-        });
-    });
-
-    describe('on a version-suspended bucket with non-versioned object', () => {
-        const eTags = [];
-
-        beforeEach(done => {
-            s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
-                (err, data) => {
-                    if (err) {
-                        done(err);
-                    }
-                    eTags.push(data.ETag);
-                    s3.putBucketVersioning({
-                        Bucket: bucket,
-                        VersioningConfiguration: constants.versioningSuspended,
-                    }, done);
+                    s3.headObject({ Bucket: bucket, Key: key,
+                        VersionId: newVersion }, (err, data) => {
+                        assert.strictEqual(err, null);
+                        assert.strictEqual(data.VersionId, newVersion,
+                            'version ids are not equal');
+                        assert.strictEqual(data.ETag, eTags[1]);
+                        s3.headObject({ Bucket: bucket, Key: key,
+                        VersionId: 'null' }, (err, data) => {
+                            _assertNoError(err, 'heading null version');
+                            assert.strictEqual(data.VersionId, 'null');
+                            assert.strictEqual(data.ETag, eTags[0]);
+                            done();
+                        });
+                    });
                 });
-        });
+            });
 
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
-
-        it('should head null version in versioning suspended bucket',
-        done => {
-            const paramsNull = { Bucket: bucket, Key: '/', VersionId: 'null' };
-            s3.headObject(paramsNull, err => {
-                _assertNoError(err, 'heading null version');
-                done();
+            it('should create new versions but still keep nullVersionId',
+            done => {
+                const versionIds = [];
+                const params = { Bucket: bucket, Key: key };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };                // create new versions
+                async.timesSeries(counter, (i, next) => s3.putObject(params,
+                    (err, data) => {
+                        versionIds.push(data.VersionId);
+                        // head the 'null' version
+                        s3.headObject(paramsNull, (err, nullVerData) => {
+                            assert.strictEqual(err, null);
+                            assert.strictEqual(nullVerData.ETag, eTags[0]);
+                            assert.strictEqual(nullVerData.VersionId, 'null');
+                            next(err);
+                        });
+                    }), done);
             });
         });
 
-        it('should update null version in versioning suspended bucket',
-        done => {
-            const params = { Bucket: bucket, Key: key };
-            const putParams = { Bucket: bucket, Key: '/', Body: data[1] };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            async.waterfall([
-                callback => s3.headObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'heading null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    callback();
-                }),
-                callback => s3.putObject(putParams, (err, data) => {
+        describe('on version-suspended bucket', () => {
+            beforeEach(done => {
+                s3.putBucketVersioning({
+                    Bucket: bucket,
+                    VersioningConfiguration: versioningSuspended,
+                }, done);
+            });
+
+            it('should not return version id for new object', done => {
+                const params = { Bucket: bucket, Key: key, Body: 'foo' };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };
+                s3.putObject(params, (err, data) => {
+                    const eTag = data.ETag;
                     _assertNoError(err, 'putting object');
                     assert.strictEqual(data.VersionId, undefined);
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.headObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'heading null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-                callback => s3.headObject(params, (err, data) => {
-                    _assertNoError(err, 'heading master version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-            ], done);
-        });
-    });
+                    // heading null version should return object we just put
+                    s3.headObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(nullVerData.ETag, eTag);
+                        assert.strictEqual(nullVerData.VersionId, 'null');
+                        done();
+                    });
+                });
+            });
 
-    describe('on versioning suspended then enabled bucket with null version',
-    () => {
-        const eTags = [];
-        beforeEach(done => {
-            const params = { Bucket: bucket, Key: key, Body: data[0] };
-            async.waterfall([
-                callback => s3.putBucketVersioning({
+            it('should update null version if put object twice', done => {
+                const params = { Bucket: bucket, Key: key };
+                const params1 = { Bucket: bucket, Key: key, Body: data[0] };
+                const params2 = { Bucket: bucket, Key: key, Body: data[1] };
+                const paramsNull = {
                     Bucket: bucket,
-                    VersioningConfiguration: constants.versioningSuspended,
-                }, err => callback(err)),
-                callback => s3.putObject(params, (err, data) => {
-                    if (err) {
-                        callback(err);
-                    }
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.putBucketVersioning({
-                    Bucket: bucket,
-                    VersioningConfiguration: constants.versioningEnabled,
-                }, callback),
-            ], done);
+                    Key: '/', VersionId:
+                    'null',
+                };
+                const eTags = [];
+                async.waterfall([
+                    callback => s3.putObject(params1, (err, data) => {
+                        _assertNoError(err, 'putting first object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.headObject(params, (err, data) => {
+                        _assertNoError(err, 'heading master version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[0],
+                            'wrong object data');
+                        callback();
+                    }),
+                    callback => s3.putObject(params2, (err, data) => {
+                        _assertNoError(err, 'putting second object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.headObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                ], done);
+            });
         });
 
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
+        describe('on a version-suspended bucket with non-versioned object',
+        () => {
+            const eTags = [];
 
-        it('should preserve the null version when creating new versions',
-        done => {
-            const params = { Bucket: bucket, Key: key };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            async.waterfall([
-                callback => s3.headObject(paramsNull, (err, nullVerData) => {
-                    _assertNoError(err, 'heading null version');
-                    assert.strictEqual(nullVerData.ETag, eTags[0]);
-                    assert.strictEqual(nullVerData.VersionId, 'null');
-                    callback();
-                }),
-                callback => async.timesSeries(counter, (i, next) =>
-                    s3.putObject(params, (err, data) => {
-                        _assertNoError(err, `putting object #${i}`);
-                        assert.notEqual(data.VersionId, undefined);
-                        next();
-                    }), err => callback(err)),
-                callback => s3.headObject(paramsNull, (err, nullVerData) => {
-                    _assertNoError(err, 'heading null version');
-                    assert.strictEqual(nullVerData.ETag, eTags[0]);
-                    callback();
-                }),
-            ], done);
-        });
+            beforeEach(done => {
+                s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
+                    (err, data) => {
+                        if (err) {
+                            done(err);
+                        }
+                        eTags.push(data.ETag);
+                        s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningSuspended,
+                        }, done);
+                    });
+            });
 
-        it('should create a bunch of objects and their versions', done => {
-            const vids = [];
-            const keycount = 50;
-            const versioncount = 20;
-            const value = '{"foo":"bar"}';
-            async.times(keycount, (i, next1) => {
-                const key = `foo${i}`;
-                const params = { Bucket: bucket, Key: key, Body: value };
-                async.times(versioncount, (j, next2) =>
-                    s3.putObject(params, (err, data) => {
-                        assert.strictEqual(err, null);
-                        assert(data.VersionId, 'invalid versionId');
-                        vids.push({ Key: key, VersionId: data.VersionId });
-                        next2();
-                    }), next1);
-            }, err => {
-                assert.strictEqual(err, null);
-                assert.strictEqual(vids.length, keycount * versioncount);
-                // TODO use delete marker and check with the result
-                process.stdout.write('creating objects done, now deleting...');
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
                 done();
+            });
+
+            it('should head null version in versioning suspended bucket',
+            done => {
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };
+                s3.headObject(paramsNull, err => {
+                    _assertNoError(err, 'heading null version');
+                    done();
+                });
+            });
+
+            it('should update null version in versioning suspended bucket',
+            done => {
+                const params = { Bucket: bucket, Key: key };
+                const putParams = { Bucket: bucket, Key: '/', Body: data[1] };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };
+                async.waterfall([
+                    callback => s3.headObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        callback();
+                    }),
+                    callback => s3.putObject(putParams, (err, data) => {
+                        _assertNoError(err, 'putting object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.headObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                    callback => s3.headObject(params, (err, data) => {
+                        _assertNoError(err, 'heading master version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                ], done);
+            });
+        });
+
+        describe('on versioning suspended then enabled bucket w/ null version',
+        () => {
+            const eTags = [];
+            beforeEach(done => {
+                const params = { Bucket: bucket, Key: key, Body: data[0] };
+                async.waterfall([
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningSuspended,
+                    }, err => callback(err)),
+                    callback => s3.putObject(params, (err, data) => {
+                        if (err) {
+                            callback(err);
+                        }
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningEnabled,
+                    }, callback),
+                ], done);
+            });
+
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
+                done();
+            });
+
+            it('should preserve the null version when creating new versions',
+            done => {
+                const params = { Bucket: bucket, Key: key };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: '/', VersionId:
+                    'null',
+                };
+                async.waterfall([
+                    cb => s3.headObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(nullVerData.ETag, eTags[0]);
+                        assert.strictEqual(nullVerData.VersionId, 'null');
+                        cb();
+                    }),
+                    cb => async.timesSeries(counter, (i, next) =>
+                        s3.putObject(params, (err, data) => {
+                            _assertNoError(err, `putting object #${i}`);
+                            assert.notEqual(data.VersionId, undefined);
+                            next();
+                        }), err => cb(err)),
+                    cb => s3.headObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'heading null version');
+                        assert.strictEqual(nullVerData.ETag, eTags[0]);
+                        cb();
+                    }),
+                ], done);
+            });
+
+            it('should create a bunch of objects and their versions', done => {
+                const vids = [];
+                const keycount = 50;
+                const versioncount = 20;
+                const value = '{"foo":"bar"}';
+                async.times(keycount, (i, next1) => {
+                    const key = `foo${i}`;
+                    const params = { Bucket: bucket, Key: key, Body: value };
+                    async.times(versioncount, (j, next2) =>
+                        s3.putObject(params, (err, data) => {
+                            assert.strictEqual(err, null);
+                            assert(data.VersionId, 'invalid versionId');
+                            vids.push({ Key: key, VersionId: data.VersionId });
+                            next2();
+                        }), next1);
+                }, err => {
+                    assert.strictEqual(err, null);
+                    assert.strictEqual(vids.length, keycount * versioncount);
+                    done();
+                });
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/versioning/objectPut.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectPut.js
@@ -1,19 +1,18 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
 import {
     removeAllVersions,
-    constants,
+    versioningEnabled,
+    versioningSuspended,
 } from '../../lib/utility/versioning-util.js';
 
-import getConfig from '../support/config';
-
-const config = getConfig('default', { signatureVersion: 'v4' });
-const s3 = new S3(config);
 const data = ['foo1', 'foo2'];
 const counter = 100;
-let bucket;
-const key = '/';
+const key = 'objectKey';
 
 function _assertNoError(err, desc) {
     assert.strictEqual(err, null, `Unexpected err ${desc}: ${err}`);
@@ -24,352 +23,386 @@ const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 testing('put and get object with versioning', function testSuite() {
     this.timeout(600000);
 
-    beforeEach(done => {
-        bucket = `versioning-bucket-${Date.now()}`;
-        s3.createBucket({ Bucket: bucket }, done);
-    });
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let bucket;
 
-    afterEach(done => {
-        removeAllVersions({ Bucket: bucket }, err => {
-            if (err) {
-                return done(err);
-            }
-            return s3.deleteBucket({ Bucket: bucket }, done);
-        });
-    });
-
-    it('should put and get a non-versioned object without including ' +
-    'version ids in response headers', done => {
-        const params = { Bucket: bucket, Key: key };
-        s3.putObject(params, (err, data) => {
-            _assertNoError(err, 'putting object');
-            assert.strictEqual(data.VersionId, undefined);
-            s3.getObject(params, (err, data) => {
-                _assertNoError(err, 'getting object');
-                assert.strictEqual(data.VersionId, undefined);
-                done();
-            });
-        });
-    });
-
-    it('version-specific get should still not return version id in ' +
-    'response header', done => {
-        const params = { Bucket: bucket, Key: key };
-        s3.putObject(params, (err, data) => {
-            _assertNoError(err, 'putting object');
-            assert.strictEqual(data.VersionId, undefined);
-            params.VersionId = 'null';
-            s3.getObject(params, (err, data) => {
-                _assertNoError(err, 'getting specific object version "null"');
-                assert.strictEqual(data.VersionId, undefined);
-                done();
-            });
-        });
-    });
-
-    describe('on a version-enabled bucket', () => {
         beforeEach(done => {
-            s3.putBucketVersioning({
-                Bucket: bucket,
-                VersioningConfiguration: constants.versioningEnabled,
-            }, done);
+            bucket = `versioning-bucket-${Date.now()}`;
+            s3.createBucket({ Bucket: bucket }, done);
         });
 
-        it('should create a new version for an object', done => {
+        afterEach(done => {
+            removeAllVersions({ Bucket: bucket }, err => {
+                if (err) {
+                    return done(err);
+                }
+                return s3.deleteBucket({ Bucket: bucket }, done);
+            });
+        });
+
+        it('should put and get a non-versioned object without including ' +
+        'version ids in response headers', done => {
             const params = { Bucket: bucket, Key: key };
             s3.putObject(params, (err, data) => {
                 _assertNoError(err, 'putting object');
-                params.VersionId = data.VersionId;
+                assert.strictEqual(data.VersionId, undefined);
                 s3.getObject(params, (err, data) => {
                     _assertNoError(err, 'getting object');
-                    assert.strictEqual(params.VersionId, data.VersionId,
-                            'version ids are not equal');
+                    assert.strictEqual(data.VersionId, undefined);
                     done();
                 });
             });
         });
-    });
 
-    describe('on a version-enabled bucket with non-versioned object', () => {
-        const eTags = [];
-
-        beforeEach(done => {
-            s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
-                (err, data) => {
-                    if (err) {
-                        done(err);
-                    }
-                    eTags.push(data.ETag);
-                    s3.putBucketVersioning({
-                        Bucket: bucket,
-                        VersioningConfiguration: constants.versioningEnabled,
-                    }, done);
+        it('version-specific get should still not return version id in ' +
+        'response header', done => {
+            const params = { Bucket: bucket, Key: key };
+            s3.putObject(params, (err, data) => {
+                _assertNoError(err, 'putting object');
+                assert.strictEqual(data.VersionId, undefined);
+                params.VersionId = 'null';
+                s3.getObject(params, (err, data) => {
+                    _assertNoError(err, 'getting specific version "null"');
+                    assert.strictEqual(data.VersionId, undefined);
+                    done();
                 });
-        });
-
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
-
-        it('should get null version in versioning enabled bucket',
-        done => {
-            const paramsNull = { Bucket: bucket, Key: '/', VersionId: 'null' };
-            s3.getObject(paramsNull, err => {
-                _assertNoError(err, 'getting null version');
-                done();
             });
         });
 
-        it('should keep null version and create a new version for an object',
-        done => {
-            const params = { Bucket: bucket, Key: key, Body: data[1] };
-            s3.putObject(params, (err, data) => {
-                const newVersion = data.VersionId;
-                eTags.push(data.ETag);
-                s3.getObject({ Bucket: bucket, Key: key,
-                    VersionId: newVersion }, (err, data) => {
-                    assert.strictEqual(err, null);
-                    assert.strictEqual(data.VersionId, newVersion,
-                        'version ids are not equal');
-                    assert.strictEqual(data.ETag, eTags[1]);
-                    s3.getObject({ Bucket: bucket, Key: key,
-                    VersionId: 'null' }, (err, data) => {
-                        _assertNoError(err, 'getting null version');
-                        assert.strictEqual(data.VersionId, 'null');
-                        assert.strictEqual(data.ETag, eTags[0]);
+        describe('on a version-enabled bucket', () => {
+            beforeEach(done => {
+                s3.putBucketVersioning({
+                    Bucket: bucket,
+                    VersioningConfiguration: versioningEnabled,
+                }, done);
+            });
+
+            it('should create a new version for an object', done => {
+                const params = { Bucket: bucket, Key: key };
+                s3.putObject(params, (err, data) => {
+                    _assertNoError(err, 'putting object');
+                    params.VersionId = data.VersionId;
+                    s3.getObject(params, (err, data) => {
+                        _assertNoError(err, 'getting object');
+                        assert.strictEqual(params.VersionId, data.VersionId,
+                                'version ids are not equal');
                         done();
                     });
                 });
             });
         });
 
-        it('should create new versions but still keep nullVersionId',
-        done => {
-            const versionIds = [];
-            const params = { Bucket: bucket, Key: key };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            // create new versions
-            async.timesSeries(counter, (i, next) => s3.putObject(params,
-                (err, data) => {
-                    versionIds.push(data.VersionId);
-                    // get the 'null' version
-                    s3.getObject(paramsNull, (err, nullVerData) => {
-                        assert.strictEqual(err, null);
-                        assert.strictEqual(nullVerData.ETag, eTags[0]);
-                        assert.strictEqual(nullVerData.VersionId, 'null');
-                        next(err);
+        describe('on a version-enabled bucket with non-versioned object',
+        () => {
+            const eTags = [];
+
+            beforeEach(done => {
+                s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
+                    (err, data) => {
+                        if (err) {
+                            done(err);
+                        }
+                        eTags.push(data.ETag);
+                        s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningEnabled,
+                        }, done);
                     });
-                }), done);
-        });
-    });
+            });
 
-    describe('on version-suspended bucket', () => {
-        beforeEach(done => {
-            s3.putBucketVersioning({
-                Bucket: bucket,
-                VersioningConfiguration: constants.versioningSuspended,
-            }, done);
-        });
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
+                done();
+            });
 
-        it('should not return version id for new object', done => {
-            const params = { Bucket: bucket, Key: key, Body: 'foo' };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            s3.putObject(params, (err, data) => {
-                const eTag = data.ETag;
-                _assertNoError(err, 'putting object');
-                assert.strictEqual(data.VersionId, undefined);
-                // getting null version should return object we just put
-                s3.getObject(paramsNull, (err, nullVerData) => {
+            it('should get null version in versioning enabled bucket',
+            done => {
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: 'null',
+                };
+                s3.getObject(paramsNull, err => {
                     _assertNoError(err, 'getting null version');
-                    assert.strictEqual(nullVerData.ETag, eTag);
-                    assert.strictEqual(nullVerData.VersionId, 'null');
                     done();
                 });
             });
-        });
 
-        it('should update null version if put object twice', done => {
-            const params = { Bucket: bucket, Key: key };
-            const params1 = { Bucket: bucket, Key: key, Body: data[0] };
-            const params2 = { Bucket: bucket, Key: key, Body: data[1] };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            const eTags = [];
-            async.waterfall([
-                callback => s3.putObject(params1, (err, data) => {
-                    _assertNoError(err, 'putting first object');
-                    assert.strictEqual(data.VersionId, undefined);
+            it('should keep null version and create a new version',
+            done => {
+                const params = { Bucket: bucket, Key: key, Body: data[1] };
+                s3.putObject(params, (err, data) => {
+                    const newVersion = data.VersionId;
                     eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.getObject(params, (err, data) => {
-                    _assertNoError(err, 'getting master version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[0],
-                        'wrong object data');
-                    callback();
-                }),
-                callback => s3.putObject(params2, (err, data) => {
-                    _assertNoError(err, 'putting second object');
-                    assert.strictEqual(data.VersionId, undefined);
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.getObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'getting null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-            ], done);
-        });
-    });
-
-    describe('on a version-suspended bucket with non-versioned object', () => {
-        const eTags = [];
-
-        beforeEach(done => {
-            s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
-                (err, data) => {
-                    if (err) {
-                        done(err);
-                    }
-                    eTags.push(data.ETag);
-                    s3.putBucketVersioning({
-                        Bucket: bucket,
-                        VersioningConfiguration: constants.versioningSuspended,
-                    }, done);
+                    s3.getObject({ Bucket: bucket, Key: key,
+                        VersionId: newVersion }, (err, data) => {
+                        assert.strictEqual(err, null);
+                        assert.strictEqual(data.VersionId, newVersion,
+                            'version ids are not equal');
+                        assert.strictEqual(data.ETag, eTags[1]);
+                        s3.getObject({ Bucket: bucket, Key: key,
+                        VersionId: 'null' }, (err, data) => {
+                            _assertNoError(err, 'getting null version');
+                            assert.strictEqual(data.VersionId, 'null');
+                            assert.strictEqual(data.ETag, eTags[0]);
+                            done();
+                        });
+                    });
                 });
-        });
+            });
 
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
-
-        it('should get null version in versioning suspended bucket',
-        done => {
-            const paramsNull = { Bucket: bucket, Key: '/', VersionId: 'null' };
-            s3.getObject(paramsNull, err => {
-                _assertNoError(err, 'getting null version');
-                done();
+            it('should create new versions but still keep nullVersionId',
+            done => {
+                const versionIds = [];
+                const params = { Bucket: bucket, Key: key };
+                const paramsNull = {
+                    Bucket: bucket, Key:
+                    key,
+                    VersionId: 'null',
+                };
+                // create new versions
+                async.timesSeries(counter, (i, next) => s3.putObject(params,
+                    (err, data) => {
+                        versionIds.push(data.VersionId);
+                        // get the 'null' version
+                        s3.getObject(paramsNull, (err, nullVerData) => {
+                            assert.strictEqual(err, null);
+                            assert.strictEqual(nullVerData.ETag, eTags[0]);
+                            assert.strictEqual(nullVerData.VersionId, 'null');
+                            next(err);
+                        });
+                    }), done);
             });
         });
 
-        it('should update null version in versioning suspended bucket',
-        done => {
-            const params = { Bucket: bucket, Key: key };
-            const putParams = { Bucket: bucket, Key: '/', Body: data[1] };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            async.waterfall([
-                callback => s3.getObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'getting null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    callback();
-                }),
-                callback => s3.putObject(putParams, (err, data) => {
+        describe('on version-suspended bucket', () => {
+            beforeEach(done => {
+                s3.putBucketVersioning({
+                    Bucket: bucket,
+                    VersioningConfiguration: versioningSuspended,
+                }, done);
+            });
+
+            it('should not return version id for new object', done => {
+                const params = { Bucket: bucket, Key: key, Body: 'foo' };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: 'null',
+                };
+                s3.putObject(params, (err, data) => {
+                    const eTag = data.ETag;
                     _assertNoError(err, 'putting object');
                     assert.strictEqual(data.VersionId, undefined);
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.getObject(paramsNull, (err, data) => {
-                    _assertNoError(err, 'getting null version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-                callback => s3.getObject(params, (err, data) => {
-                    _assertNoError(err, 'getting master version');
-                    assert.strictEqual(data.VersionId, 'null');
-                    assert.strictEqual(data.ETag, eTags[1],
-                        'wrong object data');
-                    callback();
-                }),
-            ], done);
-        });
-    });
+                    // getting null version should return object we just put
+                    s3.getObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(nullVerData.ETag, eTag);
+                        assert.strictEqual(nullVerData.VersionId, 'null');
+                        done();
+                    });
+                });
+            });
 
-    describe('on versioning suspended then enabled bucket with null version',
-    () => {
-        const eTags = [];
-        beforeEach(done => {
-            const params = { Bucket: bucket, Key: key, Body: data[0] };
-            async.waterfall([
-                callback => s3.putBucketVersioning({
+            it('should update null version if put object twice', done => {
+                const params = { Bucket: bucket, Key: key };
+                const params1 = { Bucket: bucket, Key: key, Body: data[0] };
+                const params2 = { Bucket: bucket, Key: key, Body: data[1] };
+                const paramsNull = {
                     Bucket: bucket,
-                    VersioningConfiguration: constants.versioningSuspended,
-                }, err => callback(err)),
-                callback => s3.putObject(params, (err, data) => {
-                    if (err) {
-                        callback(err);
-                    }
-                    eTags.push(data.ETag);
-                    callback();
-                }),
-                callback => s3.putBucketVersioning({
-                    Bucket: bucket,
-                    VersioningConfiguration: constants.versioningEnabled,
-                }, callback),
-            ], done);
+                    Key: key,
+                    VersionId: 'null',
+                };
+                const eTags = [];
+                async.waterfall([
+                    callback => s3.putObject(params1, (err, data) => {
+                        _assertNoError(err, 'putting first object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.getObject(params, (err, data) => {
+                        _assertNoError(err, 'getting master version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[0],
+                            'wrong object data');
+                        callback();
+                    }),
+                    callback => s3.putObject(params2, (err, data) => {
+                        _assertNoError(err, 'putting second object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.getObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                ], done);
+            });
         });
 
-        afterEach(done => {
-            // reset eTags
-            eTags.length = 0;
-            done();
-        });
+        describe('on a version-suspended bucket with non-versioned object',
+        () => {
+            const eTags = [];
 
-        it('should preserve the null version when creating new versions',
-        done => {
-            const params = { Bucket: bucket, Key: key };
-            const paramsNull = { Bucket: bucket, Key: key, VersionId: 'null' };
-            async.waterfall([
-                callback => s3.getObject(paramsNull, (err, nullVerData) => {
-                    _assertNoError(err, 'getting null version');
-                    assert.strictEqual(nullVerData.ETag, eTags[0]);
-                    assert.strictEqual(nullVerData.VersionId, 'null');
-                    callback();
-                }),
-                callback => async.timesSeries(counter, (i, next) =>
-                    s3.putObject(params, (err, data) => {
-                        _assertNoError(err, `putting object #${i}`);
-                        assert.notEqual(data.VersionId, undefined);
-                        next();
-                    }), err => callback(err)),
-                callback => s3.getObject(paramsNull, (err, nullVerData) => {
-                    _assertNoError(err, 'getting null version');
-                    assert.strictEqual(nullVerData.ETag, eTags[0]);
-                    callback();
-                }),
-            ], done);
-        });
+            beforeEach(done => {
+                s3.putObject({ Bucket: bucket, Key: key, Body: data[0] },
+                    (err, data) => {
+                        if (err) {
+                            done(err);
+                        }
+                        eTags.push(data.ETag);
+                        s3.putBucketVersioning({
+                            Bucket: bucket,
+                            VersioningConfiguration: versioningSuspended,
+                        }, done);
+                    });
+            });
 
-        it('should create a bunch of objects and their versions', done => {
-            const vids = [];
-            const keycount = 50;
-            const versioncount = 20;
-            const value = '{"foo":"bar"}';
-            async.times(keycount, (i, next1) => {
-                const key = `foo${i}`;
-                const params = { Bucket: bucket, Key: key, Body: value };
-                async.times(versioncount, (j, next2) =>
-                    s3.putObject(params, (err, data) => {
-                        assert.strictEqual(err, null);
-                        assert(data.VersionId, 'invalid versionId');
-                        vids.push({ Key: key, VersionId: data.VersionId });
-                        next2();
-                    }), next1);
-            }, err => {
-                assert.strictEqual(err, null);
-                assert.strictEqual(vids.length, keycount * versioncount);
-                // TODO use delete marker and check with the result
-                process.stdout.write('creating objects done, now deleting...');
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
                 done();
+            });
+
+            it('should get null version in versioning suspended bucket',
+            done => {
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: 'null',
+                };
+                s3.getObject(paramsNull, err => {
+                    _assertNoError(err, 'getting null version');
+                    done();
+                });
+            });
+
+            it('should update null version in versioning suspended bucket',
+            done => {
+                const params = { Bucket: bucket, Key: key };
+                const putParams = { Bucket: bucket, Key: key, Body: data[1] };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: 'null',
+                };
+                async.waterfall([
+                    callback => s3.getObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        callback();
+                    }),
+                    callback => s3.putObject(putParams, (err, data) => {
+                        _assertNoError(err, 'putting object');
+                        assert.strictEqual(data.VersionId, undefined);
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.getObject(paramsNull, (err, data) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                    callback => s3.getObject(params, (err, data) => {
+                        _assertNoError(err, 'getting master version');
+                        assert.strictEqual(data.VersionId, 'null');
+                        assert.strictEqual(data.ETag, eTags[1],
+                            'wrong object data');
+                        callback();
+                    }),
+                ], done);
+            });
+        });
+
+        describe('on versioning suspended then enabled bucket w/ null version',
+        () => {
+            const eTags = [];
+            beforeEach(done => {
+                const params = { Bucket: bucket, Key: key, Body: data[0] };
+                async.waterfall([
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningSuspended,
+                    }, err => callback(err)),
+                    callback => s3.putObject(params, (err, data) => {
+                        if (err) {
+                            callback(err);
+                        }
+                        eTags.push(data.ETag);
+                        callback();
+                    }),
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningEnabled,
+                    }, callback),
+                ], done);
+            });
+
+            afterEach(done => {
+                // reset eTags
+                eTags.length = 0;
+                done();
+            });
+
+            it('should preserve the null version when creating new versions',
+            done => {
+                const params = { Bucket: bucket, Key: key };
+                const paramsNull = {
+                    Bucket: bucket,
+                    Key: key,
+                    VersionId: 'null',
+                };
+                async.waterfall([
+                    callback => s3.getObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(nullVerData.ETag, eTags[0]);
+                        assert.strictEqual(nullVerData.VersionId, 'null');
+                        callback();
+                    }),
+                    callback => async.timesSeries(counter, (i, next) =>
+                        s3.putObject(params, (err, data) => {
+                            _assertNoError(err, `putting object #${i}`);
+                            assert.notEqual(data.VersionId, undefined);
+                            next();
+                        }), err => callback(err)),
+                    callback => s3.getObject(paramsNull, (err, nullVerData) => {
+                        _assertNoError(err, 'getting null version');
+                        assert.strictEqual(nullVerData.ETag, eTags[0]);
+                        callback();
+                    }),
+                ], done);
+            });
+
+            it('should create a bunch of objects and their versions', done => {
+                const vids = [];
+                const keycount = 50;
+                const versioncount = 20;
+                const value = '{"foo":"bar"}';
+                async.times(keycount, (i, next1) => {
+                    const key = `foo${i}`;
+                    const params = { Bucket: bucket, Key: key, Body: value };
+                    async.times(versioncount, (j, next2) =>
+                        s3.putObject(params, (err, data) => {
+                            assert.strictEqual(err, null);
+                            assert(data.VersionId, 'invalid versionId');
+                            vids.push({ Key: key, VersionId: data.VersionId });
+                            next2();
+                        }), next1);
+                }, err => {
+                    assert.strictEqual(err, null);
+                    assert.strictEqual(vids.length, keycount * versioncount);
+                    done();
+                });
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/versioning/objectPutCopyPart.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectPutCopyPart.js
@@ -1,14 +1,14 @@
 import assert from 'assert';
-import { S3 } from 'aws-sdk';
 import async from 'async';
+
+import withV4 from '../support/withV4';
+import BucketUtility from '../../lib/utility/bucket-util';
+
 import {
     removeAllVersions,
-    constants,
+    versioningEnabled,
+    versioningSuspended,
 } from '../../lib/utility/versioning-util.js';
-import getConfig from '../support/config';
-
-const config = getConfig('default', { signatureVersion: 'v4' });
-const s3 = new S3(config);
 
 let sourceBucket;
 let destBucket;
@@ -23,374 +23,380 @@ function _assertNoError(err, desc) {
 const testing = process.env.VERSIONING === 'no' ? describe.skip : describe;
 
 testing('Object Part Copy with Versioning', () => {
-    let uploadId;
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        let uploadId;
 
-    beforeEach(done => {
-        sourceBucket = `copypartsourcebucket-${Date.now()}`;
-        destBucket = `copypartdestbucket-${Date.now()}`;
-        async.forEach([sourceBucket, destBucket], (bucket, cb) => {
-            s3.createBucket({ Bucket: bucket }, cb);
-        }, done);
-    });
-
-    afterEach(done => {
-        s3.abortMultipartUpload({
-            Bucket: destBucket,
-            Key: destKey,
-            UploadId: uploadId,
-        }, err => {
-            if (err) {
-                return done(err);
-            }
-            return async.forEach([sourceBucket, destBucket], (bucket, cb) => {
-                removeAllVersions({ Bucket: bucket }, err => {
-                    if (err) {
-                        return cb(err);
-                    }
-                    return s3.deleteBucket({ Bucket: bucket }, cb);
-                });
+        beforeEach(done => {
+            sourceBucket = `copypartsourcebucket-${Date.now()}`;
+            destBucket = `copypartdestbucket-${Date.now()}`;
+            async.forEach([sourceBucket, destBucket], (bucket, cb) => {
+                s3.createBucket({ Bucket: bucket }, cb);
             }, done);
         });
-    });
-
-    describe('on bucket without versioning', () => {
-        const eTags = [];
-
-        beforeEach(done => {
-            async.waterfall([
-                next => s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
-                    Body: 'foobar' }, next),
-                (data, next) => {
-                    eTags.push(data.ETag);
-                    s3.createMultipartUpload({ Bucket: destBucket,
-                        Key: destKey }, next);
-                },
-            ], (err, data) => {
-                if (err) {
-                    return done(err);
-                }
-                uploadId = data.UploadId;
-                return done();
-            });
-        });
 
         afterEach(done => {
-            eTags.length = 0;
-            done();
-        });
-
-        it('should not return a version id when put part by copying ' +
-        'without specifying version id', done => {
-            s3.uploadPartCopy({
+            s3.abortMultipartUpload({
                 Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}`,
                 Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'uploading part copy without version id');
-                assert.strictEqual(data.CopySourceVersionId, undefined);
-                assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
-                done();
-            });
-        });
-
-        it('should return NoSuchKey if copy source version id is invalid ' +
-        'id', done => {
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}?` +
-                `versionId=${invalidId}`,
-                Key: destKey,
-                PartNumber: 1,
                 UploadId: uploadId,
             }, err => {
-                assert(err, `Expected err but got ${err}`);
-                assert.strictEqual(err.code, 'InvalidArgument');
-                assert.strictEqual(err.statusCode, 400);
-                done();
-            });
-        });
-
-        it('should allow specific version "null" for copy source ' +
-        'and return version id "null" in response headers', done => {
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err,
-                    'using specific version "null" for copy source');
-                assert.strictEqual(data.CopySourceVersionId, 'null');
-                assert.strictEqual(data.ETag, eTags[0]);
-                done();
-            });
-        });
-    });
-
-    describe('on bucket with versioning', () => {
-        const eTags = [];
-        const versionIds = [];
-        const counter = 10;
-
-        beforeEach(done => {
-            const params = { Bucket: sourceBucket, Key: sourceKey };
-            async.waterfall([
-                next => s3.putObject(params, next),
-                (data, next) => {
-                    eTags.push(data.ETag);
-                    versionIds.push('null');
-                    s3.putBucketVersioning({
-                        Bucket: sourceBucket,
-                        VersioningConfiguration: constants.versioningEnabled,
-                    }, err => next(err));
-                },
-                next => async.timesSeries(counter, (i, cb) =>
-                    s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
-                        Body: `foo${i}` }, (err, data) => {
-                        _assertNoError(err, `putting version #${i}`);
-                        eTags.push(data.ETag);
-                        versionIds.push(data.VersionId);
-                        cb(err);
-                    }), err => next(err)),
-                next => s3.createMultipartUpload({ Bucket: destBucket,
-                    Key: destKey }, next),
-            ], (err, data) => {
                 if (err) {
                     return done(err);
                 }
-                uploadId = data.UploadId;
-                return done();
+                return async.each([sourceBucket, destBucket], (bucket, cb) => {
+                    removeAllVersions({ Bucket: bucket }, err => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        return s3.deleteBucket({ Bucket: bucket }, cb);
+                    });
+                }, done);
             });
         });
 
-        afterEach(done => {
-            eTags.length = 0;
-            versionIds.length = 0;
-            done();
-        });
+        describe('on bucket without versioning', () => {
+            const eTags = [];
 
-        it('copy part without specifying version should return data and ' +
-        'version id of latest version', done => {
-            const lastVersion = versionIds[versionIds.length - 1];
-            const lastETag = eTags[eTags.length - 1];
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'uploading part copy without version id');
-                assert.strictEqual(data.CopySourceVersionId, lastVersion);
-                assert.strictEqual(data.CopyPartResult.ETag, lastETag);
+            beforeEach(done => {
+                async.waterfall([
+                    next => s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
+                        Body: 'foobar' }, next),
+                    (data, next) => {
+                        eTags.push(data.ETag);
+                        s3.createMultipartUpload({ Bucket: destBucket,
+                            Key: destKey }, next);
+                    },
+                ], (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    uploadId = data.UploadId;
+                    return done();
+                });
+            });
+
+            afterEach(done => {
+                eTags.length = 0;
                 done();
             });
-        });
 
-        it('copy part without specifying version should return NoSuchKey ' +
-        'if latest version has a delete marker', done => {
-            s3.deleteObject({ Bucket: sourceBucket, Key: sourceKey }, err => {
-                _assertNoError(err, 'deleting latest version');
+            it('should not return a version id when put part by copying ' +
+            'without specifying version id', done => {
                 s3.uploadPartCopy({
                     Bucket: destBucket,
                     CopySource: `${sourceBucket}/${sourceKey}`,
                     Key: destKey,
                     PartNumber: 1,
                     UploadId: uploadId,
-                }, err => {
-                    assert(err, 'Expected err but did not find one');
-                    assert.strictEqual(err.code, 'NoSuchKey');
-                    assert.strictEqual(err.statusCode, 404);
+                }, (err, data) => {
+                    _assertNoError(err, 'uploading part copy w/o version id');
+                    assert.strictEqual(data.CopySourceVersionId, undefined);
+                    assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
                     done();
                 });
             });
-        });
 
-        it('copy part with specific version id should return InvalidRequest ' +
-        'if that id is a delete marker', done => {
-            async.waterfall([
-                next => s3.deleteObject({
-                    Bucket: sourceBucket,
-                    Key: sourceKey,
-                }, err => next(err)),
-                next => s3.listObjectVersions({ Bucket: sourceBucket }, next),
-                (data, next) => {
-                    const deleteMarkerId = data.DeleteMarkers[0].VersionId;
-                    return s3.uploadPartCopy({
-                        Bucket: destBucket,
-                        CopySource: `${sourceBucket}/${sourceKey}` +
-                        `?versionId=${encodeURIComponent(deleteMarkerId)}`,
-                        Key: destKey,
-                        PartNumber: 1,
-                        UploadId: uploadId,
-                    }, next);
-                },
-            ], err => {
-                assert(err, 'Expected err but did not find one');
-                assert.strictEqual(err.code, 'InvalidRequest');
-                assert.strictEqual(err.statusCode, 400);
-                done();
-            });
-        });
-
-        it('copy part with specific version should return NoSuchVersion ' +
-        'if version does not exist', done => {
-            const versionId = versionIds[1];
-            s3.deleteObject({ Bucket: sourceBucket, Key: sourceKey,
-                VersionId: versionId }, (err, data) => {
-                _assertNoError(err, `deleting version ${versionId}`);
-                assert.strictEqual(data.VersionId, versionId);
+            it('should return NoSuchKey if copy source version id is invalid ' +
+            'id', done => {
                 s3.uploadPartCopy({
                     Bucket: destBucket,
-                    CopySource: `${sourceBucket}/${sourceKey}` +
-                     `?versionId=${encodeURIComponent(versionId)}`,
+                    CopySource: `${sourceBucket}/${sourceKey}?` +
+                    `versionId=${invalidId}`,
                     Key: destKey,
                     PartNumber: 1,
                     UploadId: uploadId,
                 }, err => {
-                    assert(err, 'Expected err but did not find one');
-                    assert.strictEqual(err.code, 'NoSuchVersion');
-                    assert.strictEqual(err.statusCode, 404);
+                    assert(err, `Expected err but got ${err}`);
+                    assert.strictEqual(err.code, 'InvalidArgument');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('should allow specific version "null" for copy source ' +
+            'and return version id "null" in response headers', done => {
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err,
+                        'using specific version "null" for copy source');
+                    assert.strictEqual(data.CopySourceVersionId, 'null');
+                    assert.strictEqual(data.ETag, eTags[0]);
                     done();
                 });
             });
         });
 
-        it('copy part with specific version should return copy source ' +
-        'version id if it exists', done => {
-            const versionId = versionIds[1];
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}` +
-                 `?versionId=${encodeURIComponent(versionId)}`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'copy part from specific version');
-                assert.strictEqual(data.CopySourceVersionId, versionId);
-                assert.strictEqual(data.CopyPartResult.ETag, eTags[1]);
-                done();
-            });
-        });
+        describe('on bucket with versioning', () => {
+            const eTags = [];
+            const versionIds = [];
+            const counter = 10;
 
-        it('copy part with specific version "null" should return copy ' +
-        'source version id "null" if it exists', done => {
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'copy part from specific version');
-                assert.strictEqual(data.CopySourceVersionId, 'null');
-                assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
-                done();
-            });
-        });
-    });
-
-    describe('on bucket with versioning suspended', () => {
-        const eTags = []; // or eTag = ....
-        const versionIds = [];
-        const counter = 10;
-
-        beforeEach(done => {
-            const params = { Bucket: sourceBucket, Key: sourceKey };
-            async.waterfall([
-                next => s3.putObject(params, next),
-                (data, next) => {
-                    eTags.push(data.ETag);
-                    versionIds.push('null');
-                    s3.putBucketVersioning({
-                        Bucket: sourceBucket,
-                        VersioningConfiguration: constants.versioningEnabled,
-                    }, err => next(err));
-                },
-                next => async.timesSeries(counter, (i, cb) =>
-                    s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
-                        Body: `foo${i}` }, (err, data) => {
-                        _assertNoError(err, `putting version #${i}`);
+            beforeEach(done => {
+                const params = { Bucket: sourceBucket, Key: sourceKey };
+                async.waterfall([
+                    next => s3.putObject(params, next),
+                    (data, next) => {
                         eTags.push(data.ETag);
-                        versionIds.push(data.VersionId);
-                        cb(err);
-                    }), err => next(err)),
-                next => {
-                    s3.putBucketVersioning({
+                        versionIds.push('null');
+                        s3.putBucketVersioning({
+                            Bucket: sourceBucket,
+                            VersioningConfiguration: versioningEnabled,
+                        }, err => next(err));
+                    },
+                    next => async.timesSeries(counter, (i, cb) =>
+                        s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
+                            Body: `foo${i}` }, (err, data) => {
+                            _assertNoError(err, `putting version #${i}`);
+                            eTags.push(data.ETag);
+                            versionIds.push(data.VersionId);
+                            cb(err);
+                        }), err => next(err)),
+                    next => s3.createMultipartUpload({ Bucket: destBucket,
+                        Key: destKey }, next),
+                ], (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    uploadId = data.UploadId;
+                    return done();
+                });
+            });
+
+            afterEach(done => {
+                eTags.length = 0;
+                versionIds.length = 0;
+                done();
+            });
+
+            it('copy part without specifying version should return data and ' +
+            'version id of latest version', done => {
+                const lastVersion = versionIds[versionIds.length - 1];
+                const lastETag = eTags[eTags.length - 1];
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'uploading part copy w/o version id');
+                    assert.strictEqual(data.CopySourceVersionId, lastVersion);
+                    assert.strictEqual(data.CopyPartResult.ETag, lastETag);
+                    done();
+                });
+            });
+
+            it('copy part without specifying version should return NoSuchKey ' +
+            'if latest version has a delete marker', done => {
+                s3.deleteObject({ Bucket: sourceBucket, Key: sourceKey },
+                    err => {
+                        _assertNoError(err, 'deleting latest version');
+                        s3.uploadPartCopy({
+                            Bucket: destBucket,
+                            CopySource: `${sourceBucket}/${sourceKey}`,
+                            Key: destKey,
+                            PartNumber: 1,
+                            UploadId: uploadId,
+                        }, err => {
+                            assert(err, 'Expected err but did not find one');
+                            assert.strictEqual(err.code, 'NoSuchKey');
+                            assert.strictEqual(err.statusCode, 404);
+                            done();
+                        });
+                    });
+            });
+
+            it('copy part with specific version id should return ' +
+            'InvalidRequest if that id is a delete marker', done => {
+                async.waterfall([
+                    next => s3.deleteObject({
                         Bucket: sourceBucket,
-                        VersioningConfiguration: constants.versioningSuspended,
-                    }, err => next(err));
-                },
-                next => s3.createMultipartUpload({ Bucket: destBucket,
-                    Key: destKey }, next),
-            ], (err, data) => {
-                if (err) {
-                    return done(err);
-                }
-                uploadId = data.UploadId;
-                return done();
+                        Key: sourceKey,
+                    }, err => next(err)),
+                    next => s3.listObjectVersions({ Bucket: sourceBucket },
+                        next),
+                    (data, next) => {
+                        const deleteMarkerId = data.DeleteMarkers[0].VersionId;
+                        return s3.uploadPartCopy({
+                            Bucket: destBucket,
+                            CopySource: `${sourceBucket}/${sourceKey}` +
+                            `?versionId=${deleteMarkerId}`,
+                            Key: destKey,
+                            PartNumber: 1,
+                            UploadId: uploadId,
+                        }, next);
+                    },
+                ], err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'InvalidRequest');
+                    assert.strictEqual(err.statusCode, 400);
+                    done();
+                });
+            });
+
+            it('copy part with specific version should return NoSuchVersion ' +
+            'if version does not exist', done => {
+                const versionId = versionIds[1];
+                s3.deleteObject({ Bucket: sourceBucket, Key: sourceKey,
+                    VersionId: versionId }, (err, data) => {
+                    _assertNoError(err, `deleting version ${versionId}`);
+                    assert.strictEqual(data.VersionId, versionId);
+                    s3.uploadPartCopy({
+                        Bucket: destBucket,
+                        CopySource: `${sourceBucket}/${sourceKey}` +
+                         `?versionId=${versionId}`,
+                        Key: destKey,
+                        PartNumber: 1,
+                        UploadId: uploadId,
+                    }, err => {
+                        assert(err, 'Expected err but did not find one');
+                        assert.strictEqual(err.code, 'NoSuchVersion');
+                        assert.strictEqual(err.statusCode, 404);
+                        done();
+                    });
+                });
+            });
+
+            it('copy part with specific version should return copy source ' +
+            'version id if it exists', done => {
+                const versionId = versionIds[1];
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}` +
+                     `?versionId=${versionId}`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'copy part from specific version');
+                    assert.strictEqual(data.CopySourceVersionId, versionId);
+                    assert.strictEqual(data.CopyPartResult.ETag, eTags[1]);
+                    done();
+                });
+            });
+
+            it('copy part with specific version "null" should return copy ' +
+            'source version id "null" if it exists', done => {
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'copy part from specific version');
+                    assert.strictEqual(data.CopySourceVersionId, 'null');
+                    assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
+                    done();
+                });
             });
         });
 
-        afterEach(done => {
-            eTags.length = 0;
-            versionIds.length = 0;
-            done();
-        });
+        describe('on bucket with versioning suspended', () => {
+            const eTags = []; // or eTag = ....
+            const versionIds = [];
+            const counter = 10;
 
-        it('copy part without specifying version should still return ' +
-        'version id of latest version', done => {
-            const lastVersion = versionIds[versionIds.length - 1];
-            const lastETag = eTags[eTags.length - 1];
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'uploading part copy without version id');
-                assert.strictEqual(data.CopySourceVersionId, lastVersion);
-                assert.strictEqual(data.CopyPartResult.ETag, lastETag);
+            beforeEach(done => {
+                const params = { Bucket: sourceBucket, Key: sourceKey };
+                async.waterfall([
+                    next => s3.putObject(params, next),
+                    (data, next) => {
+                        eTags.push(data.ETag);
+                        versionIds.push('null');
+                        s3.putBucketVersioning({
+                            Bucket: sourceBucket,
+                            VersioningConfiguration: versioningEnabled,
+                        }, err => next(err));
+                    },
+                    next => async.timesSeries(counter, (i, cb) =>
+                        s3.putObject({ Bucket: sourceBucket, Key: sourceKey,
+                            Body: `foo${i}` }, (err, data) => {
+                            _assertNoError(err, `putting version #${i}`);
+                            eTags.push(data.ETag);
+                            versionIds.push(data.VersionId);
+                            cb(err);
+                        }), err => next(err)),
+                    next => {
+                        s3.putBucketVersioning({
+                            Bucket: sourceBucket,
+                            VersioningConfiguration: versioningSuspended,
+                        }, err => next(err));
+                    },
+                    next => s3.createMultipartUpload({ Bucket: destBucket,
+                        Key: destKey }, next),
+                ], (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    uploadId = data.UploadId;
+                    return done();
+                });
+            });
+
+            afterEach(done => {
+                eTags.length = 0;
+                versionIds.length = 0;
                 done();
             });
-        });
 
-        it('copy part with specific version should still return copy ' +
-        'source version id if it exists', done => {
-            const versionId = versionIds[1];
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}` +
-                 `?versionId=${encodeURIComponent(versionId)}`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'copy part from specific version');
-                assert.strictEqual(data.CopySourceVersionId, versionId);
-                assert.strictEqual(data.CopyPartResult.ETag, eTags[1]);
-                done();
+            it('copy part without specifying version should still return ' +
+            'version id of latest version', done => {
+                const lastVersion = versionIds[versionIds.length - 1];
+                const lastETag = eTags[eTags.length - 1];
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'uploading part copy w/o version id');
+                    assert.strictEqual(data.CopySourceVersionId, lastVersion);
+                    assert.strictEqual(data.CopyPartResult.ETag, lastETag);
+                    done();
+                });
             });
-        });
 
-        it('copy part with specific version "null" should still return copy ' +
-        'source version id "null" if it exists', done => {
-            s3.uploadPartCopy({
-                Bucket: destBucket,
-                CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
-                Key: destKey,
-                PartNumber: 1,
-                UploadId: uploadId,
-            }, (err, data) => {
-                _assertNoError(err, 'copy part from specific version');
-                assert.strictEqual(data.CopySourceVersionId, 'null');
-                assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
-                done();
+            it('copy part with specific version should still return copy ' +
+            'source version id if it exists', done => {
+                const versionId = versionIds[1];
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}` +
+                     `?versionId=${versionId}`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'copy part from specific version');
+                    assert.strictEqual(data.CopySourceVersionId, versionId);
+                    assert.strictEqual(data.CopyPartResult.ETag, eTags[1]);
+                    done();
+                });
+            });
+
+            it('copy part with specific version "null" should still return ' +
+            'copy source version id "null" if it exists', done => {
+                s3.uploadPartCopy({
+                    Bucket: destBucket,
+                    CopySource: `${sourceBucket}/${sourceKey}?versionId=null`,
+                    Key: destKey,
+                    PartNumber: 1,
+                    UploadId: uploadId,
+                }, (err, data) => {
+                    _assertNoError(err, 'copy part from specific version');
+                    assert.strictEqual(data.CopySourceVersionId, 'null');
+                    assert.strictEqual(data.CopyPartResult.ETag, eTags[0]);
+                    done();
+                });
             });
         });
     });


### PR DESCRIPTION
Dependent on https://github.com/scality/Arsenal/pull/242

Switched to just encoding the version ids, and hex instead of base64 to simplify authentication checks.

Functional tests were changed just to test with both v2 and v4, not just v4. The large diffs are mostly due to indentation level.