### PR TITLE
fix: return versionId when delete non-exist ver [S3C-368]

### DIFF
--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -211,9 +211,6 @@ export function getObjMetadataAndDelete(authInfo, canonicalID, request,
                         // To adhere to AWS behavior, create a delete marker
                         // if trying to delete an object that does not exist
                         // when versioning has been configured
-                        // TODO: Look into AWS behavior for whether to create
-                        // a delete marker if request is trying to delete a
-                        // version that does not exist.
                         if (verCfg && !entry.versionId) {
                             log.debug('trying to delete specific version ' +
                             ' that does not exist');

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -12,7 +12,6 @@ import { metadataValidateBucketAndObj } from
 '../metadata/metadataUtils';
 
 const versionIdUtils = versioning.VersionID;
-const skipError = new Error('skip');
 
 /**
  * objectDelete - DELETE an object from a bucket
@@ -66,13 +65,10 @@ export default function objectDelete(authInfo, request, log, cb) {
                     // AWS does not return an error when trying to delete a
                     // specific version that does not exist. We skip to the end
                     // of the waterfall here.
-                    // TODO: Look into AWS behavior for whether to create
-                    // a delete marker if request is trying to delete a version
-                    // that does not exist.
                     if (reqVersionId) {
                         log.debug('trying to delete specific version ' +
                         ' that does not exist');
-                        return next(skipError, bucketMD);
+                        return next(errors.NoSuchVersion, bucketMD);
                     }
                     // To adhere to AWS behavior, create a delete marker even
                     // if trying to delete an object that does not exist when
@@ -124,10 +120,16 @@ export default function objectDelete(authInfo, request, log, cb) {
     ], (err, bucketMD, objectMD, result, deleteInfo) => {
         const resHeaders = collectCorsHeaders(request.headers.origin,
             request.method, bucketMD);
-        if (err) {
-            if (err === skipError) {
-                return cb(null, resHeaders);
+        // if deleting a specific version or delete marker, return version id
+        // in the response headers, even in case of NoSuchVersion
+        if (reqVersionId) {
+            resHeaders['x-amz-version-id'] = reqVersionId === 'null' ?
+                reqVersionId : versionIdUtils.encode(reqVersionId);
+            if (deleteInfo && deleteInfo.removeDeleteMarker) {
+                resHeaders['x-amz-delete-marker'] = true;
             }
+        }
+        if (err) {
             log.debug('error processing request', { error: err,
                 method: 'objectDelete' });
             return cb(err, resHeaders);
@@ -143,15 +145,6 @@ export default function objectDelete(authInfo, request, log, cb) {
             pushMetric('putDeleteMarkerObject', log, { authInfo,
                 bucket: bucketName });
         } else {
-            // otherwise, if deleting a specific version or delete marker,
-            // return the version id in the response headers
-            if (reqVersionId) {
-                resHeaders['x-amz-version-id'] = reqVersionId === 'null' ?
-                    reqVersionId : versionIdUtils.encode(reqVersionId);
-                if (deleteInfo.removeDeleteMarker) {
-                    resHeaders['x-amz-delete-marker'] = true;
-                }
-            }
             pushMetric('deleteObject', log, { authInfo, bucket: bucketName,
                 byteLength: objectMD['content-length'], numberOfObjects: 1 });
         }

--- a/lib/routes/routeDELETE.js
+++ b/lib/routes/routeDELETE.js
@@ -55,10 +55,10 @@ export default function routeDELETE(request, response, log, statsClient) {
               (err, corsHeaders) => {
                   /*
                   * Since AWS expects a 204 regardless of the existence of
-                  the object, the error NoSuchKey should not be sent back
-                  * as a response.
+                  the object, the errors NoSuchKey and NoSuchVersion should not
+                  * be sent back as a response.
                   */
-                  if (err && !err.NoSuchKey) {
+                  if (err && !err.NoSuchKey && !err.NoSuchVersion) {
                       return routesUtils.responseNoBody(err, corsHeaders,
                         response, null, log);
                   }

--- a/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDelete.js
@@ -12,6 +12,11 @@ import {
 
 const bucket = `versioning-bucket-${Date.now()}`;
 const key = 'anObject';
+// formats differ for AWS and S3, use respective sample ids to obtain
+// correct error response in tests
+const nonExistingId = process.env.AWS_ON_AIR ?
+    'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
+    '3939393939393939393936493939393939393939756e6437';
 
 function _assertNoError(err, desc) {
     assert.strictEqual(err, null, `Unexpected err ${desc || ''}: ${err}`);
@@ -255,6 +260,27 @@ describe('aws-node-sdk test delete object', () => {
                             VersionId: res2.VersionId,
                         }, err => done(err));
                     });
+                });
+            });
+        });
+
+        it('delete non existent version should not create delete marker',
+        done => {
+            s3.deleteObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: nonExistingId,
+            }, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                assert.strictEqual(res.VersionId, nonExistingId);
+                return s3.listObjectVersions({ Bucket: bucket }, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(res.DeleteMarkers.length, 0);
+                    return done();
                 });
             });
         });


### PR DESCRIPTION
- tests to confirm we do not create delete markers for deleting specific versions
- make sure version ID is sent back for requests trying to delete non-existing version