### PR TITLE
Patch: Bypass double buffering for 1 location

### DIFF
--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -359,6 +359,25 @@ const routesUtils = {
                 httpCode: response.statusCode,
             });
         });
+        if (parsedLocations.length === 1) {
+            return data.get(parsedLocations[0], log,
+                (err, readable) => {
+                    if (err) {
+                        log.error('failed to get full object', {
+                            error: err,
+                            method: 'data.get',
+                        });
+                        return response.connection.destroy();
+                    }
+                    readable.on('error', () => {
+                        log.error('error piping data ' +
+                        'from readable to response');
+                        return response.connection.destroy();
+                    });
+                    readable.pipe(response);
+                    return undefined;
+                });
+        }
         return readySetStream(parsedLocations, data.get, response, log);
     },
 


### PR DESCRIPTION
When getting a large object, we are experiencing memory issues. This is a patch to prevent the issues from occurring when an object was put without MPU.
