### PR TITLE
S3C-35 versioning for bucketfile client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -93,11 +93,10 @@ test:
         && ENABLE_KMS_ENCRYPTION=true npm run ft_node
 
     # Run S3 with file Backend ; run ft_tests
-    # TODO remove 'VERSIONING=no' to test versioning when file backend is ready
     - S3BACKEND=file S3VAULT=mem MPU_TESTING=yes npm start
             > $CIRCLE_ARTIFACTS/server_file_awssdk.txt
         & bash wait_for_local_port.bash 8000 40
-        && VERSIONING=no npm run ft_awssdk
+        && npm run ft_awssdk
     - S3BACKEND=file S3VAULT=mem npm start
             > $CIRCLE_ARTIFACTS/server_file_s3cmd.txt
         & bash wait_for_local_port.bash 8000 40
@@ -112,11 +111,10 @@ test:
         && npm run ft_node
 
     # Run S3 with file Backend + KMS Encryption ; run ft_tests
-    # TODO remove 'VERSIONING=no' to test versioning when file backend is ready
     - S3BACKEND=file S3VAULT=mem MPU_TESTING=yes npm start
             > $CIRCLE_ARTIFACTS/server_file_kms_awssdk.txt
         & bash wait_for_local_port.bash 8000 40
-        && VERSIONING=no ENABLE_KMS_ENCRYPTION=true npm run ft_awssdk
+        && ENABLE_KMS_ENCRYPTION=true npm run ft_awssdk
     - S3BACKEND=file S3VAULT=mem npm start
             > $CIRCLE_ARTIFACTS/server_file_kms_s3cmd.txt
         & bash wait_for_local_port.bash 8000 40

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -11,7 +11,10 @@ const errors = arsenal.errors;
 const MetadataClient = arsenal.storage.metadata.client;
 
 const METASTORE = '__metastore';
-const OPTIONS = { sync: true };
+
+function getReqUids(logger) {
+    return logger ? logger.getSerializedUids() : 'BucketFileClient';
+}
 
 class BucketFileInterface {
 
@@ -39,7 +42,7 @@ class BucketFileInterface {
             BucketInfo.currentModelVersion());
         this.metastore.put(
             constants.usersBucket,
-            usersBucketAttr.serialize(), err => {
+            usersBucketAttr.serialize(), {}, getReqUids(), err => {
                 if (err) {
                     this.logger.fatal('error writing usersBucket ' +
                                       'attributes to metadata',
@@ -87,9 +90,9 @@ class BucketFileInterface {
     }
 
     getBucketAttributes(bucketName, log, cb) {
-        this.metastore.get(bucketName, (err, data) => {
+        this.metastore.get(bucketName, {}, getReqUids(log), (err, data) => {
             if (err) {
-                if (err.notFound) {
+                if (err.ObjNotFound) {
                     return cb(errors.NoSuchBucket);
                 }
                 const logObj = {
@@ -110,9 +113,9 @@ class BucketFileInterface {
             if (err) {
                 return cb(err);
             }
-            db.get(objName, (err, objAttr) => {
+            db.get(objName, params, getReqUids(log), (err, objAttr) => {
                 if (err) {
-                    if (err.notFound) {
+                    if (err.ObjNotFound) {
                         return cb(null, {
                             bucket: bucketAttr.serialize(),
                         });
@@ -137,7 +140,7 @@ class BucketFileInterface {
 
     putBucketAttributes(bucketName, bucketMD, log, cb) {
         this.metastore.put(bucketName, bucketMD.serialize(),
-                           OPTIONS,
+                           {}, getReqUids(log),
                            err => {
                                if (err) {
                                    const logObj = {
@@ -155,7 +158,7 @@ class BucketFileInterface {
     }
 
     deleteBucket(bucketName, log, cb) {
-        this.metastore.del(bucketName,
+        this.metastore.del(bucketName, {}, getReqUids(log),
                            err => {
                                if (err) {
                                    const logObj = {
@@ -178,9 +181,7 @@ class BucketFileInterface {
                 return cb(err);
             }
             db.put(objName, JSON.stringify(objVal),
-                   OPTIONS, err => {
-                       // TODO: implement versioning for file backend
-                       const data = undefined;
+                   params, getReqUids(log), (err, data) => {
                        if (err) {
                            const logObj = {
                                rawError: err,
@@ -202,9 +203,9 @@ class BucketFileInterface {
             if (err) {
                 return cb(err);
             }
-            db.get(objName, (err, data) => {
+            db.get(objName, params, getReqUids(log), (err, data) => {
                 if (err) {
-                    if (err.notFound) {
+                    if (err.ObjNotFound) {
                         return cb(errors.NoSuchKey);
                     }
                     const logObj = {
@@ -226,7 +227,7 @@ class BucketFileInterface {
             if (err) {
                 return cb(err);
             }
-            db.del(objName, OPTIONS, err => {
+            db.del(objName, params, getReqUids(log), err => {
                 if (err) {
                     const logObj = {
                         rawError: err,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal",
+    "arsenal": "scality/Arsenal#ft/S3C-35-metadataServer-versioning",
     "async": "~1.4.2",
     "babel-core": "^6.5.2",
     "babel-plugin-transform-es2015-destructuring": "^6.5.2",


### PR DESCRIPTION
    This is to support versioning in S3 bucketfile backend by using the
    versioning support in Arsenal ported from MetaData.
    
    Additional changes:
    - moves the 'SYNC' options to the bucketfile backend in Arsenal
    - checks for the error 'ObjNotFound' instead of 'notFound'
