### PR TITLE
Ft/rpc service rest api

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -364,6 +364,10 @@ class Config {
             this.metadataDaemon.metadataPath =
                 process.env.S3METADATAPATH ?
                 process.env.S3METADATAPATH : `${__dirname}/../localMetadata`;
+
+            this.metadataDaemon.restEnabled =
+                config.metadataDaemon.restEnabled;
+            this.metadataDaemon.restPort = config.metadataDaemon.restPort;
         }
 
         if (process.env.ENABLE_LOCAL_CACHE) {

--- a/mdserver.js
+++ b/mdserver.js
@@ -9,6 +9,8 @@ if (config.backends.metadata === 'file') {
         { bindAddress: config.metadataDaemon.bindAddress,
           port: config.metadataDaemon.port,
           path: config.metadataDaemon.metadataPath,
+          restEnabled: config.metadataDaemon.restEnabled,
+          restPort: config.metadataDaemon.restPort,
           log: config.log,
           versioning: { replicationGroupId: config.replicationGroupId } });
     mdServer.startServer();


### PR DESCRIPTION
# Pull request template

## Description

Add params to enable metadata HTTP server (Arsenal PR https://github.com/scality/Arsenal/pull/252)

### Motivation and context

Why is this change required? What problem does it solve?

Ease debugging by offering an optional HTTP interface that allows access to internal metadata through HTTP POST requests.

This is disabled by default and not documented for now, it can crash the daemon if requests are not properly forged, so it's not meant to be enabled in any production system, but it can help troubleshooting and development by allowing to use curl or other standard HTTP tools instead of a socket.io client.
