### PR TITLE
Ft/s3 c 301 record log

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,5 +53,9 @@
     "dataDaemon": {
         "bindAddress": "localhost",
         "port": 9991
+    },
+    "recordLog": {
+        "enabled": false,
+        "recordLogName": "main"
     }
 }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -364,6 +364,12 @@ class Config {
                 process.env.S3METADATAPATH : `${__dirname}/../localMetadata`;
         }
 
+        this.recordLog = { enabled: false };
+        if (config.recordLog) {
+            this.recordLog.enabled = Boolean(config.recordLog.enabled);
+            this.recordLog.recordLogName = config.recordLog.recordLogName;
+        }
+
         if (process.env.ENABLE_LOCAL_CACHE) {
             this.localCache = defaultLocalCache;
         }

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -70,7 +70,7 @@ const metadata = {
     },
 
     putObjectMD: (bucketName, objName, objVal, params, log, cb) => {
-        log.debug('putting object in metdata');
+        log.debug('putting object in metadata');
         const value = typeof objVal.getValue === 'function' ?
             objVal.getValue() : objVal;
         client.putObject(bucketName, objName, value, params, log,

--- a/mdserver.js
+++ b/mdserver.js
@@ -9,7 +9,8 @@ if (config.backends.metadata === 'file') {
         { bindAddress: config.metadataDaemon.bindAddress,
           port: config.metadataDaemon.port,
           path: config.metadataDaemon.metadataPath,
-          log: config.log,
-          versioning: { replicationGroupId: config.replicationGroupId } });
+          versioning: { replicationGroupId: config.replicationGroupId },
+          recordLog: config.recordLog,
+          log: config.log });
     mdServer.startServer();
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
     "aws-sdk": "2.28.0",
-    "arsenal": "scality/Arsenal",
+    "arsenal": "scality/Arsenal#ft/S3C-301-recordLogAPI",
     "async": "~1.4.2",
     "bucketclient": "scality/bucketclient",
     "commander": "^2.9.0",


### PR DESCRIPTION
Review only PR, early comments would be appreciated.

This is basically enabling the record log functionality in the dmd necessary to enable async replication with backbeat.

The API will later be implemented on MetaData as well, but in a different way (fetching the updates from the existing transaction log).