### PR TITLE
TEST: version non-specified (tag and acl)

### DIFF
--- a/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
+++ b/tests/functional/aws-node-sdk/lib/utility/versioning-util.js
@@ -1,4 +1,5 @@
 import async from 'async';
+import assert from 'assert';
 import { S3 } from 'aws-sdk';
 
 import getConfig from '../../test/support/config';
@@ -19,6 +20,12 @@ function _deleteVersionList(versionList, bucket, callback) {
     });
 
     return s3.deleteObjects(params, callback);
+}
+
+export function checkOneVersion(data, versionId) {
+    assert.strictEqual(data.Versions.length, 1);
+    assert.strictEqual(data.Versions[0].VersionId, versionId);
+    assert.strictEqual(data.DeleteMarkers.length, 0);
 }
 
 export function removeAllVersions(params, callback) {

--- a/tests/functional/aws-node-sdk/test/versioning/objectACL.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectACL.js
@@ -3,6 +3,7 @@ import async from 'async';
 
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
+import { checkOneVersion } from '../../lib/utility/versioning-util';
 
 import {
     removeAllVersions,
@@ -290,6 +291,39 @@ describe('versioned put and get object acl ::', () => {
                 });
 
                 _testBehaviorVersioningEnabledOrSuspended(versionIds);
+            });
+        });
+
+        describe('on a version-enabled bucket - version non-specified :: ',
+        () => {
+            let versionId;
+            beforeEach(done => {
+                const params = { Bucket: bucket, Key: key };
+                async.waterfall([
+                    callback => s3.putBucketVersioning({
+                        Bucket: bucket,
+                        VersioningConfiguration: versioningEnabled,
+                    }, err => callback(err)),
+                    callback => s3.putObject(params, (err, data) => {
+                        if (err) {
+                            return callback(err);
+                        }
+                        versionId = data.VersionId;
+                        return callback();
+                    }),
+                ], done);
+            });
+
+            it('should not create version putting ACL on a' +
+            'version-enabled bucket where no version id is specified',
+            done => {
+                const params = { Bucket: bucket, Key: key, ACL: 'public-read' };
+                _putObjectAcl(params, () => s3.listObjectVersions({ Bucket:
+                  bucket }, (err, data) => {
+                    assert.ifError(err, `listObjects err ${err}`);
+                    checkOneVersion(data, versionId);
+                    done();
+                }));
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
@@ -3,6 +3,7 @@ const async = require('async');
 
 import withV4 from '../support/withV4';
 import BucketUtility from '../../lib/utility/bucket-util';
+import { checkOneVersion } from '../../lib/utility/versioning-util';
 
 const bucketName = 'testtaggingbucket';
 const objectName = 'testtaggingobject';
@@ -58,6 +59,38 @@ describe('Delete object tagging with versioning', () => {
             ], (err, data, versionId) => {
                 assert.ifError(err, `Found unexpected err ${err}`);
                 assert.strictEqual(data.VersionId, versionId);
+                done();
+            });
+        });
+
+        it('should not create version deleting object tags on a ' +
+        ' version-enabled bucket where no version id is specified ', done => {
+            async.waterfall([
+                next => s3.putBucketVersioning({ Bucket: bucketName,
+                  VersioningConfiguration: versioningEnabled },
+                  err => next(err)),
+                next => s3.putObject({ Bucket: bucketName, Key: objectName },
+                  (err, data) => next(err, data.VersionId)),
+                (versionId, next) => s3.putObjectTagging({
+                    Bucket: bucketName,
+                    Key: objectName,
+                    VersionId: versionId,
+                    Tagging: { TagSet: [
+                        {
+                            Key: 'key1',
+                            Value: 'value1',
+                        }] },
+                }, err => next(err, versionId)),
+                (versionId, next) => s3.deleteObjectTagging({
+                    Bucket: bucketName,
+                    Key: objectName,
+                }, err => next(err, versionId)),
+                (versionId, next) => s3.listObjectVersions({
+                    Bucket: bucketName,
+                }, (err, data) => next(err, data, versionId)),
+            ], (err, data, versionId) => {
+                assert.ifError(err, `Found unexpected err ${err}`);
+                checkOneVersion(data, versionId);
                 done();
             });
         });


### PR DESCRIPTION
**AWS compatibility**

AWS does not create version:
- putting ACL on a version-enabled bucket where no version id is specified
- putting object tags on a version-enabled bucket where no version id is specified
- deleting object tags on a version-enabled bucket where no version id is specified