### PR TITLE
Ft/group replication token

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "port": 8000,
     "listenOn": [],
+    "replicationGroupId": "RG001",
     "restEndpoints": {
         "localhost": "file",
         "127.0.0.1": "file",

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -199,6 +199,14 @@ class Config {
             });
         }
 
+        if (config.replicationGroupId) {
+            assert(typeof config.replicationGroupId === 'string',
+                'bad config: replicationGroupId must be a string');
+            this.replicationGroupId = config.replicationGroupId;
+        } else {
+            this.replicationGroupId = 'RG001';
+        }
+
         // legacy
         if (config.regions !== undefined) {
             throw new Error('bad config: regions key is deprecated. ' +

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -1,11 +1,13 @@
 import { errors, versioning } from 'arsenal';
 
 import metadata from '../../../metadata/wrapper';
+import config from '../../../Config';
 
 const versionIdUtils = versioning.VersionID;
-// Constant used internally by metadata as a version ID for a null version
-// that was created before bucket versioning was enabled
-const nonVersionedObjId = versionIdUtils.VID_INF;
+// Use Arsenal function to generate a version ID used internally by metadata
+// for null versions that are created before bucket versioning is configured
+const nonVersionedObjId =
+    versionIdUtils.getInfVid(config.replicationGroupId);
 
 /** decodedVidResult - decode the version id from a query object
  * @param {object} [reqQuery] - request query object

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -2,6 +2,7 @@ import { errors, algorithms, versioning } from 'arsenal';
 
 import getMultipartUploadListing from './getMultipartUploadListing';
 import { metadata } from './metadata';
+import config from '../../Config';
 
 const genVID = versioning.VersionID.generateVersionId;
 
@@ -9,7 +10,7 @@ const defaultMaxKeys = 1000;
 let uidCounter = 0;
 
 function generateVersionId() {
-    return genVID(uidCounter++);
+    return genVID(uidCounter++, config.replicationGroupId);
 }
 
 function formatVersionKey(key, versionId) {

--- a/mdserver.js
+++ b/mdserver.js
@@ -8,7 +8,9 @@ if (config.backends.metadata === 'file') {
     const mdServer = new MetadataServer(
         { metadataPath: config.filePaths.metadataPath,
           metadataPort: config.metadataDaemon.port,
-          log: config.log });
+          log: config.log,
+          versioning: { replicationGroupId: config.replicationGroupId },
+        });
     mdServer.startServer();
 }
 

--- a/tests/functional/aws-node-sdk/test/versioning/objectACL.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectACL.js
@@ -1,6 +1,5 @@
 import assert from 'assert';
 import async from 'async';
-import { versioning } from 'arsenal';
 
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
@@ -15,9 +14,7 @@ const counter = 100;
 let bucket;
 const key = '/';
 const invalidId = 'invalidId';
-const VID_INF = versioning.VersionID.VID_INF;
-const nonExistingId = versioning.VersionID
-    .encode(`${VID_INF.slice(VID_INF.length - 1)}7`);
+const nonExistingId = '3939393939393939393936493939393939393939756e6437';
 
 function _assertNoError(err, desc) {
     assert.strictEqual(err, null, `Unexpected err ${desc}: ${err}`);


### PR DESCRIPTION
Add "replicationGroupToken" to config, to be used in versioning and replication to identify a unit of deployments relevant for replication.

Depends on https://github.com/scality/Arsenal/pull/247