### PR TITLE
FIX: put object tag with empty value

### DIFF
--- a/lib/api/apiUtils/object/tagging.js
+++ b/lib/api/apiUtils/object/tagging.js
@@ -24,7 +24,7 @@ export const _validator = {
         && Object.keys(tag).length === 2
         && tag.Key && tag.Value
         && tag.Key.length === 1 && tag.Value.length === 1
-        && tag.Key[0] && tag.Value[0]
+        && tag.Key[0] !== undefined && tag.Value[0] !== undefined
         && typeof tag.Key[0] === 'string' && typeof tag.Value[0] === 'string',
 
     validateXMLStructure: result =>
@@ -79,6 +79,11 @@ function _validateTags(tags) {
         }
         const key = tag.Key[0];
         const value = tag.Value[0];
+
+        if (!key) {
+            return errors.InvalidTag.customizeDescription('The TagKey you ' +
+            'have provided is invalid');
+        }
 
         // Allowed characters are letters, whitespace, and numbers, plus
         // the following special characters: + - = . _ : /

--- a/tests/functional/aws-node-sdk/lib/utility/tagging.js
+++ b/tests/functional/aws-node-sdk/lib/utility/tagging.js
@@ -9,6 +9,8 @@ function _generateWordWithLength(nbr) {
 export const taggingTests = [
     { tag: { key: '+- =._:/', value: '+- =._:/' },
       it: 'should return tags if tags are valid' },
+    { tag: { key: 'key1', value: '' },
+      it: 'should return tags if value is an empty string' },
     { tag: { key: _generateWordWithLength(129), value: 'foo' },
       error: 'InvalidTag',
       it: 'should return InvalidTag if key length is greater than 128' },

--- a/tests/functional/aws-node-sdk/test/object/putObjTagging.js
+++ b/tests/functional/aws-node-sdk/test/object/putObjTagging.js
@@ -112,6 +112,20 @@ describe('PUT object taggings', () => {
             });
         });
 
+        it('should return InvalidTag if key is an empty string', done => {
+            s3.putObjectTagging({ Bucket: bucketName, Key: objectName,
+              Tagging: { TagSet: [
+                  {
+                      Key: '',
+                      Value: 'value1',
+                  },
+              ] },
+          }, err => {
+                _checkError(err, 'InvalidTag', 400);
+                done();
+            });
+        });
+
         it('should be able to put an empty Tag set', done => {
             s3.putObjectTagging({ Bucket: bucketName, Key: objectName,
               Tagging: { TagSet: [] },


### PR DESCRIPTION
For `putObjectTagging` - the tag's value can be an empty string. 
However - tag's key can not be empty
