### PR TITLE
fix: add objAcl checks for delete marker [S3C-184]

### DIFF
--- a/lib/api/objectGetACL.js
+++ b/lib/api/objectGetACL.js
@@ -91,6 +91,16 @@ export default function objectGetACL(authInfo, request, log, callback) {
                         { method: 'objectGetACL', error: err });
                         return next(err, bucket);
                     }
+                    if (objectMD.isDeleteMarker) {
+                        if (versionId) {
+                            log.trace('requested version is delete marker',
+                            { method: 'objectGetACL' });
+                            return next(errors.MethodNotAllowed);
+                        }
+                        log.trace('most recent version is delete marker',
+                        { method: 'objectGetACL' });
+                        return next(errors.NoSuchKey);
+                    }
                     return next(null, bucket, objectMD);
                 });
         },

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -113,6 +113,11 @@ export default function objectPutACL(authInfo, request, log, cb) {
                             errors.NoSuchKey;
                         return next(err, bucket);
                     }
+                    if (objectMD.isDeleteMarker) {
+                        log.trace('delete marker detected',
+                        { method: 'objectPutACL' });
+                        return next(errors.MethodNotAllowed, bucket);
+                    }
                     return next(null, bucket, objectMD);
                 });
         },


### PR DESCRIPTION
We were not checking for delete markers when responding to put and get acl requests.