### PR TITLE
FX: putObject with tag set policy

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -26,6 +26,14 @@ export default function prepareRequestContexts(apiMethod, request, sourceBucket,
     // itself (once we parse the locationConstraint from the xml body) so send
     // null as the requestContext to Vault so it will only do an authentication
     // check.
+
+    function generateRequestContext(apiMethod) {
+        return new RequestContext(request.headers,
+            request.query, request.bucketName, request.objectKey,
+            request.socket.remoteAddress, request.connection.encrypted,
+            apiMethod, 's3');
+    }
+
     if (apiMethod === 'multiObjectDelete' || apiMethod === 'bucketPut') {
         return null;
     }
@@ -46,30 +54,33 @@ export default function prepareRequestContexts(apiMethod, request, sourceBucket,
             reqQuery, sourceBucket, sourceObject,
             request.socket.remoteAddress, request.connection.encrypted,
             objectGetAction, 's3');
-        const putRequestContext = new RequestContext(request.headers,
-            request.query, request.bucketName, request.objectKey,
-            request.socket.remoteAddress, request.connection.encrypted,
-            'objectPut', 's3');
+        const putRequestContext = generateRequestContext('objectPut');
         requestContexts.push(getRequestContext, putRequestContext);
     } else if (apiMethodAfterVersionCheck === 'objectGet' ||
       apiMethodAfterVersionCheck === 'objectGetVersion') {
         const objectGetTaggingAction = (request.query &&
           request.query.versionId) ? 'objectGetTaggingVersion' :
           'objectGetTagging';
-        const getRequestContext = new RequestContext(request.headers,
-            request.query, request.bucketName, request.objectKey,
-            request.socket.remoteAddress, request.connection.encrypted,
-            apiMethodAfterVersionCheck, 's3');
-        const getTaggingRequestContext = new RequestContext(request.headers,
-            request.query, request.bucketName, request.objectKey,
-            request.socket.remoteAddress, request.connection.encrypted,
-            objectGetTaggingAction, 's3');
+        const getRequestContext =
+          generateRequestContext(apiMethodAfterVersionCheck);
+        const getTaggingRequestContext =
+          generateRequestContext(objectGetTaggingAction);
         requestContexts.push(getRequestContext, getTaggingRequestContext);
+    } else if ((apiMethodAfterVersionCheck === 'objectPut' ||
+      apiMethodAfterVersionCheck === 'objectPutVersion') &&
+      request.headers['x-amz-tagging']) {
+        // if put object (versioning) with tag set
+        const objectPutTaggingAction = (request.query &&
+          request.query.versionId) ? 'objectPutTaggingVersion' :
+          'objectPutTagging';
+        const getRequestContext =
+          generateRequestContext(apiMethodAfterVersionCheck);
+        const putTaggingRequestContext =
+          generateRequestContext(objectPutTaggingAction);
+        requestContexts.push(getRequestContext, putTaggingRequestContext);
     } else {
-        const requestContext = new RequestContext(request.headers,
-            request.query, request.bucketName, request.objectKey,
-            request.socket.remoteAddress, request.connection.encrypted,
-            apiMethodAfterVersionCheck, 's3');
+        const requestContext =
+          generateRequestContext(apiMethodAfterVersionCheck);
         requestContexts.push(requestContext);
     }
     return requestContexts;


### PR DESCRIPTION
To specify tags on an object, the requester must have `s3:PutObjectTagging` included in the list of permitted actions in their IAM policy.