### PR TITLE
FIX: ensure null ver data is deleted on overwrite [S3C-184]

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -3,7 +3,6 @@ import async from 'async';
 
 import constants from '../../../../constants';
 import data from '../../../data/wrapper';
-import metadata from '../../../metadata/wrapper';
 import services from '../../../services';
 import { logger } from '../../../utilities/logger';
 import utils from '../../../utils';
@@ -97,11 +96,6 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.expires = request.headers.expires;
     }
 
-    let dataToDelete = undefined;
-    if (objMD && objMD.location) {
-        dataToDelete = Array.isArray(objMD.location) ?
-            objMD.location : [objMD.location];
-    }
     const decodedVidResult = decodeVersionId(request.query);
     if (decodedVidResult instanceof Error) {
         log.trace('invalid versionId query', {
@@ -166,31 +160,6 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
                     return next(err, options, infoArr);
                 });
         },
-        function createNullVerDeleteArray(options, infoArr, next) {
-            if (!options.deleteNullVersionData) {
-                return next(null, options, infoArr);
-            }
-            // When options.deleteNullVersionData is true, need to get
-            // location info of null version for deletion. Only applies when
-            // there is pre-existing null version that is not the latest version
-            // and versioning is suspended.
-            const params = { versionId: options.nullVersionId };
-            return metadata.getObjectMD(bucketName, objectKey,
-                params, log, (err, nullObjMD) => {
-                    if (err) {
-                        log.debug('err from metadata getting null version', {
-                            error: err,
-                            method: 'createAndStoreObject',
-                        });
-                        return next(err);
-                    }
-                    if (nullObjMD.location) {
-                        dataToDelete = Array.isArray(nullObjMD.location) ?
-                            nullObjMD.location : [nullObjMD.location];
-                    }
-                    return next(null, options, infoArr);
-                });
-        },
         function storeMDAndDeleteData(options, infoArr, next) {
             metadataStoreParams.versionId = options.versionId;
             metadataStoreParams.versioning = options.versioning;
@@ -198,8 +167,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.nullVersionId = options.nullVersionId;
             return _storeInMDandDeleteData(bucketName, infoArr,
                 cipherBundle, metadataStoreParams,
-                options.deleteData ? dataToDelete : undefined,
-                requestLogger, next);
+                options.dataToDelete, requestLogger, next);
         },
     ], callback);
 }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -68,14 +68,55 @@ function _storeNullVersionMD(bucketName, objKey, objMD, options, log, cb) {
     });
 }
 
+/** get location of data for deletion
+* @param {string} bucketName - name of bucket
+* @param {string} objKey - name of object key
+* @param {object} options - metadata options for getting object MD
+* @param {string} options.versionId - version to get from metadata
+* @param {RequestLogger} log - logger instanceof
+* @param {function} cb - callback
+* @return {undefined} - and call callback with (err, dataToDelete)
+*/
+function _getDeleteLocations(bucketName, objKey, options, log, cb) {
+    return metadata.getObjectMD(bucketName, objKey, options, log,
+        (err, versionMD) => {
+            if (err) {
+                log.debug('err from metadata getting specified version', {
+                    error: err,
+                    method: '_getDeleteLocations',
+                });
+                return cb(err);
+            }
+            if (!versionMD.location) {
+                return cb();
+            }
+            const dataToDelete = Array.isArray(versionMD.location) ?
+                versionMD.location : [versionMD.location];
+            return cb(null, dataToDelete);
+        });
+}
+
 function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
-    metadata.deleteObjectMD(bucketName, objKey, options, log, err => {
-        if (err) {
-            log.debug('error from metadata deleting null version',
-            { error: err });
-        }
-        cb(err, options);
-    });
+    // before deleting null version md, retrieve location of data to delete
+    return _getDeleteLocations(bucketName, objKey, options, log,
+        (err, nullDataToDelete) => {
+            if (err) {
+                log.warn('could not find null version metadata', {
+                    error: err,
+                    method: '_deleteNullVersionMD',
+                });
+                return cb(err);
+            }
+            return metadata.deleteObjectMD(bucketName, objKey, options, log,
+                err => {
+                    if (err) {
+                        log.warn('metadata error deleting null version',
+                        { error: err, method: '_deleteNullVersionMD' });
+                        return cb(err);
+                    }
+                    return cb(null, nullDataToDelete);
+                });
+        });
 }
 
 /** versioningPreprocessing - return versioning information for S3 to handle
@@ -88,7 +129,7 @@ function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
  * @param {RequestLogger} log - logger instance
  * @param {function} callback - callback
  * @return {undefined} and call callback with params (err, options):
- * options.deleteData - (true/undefined) whether to delete data of latest ver
+ * options.dataToDelete - (array/undefined) location of data to delete
  * options.versionId - specific versionId to overwrite in metadata
  *  ('' overwrites the master version)
  * options.versioning - (true/undefined) metadata instruction to create new ver
@@ -100,9 +141,14 @@ function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
 export function versioningPreprocessing(bucketName, bucketMD, objectKey,
     objMD, reqVersionId, log, callback) {
     const options = {};
+    let mstObjLocation;
+    if (objMD && objMD.location) {
+        mstObjLocation = Array.isArray(objMD.location) ?
+            objMD.location : [objMD.location];
+    }
     // bucket is not versioning enabled
     if (!bucketMD.getVersioningConfiguration()) {
-        options.deleteData = true;
+        options.dataToDelete = mstObjLocation;
         return callback(null, options);
     }
     // bucket is versioning enabled
@@ -117,7 +163,7 @@ export function versioningPreprocessing(bucketName, bucketMD, objectKey,
                 // versioning is suspended, overwrite existing master version
                 options.versionId = '';
                 options.isNull = true;
-                options.deleteData = true;
+                options.dataToDelete = mstObjLocation;
                 return callback(null, options);
             }
             // versioning is enabled, create a new version
@@ -142,25 +188,40 @@ export function versioningPreprocessing(bucketName, bucketMD, objectKey,
             if (nullVersionId === undefined) {
                 return callback(null, options);
             }
-            options.deleteNullVersionData = true;
             return _deleteNullVersionMD(bucketName, objectKey,
-                { versionId: nullVersionId }, log,
-                err => callback(err, options));
+                { versionId: nullVersionId }, log, (err, nullDataToDelete) => {
+                    if (err) {
+                        log.warn('unexpected error deleting null version md', {
+                            error: err,
+                            method: 'versioningPreprocessing',
+                        });
+                        if (err === errors.NoSuchKey) {
+                            // it's possible there was a concurrent request to
+                            // delete the null version, so proceed with putting
+                            // a new version
+                            return callback(null, options);
+                        }
+                        return callback(errors.InternalError);
+                    }
+                    options.dataToDelete = nullDataToDelete;
+                    return callback(err, options);
+                });
         }
         // versioning is enabled, put the new version
         options.versioning = true;
         options.nullVersionId = nullVersionId;
         return callback(null, options);
+    // NOTE: Currently we do not accept requests with PUTs to specific
+    // version ID, but this may change after implementing georeplication.
     } else if (!mstVersionId) {
         // version-specific versioning operation, master is not versioned
         if (vstat === 'Suspended' || reqVersionId === 'null') {
             // object does not exist or is not versioned (before versioning)
             options.versionId = '';
             options.isNull = true;
-            options.deleteData = true;
+            options.dataToDelete = mstObjLocation;
             return callback(null, options);
         }
-        // TODO check AWS behaviour
         return callback(errors.BadRequest);
     } else if (mstIsNull) {
         // master is versioned and is a null version
@@ -168,18 +229,26 @@ export function versioningPreprocessing(bucketName, bucketMD, objectKey,
             // overwrite the existing version, make new version null
             options.versionId = '';
             options.isNull = true;
-            options.deleteData = true;
+            options.dataToDelete = mstObjLocation;
             return callback(null, options);
         }
-        // TODO check AWS behaviour
-        options.versionId = reqVersionId;
-        options.deleteData = true;
-        return callback(null, options);
     }
     // master is versioned and is not a null version
     options.versionId = reqVersionId;
-    options.deleteData = true;
-    return callback(null, options);
+    return _getDeleteLocations(bucketName, objectKey,
+        { versionId: reqVersionId }, log, (err, dataToDelete) => {
+            if (err && err === errors.NoSuchKey) {
+                return callback(null, options);
+            } else if (err) {
+                log.warn('unexpected error getting delete locations', {
+                    error: err,
+                    method: 'versioningPreprocessing',
+                });
+                return callback(errors.InternalError);
+            }
+            options.dataToDelete = dataToDelete;
+            return callback(null, options);
+        });
 }
 
 /** preprocessingVersioningDelete - return versioning information for S3 to

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -394,7 +394,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                         });
                         return next(err, destBucket);
                     }
-                    const deleteData = options.deleteData;
+                    const dataToDelete = options.dataToDelete;
                     metaStoreParams.versionId = options.versionId;
                     metaStoreParams.versioning = options.versioning;
                     metaStoreParams.isNull = options.isNull;
@@ -402,13 +402,13 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, mpuOverviewKey,
                         aggregateETag, storedPartsAsObjects, objMD,
-                        extraPartLocations, pseudoCipherBundle, deleteData);
+                        extraPartLocations, pseudoCipherBundle, dataToDelete);
                 });
         },
         function storeAsNewObj(destinationBucket, dataLocations,
             metaStoreParams, mpuBucket, mpuOverviewKey, aggregateETag,
             storedPartsAsObjects, objMD, extraPartLocations, pseudoCipherBundle,
-            deleteData, next) {
+            dataToDelete, next) {
             return services.metadataStoreObject(destinationBucket.getName(),
                 dataLocations, pseudoCipherBundle, metaStoreParams,
                 (err, res) => {
@@ -419,9 +419,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     // in cases where completing mpu overwrites a previous
                     // null version when versioning is suspended or versioning
                     // is not enabled, need to delete pre-existing data
-                    if (objMD && objMD.location && deleteData) {
-                        const dataToDelete = Array.isArray(objMD.location) ?
-                            objMD.location : [objMD.location];
+                    if (dataToDelete) {
                         data.batchDelete(dataToDelete, logger
                             .newRequestLoggerFromSerializedUids(log
                             .getSerializedUids()));

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -341,14 +341,14 @@ function objectCopy(authInfo, request, sourceBucket,
                     storeMetadataParams.isNull = options.isNull;
                     // eslint-disable-next-line
                     storeMetadataParams.nullVersionId = options.nullVersionId;
-                    const deleteData = options.deleteData;
+                    const dataToDelete = options.dataToDelete;
                     return next(null, storeMetadataParams, destDataGetInfoArr,
                         destObjMD, serverSideEncryption, destBucketMD,
-                        deleteData);
+                        dataToDelete);
                 });
         },
         function storeNewMetadata(storeMetadataParams, destDataGetInfoArr,
-            destObjMD, serverSideEncryption, destBucketMD, deleteData, next) {
+            destObjMD, serverSideEncryption, destBucketMD, dataToDelete, next) {
             return services.metadataStoreObject(destBucketName,
                 destDataGetInfoArr, serverSideEncryption,
                 storeMetadataParams, (err, result) => {
@@ -360,11 +360,7 @@ function objectCopy(authInfo, request, sourceBucket,
                     // put is an overwrite of already existing
                     // object with same name, so long as the source is not
                     // the same as the destination
-                    let dataToDelete = undefined;
-                    if (destObjMD && destObjMD.location
-                        && !sourceIsDestination && deleteData) {
-                        dataToDelete = Array.isArray(destObjMD.location) ?
-                            destObjMD.location : [destObjMD.location];
+                    if (!sourceIsDestination && dataToDelete) {
                         data.batchDelete(dataToDelete,
                                 logger.newRequestLoggerFromSerializedUids(
                                     log.getSerializedUids()));

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -6,9 +6,12 @@ import async from 'async';
 import { parseString } from 'xml2js';
 
 import bucketPut from '../../../lib/api/bucketPut';
+import bucketPutVersioning from '../../../lib/api/bucketPutVersioning';
+import objectPut from '../../../lib/api/objectPut';
 import completeMultipartUpload from '../../../lib/api/completeMultipartUpload';
 import constants from '../../../constants';
-import { cleanup, DummyRequestLogger, makeAuthInfo } from '../helpers';
+import { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
+    from '../helpers';
 import { ds } from '../../../lib/data/in_memory/backend';
 import initiateMultipartUpload from '../../../lib/api/initiateMultipartUpload';
 import { metadata } from '../../../lib/metadata/in_memory/metadata';
@@ -40,6 +43,45 @@ const initiateRequest = {
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: `/${objectKey}?uploads`,
 };
+
+function _createPutPartRequest(uploadId, partNumber, partBody) {
+    const md5Hash = crypto.createHash('md5').update(partBody);
+    const calculatedHash = md5Hash.digest('hex');
+    return new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: `/${objectKey}?partNumber=${partNumber}&uploadId=${uploadId}`,
+        query: {
+            partNumber,
+            uploadId,
+        },
+        calculatedHash,
+    }, partBody);
+}
+
+function _createCompleteMpuRequest(uploadId, parts) {
+    const completeBody = [];
+    completeBody.push('<CompleteMultipartUpload>');
+    parts.forEach(part => {
+        completeBody.push('<Part>' +
+            `<PartNumber>${part.partNumber}</PartNumber>` +
+            `<ETag>"${part.eTag}"</ETag>` +
+            '</Part>');
+    });
+    completeBody.push('</CompleteMultipartUpload>');
+    return {
+        bucketName,
+        namespace,
+        objectKey,
+        parsedHost: 's3.amazonaws.com',
+        url: `/${objectKey}?uploadId=${uploadId}`,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        query: { uploadId },
+        post: completeBody,
+    };
+}
 
 
 describe('Multipart Upload API', () => {
@@ -1622,6 +1664,79 @@ describe('Multipart Upload API', () => {
                             });
                         });
                 });
+            });
+        });
+    });
+});
+
+describe('complete mpu with versioning', () => {
+    const objData = ['foo0', 'foo1', 'foo2'].map(str =>
+        Buffer.from(str, 'utf8'));
+
+    const enableVersioningRequest =
+        versioningTestUtils.createBucketPutVersioningReq(bucketName, 'Enabled');
+    const suspendVersioningRequest = versioningTestUtils
+        .createBucketPutVersioningReq(bucketName, 'Suspended');
+    const testPutObjectRequests = objData.slice(0, 2).map(data =>
+        versioningTestUtils.createPutObjectRequest(bucketName, objectKey,
+            data));
+
+    before(done => {
+        cleanup();
+        async.series([
+            callback => bucketPut(authInfo, bucketPutRequest, log,
+                callback),
+            // putting null version: put obj before versioning configured
+            callback => objectPut(authInfo, testPutObjectRequests[0],
+                undefined, log, callback),
+            callback => bucketPutVersioning(authInfo,
+                enableVersioningRequest, log, callback),
+            // put another version:
+            callback => objectPut(authInfo, testPutObjectRequests[1],
+                undefined, log, callback),
+            callback => bucketPutVersioning(authInfo,
+                suspendVersioningRequest, log, callback),
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            versioningTestUtils.assertDataStoreValues(ds, objData.slice(0, 2));
+            return done();
+        });
+    });
+
+    after(done => {
+        cleanup();
+        done();
+    });
+
+    it('should delete null version when creating new null version, ' +
+    'even when null version is not the latest version', done => {
+        async.waterfall([
+            next =>
+                initiateMultipartUpload(authInfo, initiateRequest, log, next),
+            (result, corsHeaders, next) => parseString(result, next),
+            (json, next) => {
+                const partBody = objData[2];
+                const testUploadId =
+                    json.InitiateMultipartUploadResult.UploadId[0];
+                const partRequest = _createPutPartRequest(testUploadId, 1,
+                    partBody);
+                objectPutPart(authInfo, partRequest, undefined, log,
+                    (err, eTag) => next(err, eTag, testUploadId));
+            },
+            (eTag, testUploadId, next) => {
+                const parts = [{ partNumber: 1, eTag }];
+                const completeRequest = _createCompleteMpuRequest(testUploadId,
+                    parts);
+                completeMultipartUpload(authInfo, completeRequest, log, next);
+            },
+        ], err => {
+            assert.ifError(err, `Unexpected err: ${err}`);
+            process.nextTick(() => {
+                versioningTestUtils.assertDataStoreValues(ds, [undefined,
+                    objData[1], objData[2]]);
+                done(err);
             });
         });
     });

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -1,0 +1,105 @@
+import async from 'async';
+import assert from 'assert';
+
+import bucketPut from '../../../lib/api/bucketPut';
+import bucketPutVersioning from '../../../lib/api/bucketPutVersioning';
+import objectPut from '../../../lib/api/objectPut';
+import objectCopy from '../../../lib/api/objectCopy';
+import { ds } from '../../../lib/data/in_memory/backend';
+import DummyRequest from '../DummyRequest';
+import { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils }
+    from '../helpers';
+
+const log = new DummyRequestLogger();
+const canonicalID = 'accessKey1';
+const authInfo = makeAuthInfo(canonicalID);
+const namespace = 'default';
+const destBucketName = 'destbucketname';
+const sourceBucketName = 'sourcebucketname';
+const objectKey = 'objectName';
+
+function _createBucketPutRequest(bucketName) {
+    return new DummyRequest({
+        bucketName,
+        namespace,
+        headers: { host: `${bucketName}.s3.amazonaws.com` },
+        url: '/',
+    });
+}
+
+function _createObjectCopyRequest(destBucketName) {
+    const params = {
+        bucketName: destBucketName,
+        namespace,
+        objectKey,
+        headers: {},
+        url: `/${destBucketName}/${objectKey}`,
+    };
+    return new DummyRequest(params);
+}
+
+const putDestBucketRequest = _createBucketPutRequest(destBucketName);
+const putSourceBucketRequest = _createBucketPutRequest(sourceBucketName);
+const enableVersioningRequest = versioningTestUtils
+    .createBucketPutVersioningReq(destBucketName, 'Enabled');
+const suspendVersioningRequest = versioningTestUtils
+    .createBucketPutVersioningReq(destBucketName, 'Suspended');
+
+describe('objectCopy with versioning', () => {
+    const objData = ['foo0', 'foo1', 'foo2'].map(str =>
+        Buffer.from(str, 'utf8'));
+
+    const testPutObjectRequests = objData.slice(0, 2).map(data =>
+        versioningTestUtils.createPutObjectRequest(destBucketName, objectKey,
+            data));
+    testPutObjectRequests.push(versioningTestUtils
+        .createPutObjectRequest(sourceBucketName, objectKey, objData[2]));
+
+    before(done => {
+        cleanup();
+        async.series([
+            callback => bucketPut(authInfo, putDestBucketRequest, log,
+                callback),
+            callback => bucketPut(authInfo, putSourceBucketRequest, log,
+                callback),
+            // putting null version: put obj before versioning configured
+            // in dest bucket
+            callback => objectPut(authInfo, testPutObjectRequests[0],
+                undefined, log, callback),
+            callback => bucketPutVersioning(authInfo,
+                enableVersioningRequest, log, callback),
+            // put another version in dest bucket:
+            callback => objectPut(authInfo, testPutObjectRequests[1],
+                undefined, log, callback),
+            callback => bucketPutVersioning(authInfo,
+                suspendVersioningRequest, log, callback),
+            // put source object in source bucket
+            callback => objectPut(authInfo, testPutObjectRequests[2],
+                undefined, log, callback),
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            versioningTestUtils.assertDataStoreValues(ds, objData);
+            return done();
+        });
+    });
+
+    after(() => cleanup());
+
+    it('should delete null version when creating new null version, ' +
+    'even when null version is not the latest version', done => {
+        // will have another copy of last object in datastore after objectCopy
+        const expectedValues = [undefined, objData[1], objData[2], objData[2]];
+        const testObjectCopyRequest = _createObjectCopyRequest(destBucketName);
+        objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
+            undefined, log, err => {
+                assert.ifError(err, `Unexpected err: ${err}`);
+                process.nextTick(() => {
+                    versioningTestUtils
+                        .assertDataStoreValues(ds, expectedValues);
+                    done();
+                });
+            });
+    });
+});


### PR DESCRIPTION
Depends on scality/S3#698

Normally we overwrite and clean data when creating a new version when versioning is suspended 
and the latest version is a null version. However, we must also take care to delete the data when overwriting a null version that is not the latest version.