### PR TITLE
S3C-413 put object ACL with s3:PutObjectAcl permission

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -6,6 +6,12 @@ const apiMethodWithVersion = { objectGetACL: true, objectPutACL: true,
 objectGet: true, objectDelete: true, objectPutTagging: true,
 objectGetTagging: true, objectDeleteTagging: true };
 
+function isHeaderAcl(headers) {
+    return headers['x-amz-grant-read'] || headers['x-amz-grant-read-acp'] ||
+    headers['x-amz-grant-write-acp'] || headers['x-amz-grant-full-control'] ||
+    headers['x-amz-acl'];
+}
+
 /**
  * Prepares the requestContexts array to send to Vault for authorization
  * @param {string} apiMethod - api being called
@@ -56,6 +62,8 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
             objectGetAction, 's3');
         const putRequestContext = generateRequestContext('objectPut');
         requestContexts.push(getRequestContext, putRequestContext);
+        // if tagging directive is COPY, "s3:PutObjectTagging" don't need to be
+        // included in the list of permitted actions in IAM policy
         if (apiMethodAfterVersionCheck === 'objectCopy' &&
         request.headers['x-amz-tagging'] &&
         request.headers['x-amz-tagging-directive'] === 'REPLACE') {
@@ -73,18 +81,22 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
         const getTaggingRequestContext =
           generateRequestContext(objectGetTaggingAction);
         requestContexts.push(getRequestContext, getTaggingRequestContext);
-    } else if ((apiMethodAfterVersionCheck === 'objectPut' ||
-      apiMethodAfterVersionCheck === 'objectPutVersion') &&
-      request.headers['x-amz-tagging']) {
-        // if put object (versioning) with tag set
-        const objectPutTaggingAction = (request.query &&
-          request.query.versionId) ? 'objectPutTaggingVersion' :
-          'objectPutTagging';
-        const getRequestContext =
+    } else if (apiMethodAfterVersionCheck === 'objectPut') {
+        const putRequestContext =
           generateRequestContext(apiMethodAfterVersionCheck);
-        const putTaggingRequestContext =
-          generateRequestContext(objectPutTaggingAction);
-        requestContexts.push(getRequestContext, putTaggingRequestContext);
+        requestContexts.push(putRequestContext);
+        // if put object (versioning) with tag set
+        if (request.headers['x-amz-tagging']) {
+            const putTaggingRequestContext =
+              generateRequestContext('objectPutTagging');
+            requestContexts.push(putTaggingRequestContext);
+        }
+        // if put object (versioning) with ACL
+        if (isHeaderAcl(request.headers)) {
+            const putAclRequestContext =
+              generateRequestContext('objectPutACL');
+            requestContexts.push(putAclRequestContext);
+        }
     } else {
         const requestContext =
           generateRequestContext(apiMethodAfterVersionCheck);


### PR DESCRIPTION
If `x-amz-grant-read, x-amz-grant-read-acp, and x-amz-grant-write-acp, x-amz-grant-full-control`
 or `x-amz-acl` headers are used to change the object ACLs to something other than the default, the requester must have `s3:PutObjectAcl` included in the list of permitted actions in their AWS Identity and Access Management (IAM) policy. 

Integration tests: https://github.com/scality/Integration/pull/531