### PR TITLE
S3C-287 FIX: Always set bucket location

### DIFF
--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -8,6 +8,54 @@ import config from '../Config';
 import aclUtils from '../utilities/aclUtils';
 import { pushMetric } from '../utapi/utilities';
 
+const { locationConstraints, restEndpoints, backends } = config;
+
+
+/**
+ * checkLocationConstraint - check that a location constraint is explicitly
+ * set on the bucket and the value of the location is listed in the
+ * locationConstraint config.
+ * Note: if data backend equals "multiple", you must set a location constraint
+ * @param {object} request - http request object
+ * @param {string} locationConstraint - the location constraint sent with
+ * the xml of the request
+ * @param {object} log - Werelogs logger
+ * @return {undefined}
+ */
+export function checkLocationConstraint(request, locationConstraint, log) {
+    // AWS JS SDK sends a request with locationConstraint us-east-1 if
+    // no locationConstraint provided.
+    const { parsedHost } = request;
+    let locationConstraintChecked;
+    if (locationConstraint) {
+        locationConstraintChecked = locationConstraint;
+    } else if (parsedHost && restEndpoints[parsedHost]) {
+        locationConstraintChecked = restEndpoints[parsedHost];
+    } else if (backends.data === 'multiple') {
+        const errMsg = 'no location constraint explicitly set on a' +
+          ' bucket';
+        log.trace(`locationConstraint is invalid - ${errMsg}`);
+        return { error: errors.InvalidLocationConstraint.
+          customizeDescription(errMsg) };
+    } else {
+        // return empty string location if no location constraint explicitly set
+        // and data backend not set to "multiple"
+        // note: THIS IS ONLY FOR THE OPEN SOURCE VERSION THAT IS RUNNING
+        // IN FILE OR MEM.
+        return { error: null, locationConstraint: '' };
+    }
+
+    if (!locationConstraints[locationConstraintChecked]) {
+        const errMsg = 'value of the location is not listed in the ' +
+        'locationConstraint config';
+        log.trace(`locationConstraint is invalid - ${errMsg}`,
+          { locationConstraint: locationConstraintChecked });
+        return { error: errors.InvalidLocationConstraint.
+          customizeDescription(errMsg) };
+    }
+    return { error: null, locationConstraint: locationConstraintChecked };
+}
+
 /*
    Format of xml request:
 
@@ -30,12 +78,22 @@ function _parseXML(request, log, cb) {
                 .LocationConstraint[0];
             log.trace('location constraint',
                 { locationConstraint });
-            return cb(null, locationConstraint);
+            const locationCheck = checkLocationConstraint(request,
+              locationConstraint, log);
+            if (locationCheck.error) {
+                return cb(locationCheck.error);
+            }
+            return cb(null, locationCheck.locationConstraint);
         });
     }
-    // We need the second parameter to be `undefined` so the waterfall maintains
-    // the position of the `next` argument.
-    return process.nextTick(() => cb(null, undefined));
+    return process.nextTick(() => {
+        const locationCheck = checkLocationConstraint(request,
+          undefined, log);
+        if (locationCheck.error) {
+            return cb(locationCheck.error);
+        }
+        return cb(null, locationCheck.locationConstraint);
+    });
 }
 
 /**
@@ -100,39 +158,20 @@ export default function bucketPut(authInfo, request, log, callback) {
             }
             return next(null, locationConstraint);
         },
-        (locationConstraint, next) => {
-            // AWS JS SDK sends a request with locationConstraint us-east-1 if
-            // no locationConstraint provided.
-            const { locationConstraints, restEndpoints } = config;
-            const { parsedHost } = request;
-            if (locationConstraint && Object.keys(locationConstraints)
-                .indexOf(locationConstraint) < 0) {
-                log.trace('locationConstraint is invalid',
-                    { locationConstraint });
-                return next(errors.InvalidLocationConstraint);
-            }
-            let locationConstraintChecked;
-            if (!locationConstraint && parsedHost &&
-                restEndpoints[parsedHost]) {
-                locationConstraintChecked = restEndpoints[parsedHost];
-            } else {
-                locationConstraintChecked = locationConstraint;
-            }
-            return createBucket(authInfo, bucketName, request.headers,
-                locationConstraintChecked, log, (err, previousBucket) => {
-                    // if bucket already existed, gather any relevant cors
-                    // headers
-                    const corsHeaders = collectCorsHeaders(
-                        request.headers.origin, request.method, previousBucket);
-                    if (err) {
-                        return next(err, corsHeaders);
-                    }
-                    pushMetric('createBucket', log, {
-                        authInfo,
-                        bucket: bucketName,
-                    });
-                    return next(null, corsHeaders);
-                });
-        },
+        (locationConstraint, next) => createBucket(authInfo, bucketName,
+          request.headers, locationConstraint, log, (err, previousBucket) => {
+              // if bucket already existed, gather any relevant cors
+              // headers
+              const corsHeaders = collectCorsHeaders(
+                  request.headers.origin, request.method, previousBucket);
+              if (err) {
+                  return next(err, corsHeaders);
+              }
+              pushMetric('createBucket', log, {
+                  authInfo,
+                  bucket: bucketName,
+              });
+              return next(null, corsHeaders);
+          }),
     ], callback);
 }

--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -37,6 +37,9 @@ errorDescription) {
         url: '/',
         post,
     });
+    if (requestHost) {
+        bucketPutReq.parsedHost = requestHost;
+    }
     const initiateReq = {
         bucketName,
         namespace,

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -36,6 +36,9 @@ errorDescription) {
         url: '/',
         post,
     };
+    if (requestHost) {
+        bucketPutReq.parsedHost = requestHost;
+    }
     const initiateReq = {
         bucketName,
         namespace,


### PR DESCRIPTION
We should always explicitly set a location constraint on a bucket if data backend equals 'multiple'.