### PR TITLE
CLEANUP: Remove obsolete metadataValidateAuthorization func

### DIFF
--- a/lib/api/bucketDelete.js
+++ b/lib/api/bucketDelete.js
@@ -2,7 +2,7 @@ import { errors } from 'arsenal';
 
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { deleteBucket } from './apiUtils/bucket/bucketDeletion';
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import { pushMetric } from '../utapi/utilities';
 
 /**
@@ -28,20 +28,19 @@ export default function bucketDelete(authInfo, request, log, cb) {
         authInfo,
         bucketName,
         requestType: 'bucketDelete',
-        log,
     };
 
-    return services.metadataValidateAuthorization(metadataValParams,
+    return metadataValidateBucket(metadataValParams, log,
         (err, bucketMD) => {
             const corsHeaders = collectCorsHeaders(request.headers.origin,
                 request.method, bucketMD);
             if (err) {
                 log.debug('error processing request',
-                    { method: 'metadataValidateAuthorization', error: err });
+                    { method: 'metadataValidateBucket', error: err });
                 return cb(err, corsHeaders);
             }
             log.trace('passed checks',
-                { method: 'metadataValidateAuthorization' });
+                { method: 'metadataValidateBucket' });
             return deleteBucket(bucketMD, bucketName, authInfo.getCanonicalID(),
                 log, err => {
                     if (err) {

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -2,6 +2,7 @@ import querystring from 'querystring';
 import constants from '../../constants';
 
 import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
@@ -233,7 +234,6 @@ export default function bucketGet(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketGet',
-        log,
     };
     const listParams = {
         listingType: 'DelimiterMaster',
@@ -243,7 +243,7 @@ export default function bucketGet(authInfo, request, log, callback) {
         prefix: params.prefix,
     };
 
-    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketGetACL.js
+++ b/lib/api/bucketGetACL.js
@@ -1,6 +1,6 @@
 import aclUtils from '../utilities/aclUtils';
 import constants from '../../constants';
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import vault from '../auth/vault';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { pushMetric } from '../utapi/utilities';
@@ -45,7 +45,6 @@ export default function bucketGetACL(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketGetACL',
-        log,
     };
     const grantInfo = {
         grants: [],
@@ -60,7 +59,7 @@ export default function bucketGetACL(authInfo, request, log, callback) {
         constants.logId,
     ];
 
-    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketGetVersioning.js
+++ b/lib/api/bucketGetVersioning.js
@@ -1,4 +1,4 @@
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 
 //	Sample XML response:
@@ -53,10 +53,9 @@ export default function bucketGetVersioning(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketOwnerAction',
-        log,
     };
 
-    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketHead.js
+++ b/lib/api/bucketHead.js
@@ -1,5 +1,5 @@
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 
 import { pushMetric } from '../utapi/utilities';
 
@@ -19,9 +19,8 @@ export default function bucketHead(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketHead',
-        log,
     };
-    services.metadataValidateAuthorization(metadataValParams, (err, bucket) => {
+    metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucket);
         if (err) {

--- a/lib/api/bucketPutACL.js
+++ b/lib/api/bucketPutACL.js
@@ -6,7 +6,7 @@ import aclUtils from '../utilities/aclUtils';
 import { cleanUpBucket } from './apiUtils/bucket/bucketCreation';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import vault from '../auth/vault';
 import { pushMetric } from '../utapi/utilities';
 
@@ -72,7 +72,6 @@ export default function bucketPutACL(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketPutACL',
-        log,
     };
     const possibleGrants = ['FULL_CONTROL', 'WRITE',
         'WRITE_ACP', 'READ', 'READ_ACP'];
@@ -103,12 +102,12 @@ export default function bucketPutACL(authInfo, request, log, callback) {
 
     return async.waterfall([
         function waterfall1(next) {
-            services.metadataValidateAuthorization(metadataValParams,
+            metadataValidateBucket(metadataValParams, log,
             (err, bucket) => {
                 if (err) {
                     log.trace('request authorization failed', {
                         error: err,
-                        method: 'services.metadataValidateAuthorization',
+                        method: 'metadataValidateBucket',
                     });
                     return next(err, bucket);
                 }

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -4,7 +4,7 @@ import { parseString } from 'xml2js';
 
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import metadata from '../metadata/wrapper';
-import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 
 /**
  * Format of xml request:
@@ -65,12 +65,11 @@ export default function bucketPutVersioning(authInfo, request, log, callback) {
         authInfo,
         bucketName,
         requestType: 'bucketOwnerAction',
-        log,
     };
 
     return waterfall([
         next => _parseXML(request, log, next),
-        next => services.metadataValidateAuthorization(metadataValParams,
+        next => metadataValidateBucket(metadataValParams, log,
             (err, bucket) => next(err, bucket)), // ignore extra null object,
         (bucket, next) => parseString(request.post, (err, result) => {
             // just for linting; there should not be any parsing error here

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -11,6 +11,7 @@ import constants from '../../constants';
 import { versioningPreprocessing } from './apiUtils/object/versioning';
 import metadata from '../metadata/wrapper';
 import services from '../services';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 
 import { logger } from '../utilities/logger';
 
@@ -125,9 +126,8 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 // Required permissions for this action
                 // at the destinationBucket level are same as objectPut
                 requestType: 'objectPut',
-                log,
             };
-            services.metadataValidateAuthorization(metadataValParams, next);
+            metadataValidateBucketAndObj(metadataValParams, log, next);
         },
         function validateMultipart(destBucket, objMD, next) {
             services.metadataValidateMultipart(metadataValParams,

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -6,6 +6,7 @@ import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import { cleanUpBucket } from './apiUtils/bucket/bucketCreation';
 import constants from '../../constants';
 import services from '../services';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 import utils from '../utils';
 import locationConstraintCheck from './apiUtils/object/locationConstraintCheck';
 
@@ -92,7 +93,6 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
         bucketName,
         // Required permissions for this action are same as objectPut
         requestType: 'objectPut',
-        log,
     };
     const accountCanonicalID = authInfo.getCanonicalID();
     let initiatorID = accountCanonicalID;
@@ -181,14 +181,14 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
             });
     }
 
-    services.metadataValidateAuthorization(metadataValParams,
+    metadataValidateBucketAndObj(metadataValParams, log,
         (err, destinationBucket) => {
             const corsHeaders = collectCorsHeaders(request.headers.origin,
                 request.method, destinationBucket);
             if (err) {
                 log.debug('error processing request', {
                     error: err,
-                    method: 'services.metadataValidateAuthorization',
+                    method: 'metadataValidateBucketAndObj',
                 });
                 return callback(err, null, corsHeaders);
             }

--- a/lib/api/listMultipartUploads.js
+++ b/lib/api/listMultipartUploads.js
@@ -5,6 +5,7 @@ import querystring from 'querystring';
 import constants from '../../constants';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
+import { metadataValidateBucket } from '../metadata/metadataUtils';
 import { pushMetric } from '../utapi/utilities';
 import { errors } from 'arsenal';
 
@@ -178,14 +179,13 @@ export default function listMultipartUploads(authInfo,
         // the authorization to list multipart uploads is the same
         // as listing objects in a bucket.
         requestType: 'bucketGet',
-        log,
     };
 
     async.waterfall([
         function waterfall1(next) {
             // Check final destination bucket for authorization rather
             // than multipart upload bucket
-            services.metadataValidateAuthorization(metadataValParams,
+            metadataValidateBucket(metadataValParams, log,
                 (err, bucket) => next(err, bucket));
         },
         function getMPUBucket(bucket, next) {

--- a/lib/api/listParts.js
+++ b/lib/api/listParts.js
@@ -4,6 +4,7 @@ import querystring from 'querystring';
 import constants from '../../constants';
 import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import services from '../services';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 import escapeForXML from '../utilities/escapeForXML';
 import { pushMetric } from '../utapi/utilities';
 import { errors } from 'arsenal';
@@ -91,7 +92,6 @@ export default function listParts(authInfo, request, log, callback) {
         objectKey,
         uploadId,
         requestType: 'listParts',
-        log,
     };
     // For validating the request at the destinationBucket level
     // params are the same as validating at the MPU level
@@ -106,7 +106,7 @@ export default function listParts(authInfo, request, log, callback) {
 
     async.waterfall([
         function checkDestBucketVal(next) {
-            services.metadataValidateAuthorization(metadataValParams,
+            metadataValidateBucketAndObj(metadataValParams, log,
                 (err, destinationBucket) => {
                     if (err) {
                         return next(err, destinationBucket, null);
@@ -125,6 +125,7 @@ export default function listParts(authInfo, request, log, callback) {
                 });
         },
         function waterfall2(destBucket, next) {
+            metadataValMPUparams.log = log;
             services.metadataValidateMultipart(metadataValMPUparams,
                 (err, mpuBucket, mpuOverview) => {
                     if (err) {

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -5,6 +5,7 @@ import collectCorsHeaders from '../utilities/collectCorsHeaders';
 import constants from '../../constants';
 import data from '../data/wrapper';
 import services from '../services';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 import { pushMetric } from '../utapi/utilities';
 import isLegacyAWSBehavior from '../utilities/legacyAWSBehavior';
 
@@ -32,7 +33,6 @@ function multipartDelete(authInfo, request, log, callback) {
         objectKey,
         uploadId,
         requestType: 'deleteMPU',
-        log,
     };
     // For validating the request at the destinationBucket level
     // params are the same as validating at the MPU level
@@ -42,7 +42,7 @@ function multipartDelete(authInfo, request, log, callback) {
 
     async.waterfall([
         function checkDestBucketVal(next) {
-            services.metadataValidateAuthorization(metadataValParams,
+            metadataValidateBucketAndObj(metadataValParams, log,
                 (err, destinationBucket) => {
                     if (err) {
                         return next(err, destinationBucket);
@@ -61,6 +61,7 @@ function multipartDelete(authInfo, request, log, callback) {
                 });
         },
         function checkMPUval(destBucket, next) {
+            metadataValParams.log = log;
             services.metadataValidateMultipart(metadataValParams,
                 (err, mpuBucket, mpuOverviewArray) => {
                     if (err) {

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -12,8 +12,7 @@ import utils from '../utils';
 import validateHeaders from '../utilities/validateHeaders';
 import { pushMetric } from '../utapi/utilities';
 import removeAWSChunked from './apiUtils/object/removeAWSChunked';
-import { metadataValidateBucketAndObj } from
-'../metadata/metadataUtils';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 
 const versionIdUtils = versioning.VersionID;
 
@@ -130,7 +129,6 @@ function objectCopy(authInfo, request, sourceBucket,
         bucketName: destBucketName,
         objectKey: destObjectKey,
         requestType: 'objectPut',
-        log,
     };
     const dataStoreContext = {
         bucketName: destBucketName,
@@ -150,7 +148,7 @@ function objectCopy(authInfo, request, sourceBucket,
 
     return async.waterfall([
         function checkDestAuth(next) {
-            return services.metadataValidateAuthorization(valPutParams,
+            return metadataValidateBucketAndObj(valPutParams, log,
                 (err, destBucketMD, destObjMD) => {
                     if (err) {
                         log.debug('error validating put part of request',

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -12,8 +12,7 @@ import { logger } from '../utilities/logger';
 import services from '../services';
 import setUpCopyLocator from './apiUtils/object/setUpCopyLocator';
 import validateHeaders from '../utilities/validateHeaders';
-import { metadataValidateBucketAndObj } from
-    '../metadata/metadataUtils';
+import { metadataValidateBucketAndObj } from '../metadata/metadataUtils';
 
 const versionIdUtils = versioning.VersionID;
 
@@ -64,7 +63,6 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         bucketName: destBucketName,
         objectKey: destObjectKey,
         requestType: 'objectPut',
-        log,
     };
 
     // For validating the request at the MPU, the params are the same
@@ -88,7 +86,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
 
     return async.waterfall([
         function checkDestAuth(next) {
-            return services.metadataValidateAuthorization(valPutParams,
+            return metadataValidateBucketAndObj(valPutParams, log,
                 (err, destBucketMD) => {
                     if (err) {
                         log.debug('error validating authorization for ' +

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -161,3 +161,55 @@ export function metadataValidateBucketAndObj(params, log, callback) {
         return callback(null, bucket, objMD);
     });
 }
+
+/** metadataGetBucket - retrieves bucket from metadata, returning error if
+ * bucket is shielded
+ * @param {string} requestType - type of request
+ * @param {string} bucketName - name of bucket
+ * @param {RequestLogger} log - request logger
+ * @param {function} cb - callback
+ * @return {undefined} - and call callback with err, bucket md
+ */
+function metadataGetBucket(requestType, bucketName, log, cb) {
+    return metadata.getBucket(bucketName, log, (err, bucket) => {
+        if (err) {
+            log.debug('metadata getbucket failed', { error: err });
+            return cb(err);
+        }
+        if (bucketShield(bucket, requestType)) {
+            log.debug('bucket is shielded from request', {
+                requestType,
+                method: 'metadataGetBucketAndObject',
+            });
+            return cb(errors.NoSuchBucket);
+        }
+        log.trace('found bucket in metadata');
+        return cb(null, bucket);
+    });
+}
+
+/** metadataValidateBucket - retrieve bucket from metadata and check if user
+ * is authorized to access it
+ * @param {object} params - function parameters
+ * @param {AuthInfo} params.authInfo - AuthInfo class instance, requester's info
+ * @param {string} params.bucketName - name of bucket
+ * @param {string} params.requestType - type of request
+ * @param {RequestLogger} log - request logger
+ * @param {function} callback - callback
+ * @return {undefined} - and call callback with params err, bucket md
+ */
+export function metadataValidateBucket(params, log, callback) {
+    const { authInfo, bucketName, requestType } = params;
+    const canonicalID = authInfo.getCanonicalID();
+    return metadataGetBucket(requestType, bucketName, log, (err, bucket) => {
+        if (err) {
+            return callback(err);
+        }
+        // still return bucket for cors headers
+        if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
+            log.debug('access denied for user on bucket', { requestType });
+            return callback(errors.AccessDenied, bucket);
+        }
+        return callback(null, bucket);
+    });
+}

--- a/lib/services.js
+++ b/lib/services.js
@@ -4,12 +4,9 @@ import async from 'async';
 import { errors } from 'arsenal';
 
 import BucketInfo from './metadata/BucketInfo';
-import bucketShield from './api/apiUtils/bucket/bucketShield';
 import acl from './metadata/acl';
 import constants from '../constants';
 import data from './data/wrapper';
-import { isBucketAuthorized, isObjAuthorized } from
-    './api/apiUtils/authorization/aclChecks';
 import metadata from './metadata/wrapper';
 import { logger } from './utilities/logger';
 import removeAWSChunked from './api/apiUtils/object/removeAWSChunked';
@@ -60,87 +57,6 @@ export default {
                 }
                 return cb(null, listResponse.Contents, splitter);
             });
-    },
-
-     /**
-     * TODO: Remove this function in a clean-up PR as it is obsolete (does
-     * not handle versioned objects). Current references to this function
-     * can be switched to its equivalent, metadataValidateBucketAndObj(),
-     * in apiUtils/authorization/validation.
-     * Checks whether resource exists and the user is authorized
-     * @param {object} params - custom built object containing
-     * resource name, type, authInfo etc.
-     * @param {function} cb - callback containing error,
-     * bucket and object references for the next task
-     * @return {function} calls callback with arguments:
-     * error, bucket, and objectMetada(if any)
-     */
-    metadataValidateAuthorization(params, cb) {
-        const { authInfo, bucketName, objectKey, requestType, log } = params;
-        const canonicalID = authInfo.getCanonicalID();
-        assert.strictEqual(typeof bucketName, 'string');
-        assert.strictEqual(typeof canonicalID, 'string');
-        log.trace('performing metadata validation checks');
-
-        if (objectKey === undefined) {
-            return metadata.getBucket(bucketName, log, (err, bucket) => {
-                if (err) {
-                    log.debug('metadata getbucket failed', { error: err });
-                    return cb(err);
-                }
-                if (bucketShield(bucket, requestType)) {
-                    return cb(errors.NoSuchBucket);
-                }
-                if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
-                    log.debug('access denied for user on bucket', {
-                        requestType,
-                    });
-                    // still return bucket for CORS headers
-                    return cb(errors.AccessDenied, bucket);
-                }
-                log.trace('found bucket in metadata');
-                return cb(null, bucket, null);
-            });
-        }
-        return metadata.getBucketAndObjectMD(bucketName, objectKey, {}, log,
-        (err, data) => {
-            if (err) {
-                log.debug('metadata get failed', { error: err });
-                return cb(err);
-            }
-            log.debug('bucket and object retrieved from metadata',
-                { database: bucketName, object: objectKey });
-            const bucket = data.bucket ?
-                      BucketInfo.deSerialize(data.bucket) : undefined;
-            const obj = data.obj ? JSON.parse(data.obj) : undefined;
-            if (!bucket) {
-                log.debug('bucketAttrs is undefined', {
-                    bucket: bucketName,
-                    method: 'services.metadataValidateAuthorization',
-                });
-                return cb(errors.NoSuchBucket);
-            }
-            if (bucketShield(bucket, requestType)) {
-                return cb(errors.NoSuchBucket);
-            }
-            if (!isBucketAuthorized(bucket, requestType, canonicalID)) {
-                log.debug('access denied for user on bucket', { requestType });
-                return cb(errors.AccessDenied, bucket);
-            }
-            if (!obj) {
-                // NEED to pass on three arguments here for the objectPut
-                // async waterfall to work
-                log.trace('Bucket found', { bucketName });
-                return cb(null, bucket, null);
-            }
-            // TODO: Add bucket policy and IAM checks
-            if (!isObjAuthorized(bucket, obj, requestType, canonicalID)) {
-                log.debug('access denied for user on object', { requestType });
-                return cb(errors.AccessDenied, bucket);
-            }
-            log.trace('found bucket and object in metadata');
-            return cb(null, bucket, obj);
-        });
     },
 
    /**


### PR DESCRIPTION
Versioning PR introduced new metadata validation function called metadataValidateBucketAndObj, so the old metadataValidateAuthorization function is no longer needed.