### PR TITLE
fix: delete marker creation / md [S3C-184]

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -51,7 +51,7 @@ export default
 function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         canonicalID, cipherBundle, request, isDeleteMarker, streamingV4Params,
         log, callback) {
-    const size = request.parsedContentLength;
+    const size = isDeleteMarker ? 0 : request.parsedContentLength;
 
     const websiteRedirectHeader =
         request.headers['x-amz-website-redirect-location'];
@@ -62,7 +62,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         return callback(err);
     }
 
-    const metaHeaders = utils.getMetaHeaders(request.headers);
+    const metaHeaders = isDeleteMarker ? [] :
+        utils.getMetaHeaders(request.headers);
     log.trace('meta headers', { metaHeaders, method: 'objectPut' });
     const objectKeyContext = {
         bucketName,
@@ -78,16 +79,24 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         headers['x-amz-acl'] = request.query['x-amz-acl'];
     }
     const metadataStoreParams = {
-        objectKey, authInfo, metaHeaders, size,
-        contentType: request.headers['content-type'],
-        cacheControl: request.headers['cache-control'],
-        contentDisposition: request.headers['content-disposition'],
-        contentEncoding: removeAWSChunked(request.headers['content-encoding']),
-        expires: request.headers.expires,
+        objectKey,
+        authInfo,
+        metaHeaders,
+        size,
         headers,
-        log,
         isDeleteMarker,
+        log,
     };
+    if (!isDeleteMarker) {
+        metadataStoreParams.contentType = request.headers['content-type'];
+        metadataStoreParams.cacheControl = request.headers['cache-control'];
+        metadataStoreParams.contentDisposition =
+            request.headers['content-disposition'];
+        metadataStoreParams.contentEncoding =
+            removeAWSChunked(request.headers['content-encoding']);
+        metadataStoreParams.expires = request.headers.expires;
+    }
+
     let dataToDelete = undefined;
     if (objMD && objMD.location) {
         dataToDelete = Array.isArray(objMD.location) ?

--- a/lib/services.js
+++ b/lib/services.js
@@ -177,12 +177,14 @@ export default {
                 omVal[val] = overrideMetadata[val];
             });
         }
+
         log.trace('object metadata', { omVal });
-        // If this is not the completion of a multipart upload
-        // parse the headers to get the ACL's if any
+        // If this is not the completion of a multipart upload or
+        // the creation of a delete marker, parse the headers to
+        // get the ACL's if any
         async.waterfall([
             callback => {
-                if (multipart) {
+                if (multipart || omVal.isDeleteMarker) {
                     return callback();
                 }
                 const parseAclParams = {

--- a/tests/unit/api/deleteMarker.js
+++ b/tests/unit/api/deleteMarker.js
@@ -1,0 +1,172 @@
+import async from 'async';
+import assert from 'assert';
+import crypto from 'crypto';
+
+import { versioning } from 'arsenal';
+import { parseString } from 'xml2js';
+
+import bucketPut from '../../../lib/api/bucketPut';
+import bucketPutVersioning from '../../../lib/api/bucketPutVersioning';
+import objectDelete from '../../../lib/api/objectDelete';
+import multiObjectDelete from '../../../lib/api/multiObjectDelete';
+import metadata from '../metadataswitch';
+import DummyRequest from '../DummyRequest';
+import { cleanup, DummyRequestLogger, makeAuthInfo } from '../helpers';
+
+const versionIdUtils = versioning.VersionID;
+
+const log = new DummyRequestLogger();
+const canonicalID = 'accessKey1';
+const authInfo = makeAuthInfo(canonicalID);
+const namespace = 'default';
+const bucketName = 'bucketname';
+const objectName = 'objectName';
+
+const testPutBucketRequest = new DummyRequest({
+    bucketName,
+    namespace,
+    headers: { host: `${bucketName}.s3.amazonaws.com` },
+    url: '/',
+});
+const testDeleteRequest = new DummyRequest({
+    bucketName,
+    namespace,
+    objectKey: objectName,
+    headers: {},
+    url: `/${bucketName}/${objectName}`,
+});
+
+function _createBucketPutVersioningReq(status) {
+    const request = {
+        bucketName,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+        },
+        url: '/?versioning',
+        query: { versioning: '' },
+    };
+    const xml = '<VersioningConfiguration ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    `<Status>${status}</Status>` +
+    '</VersioningConfiguration>';
+    request.post = xml;
+    return request;
+}
+
+function _createMultiObjectDeleteRequest(numObjects) {
+    const request = {
+        bucketName,
+        headers: {
+            host: `${bucketName}.s3.amazonaws.com`,
+        },
+        url: '/?delete',
+        query: { delete: '' },
+    };
+    const xml = [];
+    xml.push('<?xml version="1.0" encoding="UTF-8"?>');
+    xml.push('<Delete>');
+    for (let i = 0; i < numObjects; i++) {
+        xml.push('<Object>');
+        xml.push(`<Key>${objectName}</Key>`);
+        xml.push('</Object>');
+    }
+    xml.push('</Delete>');
+    request.post = xml.join('');
+    request.headers['content-md5'] = crypto.createHash('md5')
+        .update(request.post, 'utf8').digest('base64');
+    return request;
+}
+
+const enableVersioningRequest = _createBucketPutVersioningReq('Enabled');
+
+const expectedAcl = {
+    Canned: 'private',
+    FULL_CONTROL: [],
+    WRITE_ACP: [],
+    READ: [],
+    READ_ACP: [],
+};
+
+const undefHeadersExpected = [
+    'cache-control',
+    'content-disposition',
+    'content-encoding',
+    'expires',
+];
+
+describe('delete marker creation', () => {
+    beforeEach(done => {
+        cleanup();
+        bucketPut(authInfo, testPutBucketRequest, log, err => {
+            if (err) {
+                return done(err);
+            }
+            return bucketPutVersioning(authInfo, enableVersioningRequest,
+                log, done);
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    function _assertDeleteMarkerMd(deleteResultVersionId, isLatest, callback) {
+        const options = {
+            versionId: isLatest ? undefined :
+                versionIdUtils.decode(deleteResultVersionId),
+        };
+        return metadata.getObjectMD(bucketName, objectName, options, log,
+            (err, deleteMarkerMD) => {
+                assert.strictEqual(err, null);
+                const mdVersionId = deleteMarkerMD.versionId;
+                assert.strictEqual(deleteMarkerMD.isDeleteMarker, true);
+                assert.strictEqual(versionIdUtils.encode(mdVersionId),
+                    deleteResultVersionId);
+                assert.strictEqual(deleteMarkerMD['content-length'], 0);
+                assert.strictEqual(deleteMarkerMD.location, null);
+                assert.deepStrictEqual(deleteMarkerMD.acl, expectedAcl);
+                undefHeadersExpected.forEach(header => {
+                    assert.strictEqual(deleteMarkerMD[header], undefined);
+                });
+                return callback();
+            });
+    }
+
+    it('should create a delete marker if versioning enabled and deleting ' +
+    'object without specifying version id', done => {
+        objectDelete(authInfo, testDeleteRequest, log, (err, delResHeaders) => {
+            if (err) {
+                return done(err);
+            }
+            assert.strictEqual(delResHeaders['x-amz-delete-marker'], true);
+            assert(delResHeaders['x-amz-version-id']);
+            return _assertDeleteMarkerMd(delResHeaders['x-amz-version-id'],
+                true, done);
+        });
+    });
+
+    it('multi-object delete should create delete markers if versioning ' +
+    'enabled and items do not have version id specified', done => {
+        const testMultiObjectDeleteRequest =
+            _createMultiObjectDeleteRequest(3);
+        return multiObjectDelete(authInfo, testMultiObjectDeleteRequest, log,
+            (err, xml) => {
+                if (err) {
+                    return done(err);
+                }
+                return parseString(xml, (err, parsedResult) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    const results = parsedResult.DeleteResult.Deleted;
+                    return async.forEach(results, (result, cb) => {
+                        assert.strictEqual(result.Key[0], objectName);
+                        assert.strictEqual(result.DeleteMarker[0], 'true');
+                        assert(result.DeleteMarkerVersionId[0]);
+                        _assertDeleteMarkerMd(result.DeleteMarkerVersionId[0],
+                            false, cb);
+                    }, err => done(err));
+                });
+            });
+    });
+});

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -69,10 +69,6 @@ describe('objectDelete API', () => {
         url: `/${bucketName}/${objectKey}`,
     });
 
-    it.skip('should set delete markers when versioning enabled', () => {
-        // TODO
-    });
-
     it('should delete an object', done => {
         bucketPut(authInfo, testBucketPutRequest, log, () => {
             objectPut(authInfo, testPutObjectRequest,


### PR DESCRIPTION
@jonathan-gramain noticed we did not reset the content length for multi-object delete requests when creating delete markers, meaning the delete marker stores content-length with the length of the xml, which is incorrect and causes the request to hang at least for file backend. It would likely also pose an issue for accurately tracking bytes created in Utapi.