### PR TITLE
rf: clean up listing types, parsing [S3C-184]

### DIFF
--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,0 +1,20 @@
+# Listing
+
+## Listing Types
+
+We use three different types of metadata listing for various operations.
+Here are the scenarios we use each for:
+
+- 'Delimiter' - when no versions are possible in the bucket since it is an
+   internally-used only bucket which is not exposed to a user. Namely,
+  1. to list objects in the "user's bucket" to respond to a GET SERVICE
+  request and
+  2. to do internal listings on an MPU shadow bucket to complete multipart
+  upload operations.
+- 'DelimiterVersion' - to list all versions in a bucket
+- 'DelimiterMaster' - to list just the master versions of objects in a bucket
+
+## Algorithms
+
+The algorithms for each listing type can be found in the open-source
+[scality/Arsenal](https://github.com/scality/Arsenal) repository, in [lib/algos/list](https://github.com/scality/Arsenal/tree/master/lib/algos/list).

--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -112,27 +112,27 @@ function processVersions(bucketName, listParams, list) {
     let lastKey = listParams.keyMarker ?
         escapeXmlFn(listParams.keyMarker) : undefined;
     list.Versions.forEach(item => {
-        const v = JSON.parse(item.value);
+        const v = item.value;
         const objectKey = escapeXmlFn(item.key);
         const isLatest = lastKey !== objectKey;
         lastKey = objectKey;
         xml.push(
-            v.isDeleteMarker ? '<DeleteMarker>' : '<Version>',
+            v.IsDeleteMarker ? '<DeleteMarker>' : '<Version>',
             `<Key>${objectKey}</Key>`,
             '<VersionId>',
-            (v.isNull || v.versionId === undefined) ?
-                'null' : versionIdUtils.encode(v.versionId),
+            (v.IsNull || v.VersionId === undefined) ?
+                'null' : versionIdUtils.encode(v.VersionId),
             '</VersionId>',
             `<IsLatest>${isLatest}</IsLatest>`,
-            `<LastModified>${v['last-modified']}</LastModified>`,
-            `<ETag>&quot;${v['content-md5']}&quot;</ETag>`,
-            `<Size>${v['content-length']}</Size>`,
+            `<LastModified>${v.LastModified}</LastModified>`,
+            `<ETag>&quot;${v.ETag}&quot;</ETag>`,
+            `<Size>${v.Size}</Size>`,
             '<Owner>',
-            `<ID>${v['owner-id']}</ID>`,
-            `<DisplayName>${v['owner-display-name']}</DisplayName>`,
+            `<ID>${v.Owner.ID}</ID>`,
+            `<DisplayName>${v.Owner.DisplayName}</DisplayName>`,
             '</Owner>',
-            `<StorageClass>${v['x-amz-storage-class']}</StorageClass>`,
-            v.isDeleteMarker ? '</DeleteMarker>' : '</Version>'
+            `<StorageClass>${v.StorageClass}</StorageClass>`,
+            v.IsDeleteMarker ? '</DeleteMarker>' : '</Version>'
         );
     });
     list.CommonPrefixes.forEach(item => {

--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -254,7 +254,7 @@ class BucketFileInterface {
      *  @return {undefined}
      */
     internalListObject(bucketName, params, log, cb) {
-        const extName = params.listingType || 'Basic';
+        const extName = params.listingType;
         const extension = new arsenal.algorithms.list[extName](params, log);
         const requestParams = extension.genMDParams();
         this.loadDBIfExists(bucketName, log, (err, db) => {

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -235,7 +235,7 @@ const metastore = {
 
             // If marker specified, edit the keys array so it
             // only contains keys that occur alphabetically after the marker
-            const listingType = params.listingType || 'Delimiter';
+            const listingType = params.listingType;
             const extension = new algorithms.list[listingType](params, log);
             const listingParams = extension.genMDParams();
 

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -8,6 +8,56 @@ import { isBucketAuthorized,
     isObjAuthorized } from '../api/apiUtils/authorization/aclChecks';
 import bucketShield from '../api/apiUtils/bucket/bucketShield';
 
+/** _parseListEntries - parse the values returned in a listing by metadata
+ * @param {object[]} entries - Version or Content entries in a metadata listing
+ * @param {string} entries[].key - metadata key
+ * @param {string} entries[].value - stringified object metadata
+ * @return {object} - mapped array with parsed value or JSON parsing err
+ */
+function _parseListEntries(entries) {
+    return entries.map(entry => {
+        const tmp = JSON.parse(entry.value);
+        return {
+            key: entry.key,
+            value: {
+                Size: tmp['content-length'],
+                ETag: tmp['content-md5'],
+                VersionId: tmp.versionId,
+                IsNull: tmp.isNull,
+                IsDeleteMarker: tmp.isDeleteMarker,
+                LastModified: tmp['last-modified'],
+                Owner: {
+                    DisplayName: tmp['owner-display-name'],
+                    ID: tmp['owner-id'],
+                },
+                StorageClass: tmp['x-amz-storage-class'],
+                // MPU listing properties
+                Initiated: tmp.initiated,
+                Initiator: tmp.initiator,
+                EventualStorageBucket: tmp.eventualStorageBucket,
+                partLocations: tmp.partLocations,
+                creationDate: tmp.creationDate,
+            },
+        };
+    });
+}
+
+/** parseListEntries - parse the values returned in a listing by metadata
+ * @param {object[]} entries - Version or Content entries in a metadata listing
+ * @param {string} entries[].key - metadata key
+ * @param {string} entries[].value - stringified object metadata
+ * @return {(object|Error)} - mapped array with parsed value or JSON parsing err
+ */
+exports.parseListEntries = entries => {
+    // wrap private function in a try/catch clause
+    // just in case JSON parsing throws an exception
+    try {
+        return _parseListEntries(entries);
+    } catch (e) {
+        return e;
+    }
+};
+
 /** getNullVersion - return metadata of null version if it exists
  * @param {object} objMD - metadata of master version
  * @param {string} bucketName - name of bucket

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -1,8 +1,12 @@
+const errors = require('arsenal').errors;
+
 import BucketClientInterface from './bucketclient/backend';
 import BucketFileInterface from './bucketfile/backend';
 import BucketInfo from './BucketInfo';
 import inMemory from './in_memory/backend';
 import config from '../Config';
+
+const metadataUtils = require('./metadataUtils');
 
 let client;
 let implName;
@@ -137,34 +141,29 @@ const metadata = {
             }
             log.debug('object listing retrieved from metadata');
             if (listingParams.listingType === 'DelimiterVersions') {
-                return cb(err, data);
+                // eslint-disable-next-line
+                data.Versions = metadataUtils.parseListEntries(data.Versions);
+                if (data.Versions instanceof Error) {
+                    log.error('error parsing metadata listing', {
+                        error: data.Versions,
+                        listingType: listingParams.listingType,
+                        method: 'listObject',
+                    });
+                    return cb(errors.InternalError);
+                }
+                return cb(null, data);
             }
             // eslint-disable-next-line
-            data.Contents = data.Contents.map(entry => {
-                const tmp = JSON.parse(entry.value);
-                return {
-                    key: entry.key,
-                    value: {
-                        Size: tmp['content-length'],
-                        ETag: tmp['content-md5'],
-                        VersionId: tmp.versionId,
-                        IsNull: tmp.isNull,
-                        IsDeleteMarker: tmp.isDeleteMarker,
-                        LastModified: tmp['last-modified'],
-                        Owner: {
-                            DisplayName: tmp['owner-display-name'],
-                            ID: tmp['owner-id'],
-                        },
-                        StorageClass: tmp['x-amz-storage-class'],
-                        Initiated: tmp.initiated,
-                        Initiator: tmp.initiator,
-                        EventualStorageBucket: tmp.eventualStorageBucket,
-                        partLocations: tmp.partLocations,
-                        creationDate: tmp.creationDate,
-                    },
-                };
-            });
-            return cb(err, data);
+            data.Contents = metadataUtils.parseListEntries(data.Contents);
+            if (data.Contents instanceof Error) {
+                log.error('error parsing metadata listing', {
+                    error: data.Contents,
+                    listingType: listingParams.listingType,
+                    method: 'listObject',
+                });
+                return cb(errors.InternalError);
+            }
+            return cb(null, data);
         });
     },
 

--- a/tests/functional/aws-node-sdk/test/versioning/listObjectMasterVersions.js
+++ b/tests/functional/aws-node-sdk/test/versioning/listObjectMasterVersions.js
@@ -8,6 +8,24 @@ import { removeAllVersions } from '../../lib/utility/versioning-util';
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
+function _assertResultElements(entry) {
+    const elements = [
+        'LastModified',
+        'ETag',
+        'Size',
+        'Owner',
+        'StorageClass',
+    ];
+    elements.forEach(elem => {
+        assert.notStrictEqual(entry[elem], undefined,
+            `Expected ${elem} in result but did not find it`);
+        if (elem === 'Owner') {
+            assert(entry.Owner.ID, 'Expected Owner ID but did not find it');
+            assert(entry.Owner.DisplayName,
+                'Expected Owner DisplayName but did not find it');
+        }
+    });
+}
 
 describe('listObject - Delimiter master', function testSuite() {
     this.timeout(600000);
@@ -324,6 +342,7 @@ describe('listObject - Delimiter master', function testSuite() {
                                 throw new Error('listing fail, ' +
                                 `unexpected key ${result.Key}`);
                             }
+                            _assertResultElements(result);
                         });
                         res.CommonPrefixes.forEach(cp => {
                             if (!test.commonPrefix

--- a/tests/functional/aws-node-sdk/test/versioning/listObjectVersions.js
+++ b/tests/functional/aws-node-sdk/test/versioning/listObjectVersions.js
@@ -8,6 +8,31 @@ import { removeAllVersions } from '../../lib/utility/versioning-util';
 
 const bucket = `versioning-bucket-${Date.now()}`;
 
+const resultElements = [
+    'VersionId',
+    'IsLatest',
+    'LastModified',
+    'Owner',
+];
+const versionResultElements = [
+    'ETag',
+    'Size',
+    'StorageClass',
+];
+
+function _assertResultElements(entry, type) {
+    const elements = type === 'DeleteMarker' ? resultElements :
+        resultElements.concat(versionResultElements);
+    elements.forEach(elem => {
+        assert.notStrictEqual(entry[elem], undefined,
+            `Expected ${elem} in result but did not find it`);
+        if (elem === 'Owner') {
+            assert(entry.Owner.ID, 'Expected Owner ID but did not find it');
+            assert(entry.Owner.DisplayName,
+                'Expected Owner DisplayName but did not find it');
+        }
+    });
+}
 
 describe('listObject - Delimiter version', function testSuite() {
     this.timeout(600000);
@@ -341,6 +366,7 @@ describe('listObject - Delimiter version', function testSuite() {
                                     `unexpected key ${result.Key} ` +
                                     `with version ${result.VersionId}`);
                             }
+                            _assertResultElements(result, 'Version');
                         });
                         res.DeleteMarkers.forEach(result => {
                             const item = expectedResult.find(obj => {
@@ -356,6 +382,7 @@ describe('listObject - Delimiter version', function testSuite() {
                                     `unexpected key ${result.Key} ` +
                                     `with version ${result.VersionId}`);
                             }
+                            _assertResultElements(result, 'DeleteMarker');
                         });
                         res.CommonPrefixes.forEach(cp => {
                             if (!test.commonPrefix.find(


### PR DESCRIPTION
No longer use 'Basic' listing type.
Move JSON parsing for 'DelimiterVersions' to metadata wrapper to be consistent with what we do for other listing types.
Add some more assertions to listing tests.

Note that it seems we still use 'Delimiter' listing type for listing buckets and for internal bucket listing, such as listing objects inside a mpuBucket.