### PR TITLE
FIX: returning correct DeleteMarkerVersionId when deleteObjects

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -97,10 +97,9 @@ function _formatXML(quietSetting, errorResults, deleted) {
     }
     const deletedXML = [];
     deleted.forEach(version => {
-        const isDeletingDeleteMarker = version.isDeletingDeleteMarker;
+        const isDeleteMarker = version.isDeleteMarker;
+        const deleteMarkerVersionId = version.deleteMarkerVersionId;
         // if deletion resulted in new delete marker or deleting a delete marker
-        const isDeleteMarker =
-            version.newDeleteMarker || isDeletingDeleteMarker;
         deletedXML.push(
             '<Deleted>',
             '<Key>',
@@ -118,13 +117,9 @@ function _formatXML(quietSetting, errorResults, deleted) {
             deletedXML.push(
                 '<DeleteMarker>',
                 isDeleteMarker,
-                '</DeleteMarker>'
-            );
-        }
-        if (isDeletingDeleteMarker) {
-            deletedXML.push(
+                '</DeleteMarker>',
                 '<DeleteMarkerVersionId>',
-                isDeletingDeleteMarker,
+                deleteMarkerVersionId,
                 '</DeleteMarkerVersionId>'
             );
         }
@@ -253,10 +248,10 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
                 // This call will create a delete-marker
                 return createAndStoreObject(bucketName, bucket, entry.key,
                     objMD, authInfo, canonicalID, null, request,
-                    deleteInfo.newDeleteMarker, null, log, err =>
-                    callback(err, objMD, deleteInfo));
+                    deleteInfo.newDeleteMarker, null, log, (err, result) =>
+                    callback(err, objMD, deleteInfo, result.versionId));
             },
-        ], (err, objMD, deleteInfo) => {
+        ], (err, objMD, deleteInfo, versionId) => {
             if (err === skipError) {
                 return moveOn();
             } else if (err) {
@@ -271,9 +266,24 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
             // TODO: update number of objects to reflect creation of
             // delete markers; Utapi must be updated to allow this for
             // 'deleteObject' metrics
-            const newDeleteMarker = deleteInfo.newDeleteMarker;
-            successfullyDeleted.push({ entry, newDeleteMarker,
-                isDeletingDeleteMarker: objMD.isDeleteMarker });
+            let isDeleteMarker;
+            let deleteMarkerVersionId;
+            // - If trying to delete an object that does not exist (if a new
+            // delete marker was created)
+            // - Or if an object exists but no version was specified
+            // return DeleteMarkerVersionId equals the versionID of the marker
+            // you just generated and DeleteMarker tag equals true
+            if (deleteInfo.newDeleteMarker) {
+                isDeleteMarker = true;
+                deleteMarkerVersionId = versionIdUtils.encode(versionId);
+            // If trying to delete a delete marker, DeleteMarkerVersionId equals
+            // deleteMarker's versionID and DeleteMarker equals true
+            } else if (objMD && objMD.isDeleteMarker) {
+                isDeleteMarker = true;
+                deleteMarkerVersionId = entry.versionId;
+            }
+            successfullyDeleted.push({ entry, isDeleteMarker,
+              deleteMarkerVersionId });
             return moveOn();
         });
     },


### PR DESCRIPTION
Fixing ceph test: 
`ERROR: s3tests.functional.test_s3.test_versioning_multi_object_delete_with_marker_create`

`DeleteMarkerVersionId` should be a versionId not a boolean. 

6. Also check that multi-object delete has ‘isDeleteMarker’ in result in both cases deleting delete marker and new delete marker (according to AWS)