### PR TITLE
S3C-413 copy object ACL with s3:PutObjectAcl permission

### DIFF
--- a/lib/api/apiUtils/authorization/prepareRequestContexts.js
+++ b/lib/api/apiUtils/authorization/prepareRequestContexts.js
@@ -43,15 +43,18 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
     if (apiMethod === 'multiObjectDelete' || apiMethod === 'bucketPut') {
         return null;
     }
+
     if (apiMethodWithVersion[apiMethod] && request.query &&
-      request.query.versionId) {
+        request.query.versionId) {
         apiMethodAfterVersionCheck = `${apiMethod}Version`;
     } else {
         apiMethodAfterVersionCheck = apiMethod;
     }
+
     const requestContexts = [];
-    if (apiMethodAfterVersionCheck === 'objectCopy' ||
-    apiMethodAfterVersionCheck === 'objectPutCopyPart') {
+
+    if (apiMethodAfterVersionCheck === 'objectCopy'
+        || apiMethodAfterVersionCheck === 'objectPutCopyPart') {
         const objectGetAction = sourceVersionId ? 'objectGetVersion' :
           'objectGet';
         const reqQuery = Object.assign({}, request.query,
@@ -62,17 +65,23 @@ function prepareRequestContexts(apiMethod, request, sourceBucket,
             objectGetAction, 's3');
         const putRequestContext = generateRequestContext('objectPut');
         requestContexts.push(getRequestContext, putRequestContext);
-        // if tagging directive is COPY, "s3:PutObjectTagging" don't need to be
-        // included in the list of permitted actions in IAM policy
-        if (apiMethodAfterVersionCheck === 'objectCopy' &&
-        request.headers['x-amz-tagging'] &&
-        request.headers['x-amz-tagging-directive'] === 'REPLACE') {
-            const putTaggingRequestContext =
-                generateRequestContext('objectPutTagging');
-            requestContexts.push(putTaggingRequestContext);
+        if (apiMethodAfterVersionCheck === 'objectCopy') {
+            // if tagging directive is COPY, "s3:PutObjectTagging" don't need
+            // to be included in the list of permitted actions in IAM policy
+            if (request.headers['x-amz-tagging'] &&
+                request.headers['x-amz-tagging-directive'] === 'REPLACE') {
+                const putTaggingRequestContext =
+                    generateRequestContext('objectPutTagging');
+                requestContexts.push(putTaggingRequestContext);
+            }
+            if (isHeaderAcl(request.headers)) {
+                const putAclRequestContext =
+                  generateRequestContext('objectPutACL');
+                requestContexts.push(putAclRequestContext);
+            }
         }
-    } else if (apiMethodAfterVersionCheck === 'objectGet' ||
-      apiMethodAfterVersionCheck === 'objectGetVersion') {
+    } else if (apiMethodAfterVersionCheck === 'objectGet'
+               || apiMethodAfterVersionCheck === 'objectGetVersion') {
         const objectGetTaggingAction = (request.query &&
           request.query.versionId) ? 'objectGetTaggingVersion' :
           'objectGetTagging';


### PR DESCRIPTION
If `x-amz-grant-read, x-amz-grant-read-acp, and x-amz-grant-write-acp, x-amz-grant-full-control`
 or `x-amz-acl` headers are used to change the object ACLs to something other than the default, the requester must have `s3:PutObjectAcl` included in the list of permitted actions in their AWS Identity and Access Management (IAM) policy. 

Integration tests: https://github.com/scality/Integration/pull/532