### PR TITLE
FT: getObject with tagging

### DIFF
--- a/lib/api/api.js
+++ b/lib/api/api.js
@@ -48,6 +48,7 @@ auth.setHandler(vault);
 /* eslint-disable no-param-reassign */
 const api = {
     callApiMethod(apiMethod, request, response, log, callback) {
+        let returnTagCount = true;
         // no need to check auth on website or cors preflight requests
         if (apiMethod === 'websiteGet' || apiMethod === 'websiteHead' ||
         apiMethod === 'corsPreflight') {
@@ -72,10 +73,24 @@ const api = {
                 return callback(err);
             }
             if (authorizationResults) {
-                for (let i = 0; i < authorizationResults.length; i++) {
-                    if (!authorizationResults[i].isAllowed) {
-                        log.trace('authorization denial from Vault');
+                if (apiMethod === 'objectGet') {
+                    // first item checks s3:GetObject(Version) action
+                    if (!authorizationResults[0].isAllowed) {
+                        log.trace('get object authorization denial from Vault');
                         return callback(errors.AccessDenied);
+                    }
+                    // second item checks s3:GetObject(Version)Tagging action
+                    if (!authorizationResults[1].isAllowed) {
+                        log.trace('get tagging authorization denial ' +
+                        'from Vault');
+                        returnTagCount = false;
+                    }
+                } else {
+                    for (let i = 0; i < authorizationResults.length; i++) {
+                        if (!authorizationResults[i].isAllowed) {
+                            log.trace('authorization denial from Vault');
+                            return callback(errors.AccessDenied);
+                        }
                     }
                 }
             }
@@ -118,6 +133,10 @@ const api = {
                     apiMethod === 'objectPutCopyPart') {
                     return this[apiMethod](userInfo, request, sourceBucket,
                         sourceObject, sourceVersionId, log, callback);
+                }
+                if (apiMethod === 'objectGet') {
+                    return this[apiMethod](userInfo, request,
+                      returnTagCount, log, callback);
                 }
                 return this[apiMethod](userInfo, request, log, callback);
             });

--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -51,6 +51,20 @@ export default function prepareRequestContexts(apiMethod, request, sourceBucket,
             request.socket.remoteAddress, request.connection.encrypted,
             'objectPut', 's3');
         requestContexts.push(getRequestContext, putRequestContext);
+    } else if (apiMethodAfterVersionCheck === 'objectGet' ||
+      apiMethodAfterVersionCheck === 'objectGetVersion') {
+        const objectGetTaggingAction = (request.query &&
+          request.query.versionId) ? 'objectGetTaggingVersion' :
+          'objectGetTagging';
+        const getRequestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            request.socket.remoteAddress, request.connection.encrypted,
+            apiMethodAfterVersionCheck, 's3');
+        const getTaggingRequestContext = new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            request.socket.remoteAddress, request.connection.encrypted,
+            objectGetTaggingAction, 's3');
+        requestContexts.push(getRequestContext, getTaggingRequestContext);
     } else {
         const requestContext = new RequestContext(request.headers,
             request.query, request.bucketName, request.objectKey,

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -14,12 +14,13 @@ import { metadataValidateBucketAndObj } from
  * GET Object - Get an object
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
  * @param {object} request - normalized request object
+ * @param {boolean} returnTagCount - returns the x-amz-tagging-count header
  * @param {object} log - Werelogs instance
  * @param {function} callback - callback to function in route
  * @return {undefined}
  */
 export default
-function objectGet(authInfo, request, log, callback) {
+function objectGet(authInfo, request, returnTagCount, log, callback) {
     log.debug('processing request', { method: 'objectGet' });
     const bucketName = request.bucketName;
     const objectKey = request.objectKey;
@@ -76,7 +77,7 @@ function objectGet(authInfo, request, log, callback) {
             return callback(headerValResult.error, null, corsHeaders);
         }
         const responseMetaHeaders = collectResponseHeaders(objMD,
-            corsHeaders, verCfg);
+            corsHeaders, verCfg, returnTagCount);
 
         const objLength = (objMD.location === null ?
                            0 : parseInt(objMD['content-length'], 10));

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -7,10 +7,12 @@ import { getVersionIdResHeader } from '../api/apiUtils/object/versioning';
  * other response headers
  * @param {object} versioningCfg - if bucket is configured for versioning,
  * return version ID
+ * @param {boolean} returnTagCount - returns the x-amz-tagging-count header
  * @return {object} responseMetaHeaders headers with object metadata to include
  * in response to client
  */
-function collectResponseHeaders(objectMD, corsHeaders, versioningCfg) {
+function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
+  returnTagCount) {
     // Add user meta headers from objectMD
     const responseMetaHeaders = Object.assign({}, corsHeaders);
     Object.keys(objectMD).filter(val => (val.substr(0, 11) === 'x-amz-meta-' ||
@@ -57,6 +59,11 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg) {
         new Date(objectMD['last-modified']).toUTCString();
     if (objectMD['content-type']) {
         responseMetaHeaders['Content-Type'] = objectMD['content-type'];
+    }
+    if (returnTagCount && objectMD.tags &&
+    Object.keys(objectMD.tags).length > 0) {
+        responseMetaHeaders['x-amz-tagging-count'] =
+          Object.keys(objectMD.tags).length;
     }
     return responseMetaHeaders;
 }

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -111,5 +111,56 @@ describe('GET object', () => {
                   });
             });
         });
+
+        describe('x-amz-tagging-count', () => {
+            const params = {
+                Bucket: bucketName,
+                Key: objectName,
+            };
+            const paramsTagging = {
+                Bucket: bucketName,
+                Key: objectName,
+                Tagging: {
+                    TagSet: [
+                        {
+                            Key: 'key1',
+                            Value: 'value',
+                        },
+                    ],
+                },
+            };
+            beforeEach(done => {
+                s3.putObject(params, done);
+            });
+
+            it('should not return "x-amz-tagging-count" if no tag ' +
+            'associated with the object',
+            done => {
+                s3.getObject(params, (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(data.TagCount, undefined);
+                    return done();
+                });
+            });
+
+            describe('tag associated with the object', () => {
+                beforeEach(done => {
+                    s3.putObjectTagging(paramsTagging, done);
+                });
+                it('should return "x-amz-tagging-count" header that provides ' +
+                'the count of number of tags associated with the object',
+                done => {
+                    s3.getObject(params, (err, data) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.equal(data.TagCount, 1);
+                        return done();
+                    });
+                });
+            });
+        });
     });
 });

--- a/tests/functional/aws-node-sdk/test/versioning/objectGet.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectGet.js
@@ -130,5 +130,65 @@ describe('get behavior after delete with versioning', () => {
                 });
             });
         });
+
+        describe('x-amz-tagging-count with versioning', () => {
+            let params;
+            let paramsTagging;
+            beforeEach(function beforeEach(done) {
+                params = {
+                    Bucket: bucket,
+                    Key: key,
+                };
+                paramsTagging = {
+                    Bucket: bucket,
+                    Key: key,
+                    Tagging: {
+                        TagSet: [
+                            {
+                                Key: 'key1',
+                                Value: 'value',
+                            },
+                        ],
+                    },
+                };
+                s3.putObject(params, (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    this.currentTest.versionId = data.VersionId;
+                    return done();
+                });
+            });
+
+            it('should not return "x-amz-tagging-count" if no tag ' +
+            'associated with the object',
+            function itF(done) {
+                params.VersionId = this.test.VersionId;
+                s3.getObject(params, (err, data) => {
+                    if (err) {
+                        return done(err);
+                    }
+                    assert.strictEqual(data.TagCount, undefined);
+                    return done();
+                });
+            });
+
+            describe('tag associated with the object ', () => {
+                beforeEach(done => s3.putObjectTagging(paramsTagging, done));
+
+                it('should return "x-amz-tagging-count" header that provides ' +
+                'the count of number of tags associated with the object',
+                function itF(done) {
+                    params.VersionId = this.test.VersionId;
+                    s3.getObject(params, (err, data) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.equal(data.TagCount, 1);
+                        return done();
+                    });
+                });
+            });
+        });
     });
 });

--- a/tests/unit/api/deletedFlagBucket.js
+++ b/tests/unit/api/deletedFlagBucket.js
@@ -499,7 +499,7 @@ describe('deleted flag bucket handling', () => {
     it('objectGet request on bucket with deleted flag should' +
         'return NoSuchBucket error and finish deletion',
         done => {
-            objectGet(authInfo, baseTestRequest,
+            objectGet(authInfo, baseTestRequest, false,
             log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
                 confirmDeleted(done);

--- a/tests/unit/api/objectDelete.js
+++ b/tests/unit/api/objectDelete.js
@@ -75,7 +75,7 @@ describe('objectDelete API', () => {
                 undefined, log, () => {
                     objectDelete(authInfo, testDeleteRequest, log, err => {
                         assert.strictEqual(err, null);
-                        objectGet(authInfo, testGetObjectRequest,
+                        objectGet(authInfo, testGetObjectRequest, false,
                             log, err => {
                                 assert.deepStrictEqual(err,
                                     errors.NoSuchKey);
@@ -99,7 +99,7 @@ describe('objectDelete API', () => {
                 undefined, log, () => {
                     objectDelete(authInfo, testDeleteRequest, log, err => {
                         assert.strictEqual(err, null);
-                        objectGet(authInfo, testGetObjectRequest,
+                        objectGet(authInfo, testGetObjectRequest, false,
                             log, err => {
                                 const expected =
                                 Object.assign({}, errors.NoSuchKey);

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -60,7 +60,7 @@ describe('objectGet API', () => {
             objectPut(authInfo, testPutObjectRequest, undefined,
                 log, (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest,
+                    objectGet(authInfo, testGetRequest, false,
                         log, (err, result, responseMetaHeaders) => {
                             assert.strictEqual(responseMetaHeaders
                                 [userMetadataKey],
@@ -78,7 +78,7 @@ describe('objectGet API', () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest, log,
+                    objectGet(authInfo, testGetRequest, false, log,
                         (err, dataGetInfo) => {
                             assert.deepStrictEqual(dataGetInfo,
                         [{
@@ -184,7 +184,8 @@ describe('objectGet API', () => {
                 },
             ],
             () => {
-                objectGet(authInfo, testGetRequest, log, (err, dataGetInfo) => {
+                objectGet(authInfo, testGetRequest, false, log,
+                (err, dataGetInfo) => {
                     assert.deepStrictEqual(dataGetInfo,
                         [{
                             key: 1,
@@ -222,7 +223,7 @@ describe('objectGet API', () => {
             objectPut(authInfo, testPutObjectRequest, undefined, log,
                 (err, resHeaders) => {
                     assert.strictEqual(resHeaders.ETag, `"${correctMD5}"`);
-                    objectGet(authInfo, testGetRequest,
+                    objectGet(authInfo, testGetRequest, false,
                     log, (err, result, responseMetaHeaders) => {
                         assert.strictEqual(result, null);
                         assert.strictEqual(responseMetaHeaders

--- a/tests/unit/api/transientBucket.js
+++ b/tests/unit/api/transientBucket.js
@@ -442,7 +442,7 @@ describe('transient bucket handling', () => {
     it('objectGet request on transient bucket should' +
         'return NoSuchBucket error',
         done => {
-            objectGet(authInfo, baseTestRequest,
+            objectGet(authInfo, baseTestRequest, false,
             log, err => {
                 assert.deepStrictEqual(err, errors.NoSuchBucket);
                 done();


### PR DESCRIPTION
E2E passed with https://github.com/scality/Integration/pull/523

Testing getObject with tagging:

- if `s3:GetObject` and `s3:GetObjectTagging` permissions : getObject return the header: `x-amz-tagging-count` that provides the count of number of tags associated with the object.

- if `s3:GetObjectVersion` and `s3:GetObjectVersionTagging` permissions : getObject with versioning return the header: `x-amz-tagging-count`.
