### PR TITLE
fix: clean up existing master null version before overwrite [S3C-444]

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -10,7 +10,6 @@ const { dataStore } = require('./storeObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
 const { versioningPreprocessing } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
-const { decodeVersionId } = require('./versioning');
 const { config } = require('../../../Config');
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
@@ -108,16 +107,6 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.tagging = request.headers['x-amz-tagging'];
     }
 
-    const decodedVidResult = decodeVersionId(request.query);
-    if (decodedVidResult instanceof Error) {
-        log.trace('invalid versionId query', {
-            versionId: request.query.versionId,
-            error: decodedVidResult,
-        });
-        return callback(decodedVidResult);
-    }
-    const reqVersionId = decodedVidResult;
-
     const backendInfoObj =
         locationConstraintCheck(request, null, bucketMD, log);
     if (backendInfoObj.err) {
@@ -164,8 +153,7 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         },
         function getVersioningInfo(infoArr, next) {
             return versioningPreprocessing(bucketName, bucketMD,
-                metadataStoreParams.objectKey, objMD, reqVersionId, log,
-                (err, options) => {
+                metadataStoreParams.objectKey, objMD, log, (err, options) => {
                     if (err) {
                         // TODO: check AWS error when user requested a specific
                         // version before any versions have been put

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -1,4 +1,5 @@
 const { errors, versioning } = require('arsenal');
+const async = require('async');
 
 const metadata = require('../../../metadata/wrapper');
 const { config } = require('../../../Config');
@@ -121,13 +122,71 @@ function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
         });
 }
 
+function processVersioningState(mst, vstat, cb) {
+    const options = {};
+    const storeOptions = {};
+    const delOptions = {};
+    // object does not exist or is not versioned (before versioning)
+    if (mst.versionId === undefined || mst.isNull) {
+        // versioning is suspended, overwrite existing master version
+        if (vstat === 'Suspended') {
+            options.versionId = '';
+            options.isNull = true;
+            options.dataToDelete = mst.objLocation;
+            return cb(null, options);
+        }
+        // versioning is enabled, create a new version
+        options.versioning = true;
+        if (mst.exists) {
+            // store master version in a new key
+            const versionId = mst.isNull ? mst.versionId : nonVersionedObjId;
+            storeOptions.versionId = versionId;
+            storeOptions.isNull = true;
+            options.nullVersionId = versionId;
+            return cb(null, options, storeOptions);
+        }
+        return cb(null, options);
+    }
+    // master is versioned and is not a null version
+    const nullVersionId = mst.nullVersionId;
+    if (vstat === 'Suspended') {
+        // versioning is suspended, overwrite the existing master version
+        options.versionId = '';
+        options.isNull = true;
+        if (nullVersionId === undefined) {
+            return cb(null, options);
+        }
+        delOptions.versionId = nullVersionId;
+        return cb(null, options, null, delOptions);
+    }
+    // versioning is enabled, put the new version
+    options.versioning = true;
+    options.nullVersionId = nullVersionId;
+    return cb(null, options);
+}
+
+function getMasterState(objMD) {
+    if (!objMD) {
+        return {};
+    }
+    const mst = {
+        exists: true,
+        versionId: objMD.versionId,
+        isNull: objMD.isNull,
+        nullVersionId: objMD.nullVersionId,
+    };
+    if (objMD.location) {
+        mst.objLocation = Array.isArray(objMD.location) ?
+            objMD.location : [objMD.location];
+    }
+    return mst;
+}
 /** versioningPreprocessing - return versioning information for S3 to handle
  * creation of new versions and manage deletion of old data and metadata
  * @param {string} bucketName - name of bucket
  * @param {object} bucketMD - bucket metadata
  * @param {string} objectKey - name of object
  * @param {object} objMD - obj metadata
- * @param {string} [reqVersionId] - specific version ID sent as part of request
  * @param {RequestLogger} log - logger instance
  * @param {function} callback - callback
  * @return {undefined} and call callback with params (err, options):
@@ -140,117 +199,57 @@ function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
  *  version id of the null version
  * options.deleteNullVersionData - whether to delete the data of the null ver
  */
-function versioningPreprocessing(bucketName, bucketMD, objectKey,
-    objMD, reqVersionId, log, callback) {
+function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
+    log, callback) {
     const options = {};
-    let mstObjLocation;
-    if (objMD && objMD.location) {
-        mstObjLocation = Array.isArray(objMD.location) ?
-            objMD.location : [objMD.location];
+    const mst = getMasterState(objMD);
+    const vCfg = bucketMD.getVersioningConfiguration();
+    // bucket is not versioning configured
+    if (!vCfg) {
+        options.dataToDelete = mst.objLocation;
+        return process.nextTick(callback, null, options);
     }
-    // bucket is not versioning enabled
-    if (!bucketMD.getVersioningConfiguration()) {
-        options.dataToDelete = mstObjLocation;
-        return callback(null, options);
-    }
-    // bucket is versioning enabled
-    const mstVersionId = objMD ? objMD.versionId : undefined;
-    const mstIsNull = objMD ? objMD.isNull : false;
-    const vstat = bucketMD.getVersioningConfiguration().Status;
-    if (!reqVersionId) {
-        // non-version-specific versioning operation
-        if (mstVersionId === undefined || mstIsNull) {
-            // object does not exist or is not versioned (before versioning)
-            if (vstat === 'Suspended') {
-                // versioning is suspended, overwrite existing master version
-                options.versionId = '';
-                options.isNull = true;
-                options.dataToDelete = mstObjLocation;
-                return callback(null, options);
+    // bucket is versioning configured
+    return async.waterfall([
+        function processState(next) {
+            processVersioningState(mst, vCfg.Status,
+                (err, options, storeOptions, delOptions) => {
+                    process.nextTick(next, err, options, storeOptions,
+                        delOptions);
+                });
+        },
+        function storeVersion(options, storeOptions, delOptions, next) {
+            if (!storeOptions) {
+                return process.nextTick(next, null, options, delOptions);
             }
-            // versioning is enabled, create a new version
-            options.versioning = true;
-            if (objMD) {
-                // store master version in a new key
-                const versionId = mstIsNull ? mstVersionId : nonVersionedObjId;
-                objMD.versionId = versionId; // eslint-disable-line
-                objMD.isNull = true; // eslint-disable-line
-                options.nullVersionId = versionId;
-                return _storeNullVersionMD(bucketName, objectKey, objMD,
-                    { versionId }, log, err => callback(err, options));
+            const versionMD = Object.assign({}, objMD, storeOptions);
+            const params = { versionId: storeOptions.versionId };
+            return _storeNullVersionMD(bucketName, objectKey, versionMD,
+                params, log, err => next(err, options, delOptions));
+        },
+        function deleteNullVersion(options, delOptions, next) {
+            if (!delOptions) {
+                return process.nextTick(next, null, options);
             }
-            return callback(null, options);
-        }
-        // master is versioned and is not a null version
-        const nullVersionId = objMD.nullVersionId;
-        if (vstat === 'Suspended') {
-            // versioning is suspended, overwrite the existing master version
-            options.versionId = '';
-            options.isNull = true;
-            if (nullVersionId === undefined) {
-                return callback(null, options);
-            }
-            return _deleteNullVersionMD(bucketName, objectKey,
-                { versionId: nullVersionId }, log, (err, nullDataToDelete) => {
-                    if (err) {
-                        log.warn('unexpected error deleting null version md', {
-                            error: err,
-                            method: 'versioningPreprocessing',
-                        });
-                        if (err === errors.NoSuchKey) {
-                            // it's possible there was a concurrent request to
-                            // delete the null version, so proceed with putting
-                            // a new version
-                            return callback(null, options);
-                        }
-                        return callback(errors.InternalError);
+            return _deleteNullVersionMD(bucketName, objectKey, delOptions, log,
+            (err, nullDataToDelete) => {
+                if (err) {
+                    log.warn('unexpected error deleting null version md', {
+                        error: err,
+                        method: 'versioningPreprocessing',
+                    });
+                    // it's possible there was a concurrent request to delete
+                    // the null version, so proceed with putting a new version
+                    if (err === errors.NoSuchKey) {
+                        return next(null, options);
                     }
-                    options.dataToDelete = nullDataToDelete;
-                    return callback(err, options);
-                });
-        }
-        // versioning is enabled, put the new version
-        options.versioning = true;
-        options.nullVersionId = nullVersionId;
-        return callback(null, options);
-    // NOTE: Currently we do not accept requests with PUTs to specific
-    // version ID, but this may change after implementing georeplication.
-    } else if (!mstVersionId) {
-        // version-specific versioning operation, master is not versioned
-        if (vstat === 'Suspended' || reqVersionId === 'null') {
-            // object does not exist or is not versioned (before versioning)
-            options.versionId = '';
-            options.isNull = true;
-            options.dataToDelete = mstObjLocation;
-            return callback(null, options);
-        }
-        return callback(errors.BadRequest);
-    } else if (mstIsNull) {
-        // master is versioned and is a null version
-        if (reqVersionId === 'null') {
-            // overwrite the existing version, make new version null
-            options.versionId = '';
-            options.isNull = true;
-            options.dataToDelete = mstObjLocation;
-            return callback(null, options);
-        }
-    }
-    // master is versioned and is not a null version
-    options.versionId = reqVersionId;
-    return _getDeleteLocations(bucketName, objectKey,
-        { versionId: reqVersionId }, log, (err, dataToDelete) => {
-            if (err && err === errors.NoSuchKey) {
-                return callback(null, options);
-            } else if (err) {
-                log.warn('unexpected error getting delete locations', {
-                    error: err,
-                    method: 'versioningPreprocessing',
-                });
-                return callback(errors.InternalError);
-            }
-            options.dataToDelete = dataToDelete;
-            return callback(null, options);
-        });
+                    return next(errors.InternalError);
+                }
+                Object.assign(options, { dataToDelete: nullDataToDelete });
+                return next(null, options);
+            });
+        },
+    ], (err, options) => callback(err, options));
 }
 
 /** preprocessingVersioningDelete - return versioning information for S3 to

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -133,6 +133,11 @@ function processVersioningState(mst, vstat, cb) {
             options.versionId = '';
             options.isNull = true;
             options.dataToDelete = mst.objLocation;
+            // if null version exists, clean it up prior to put
+            if (mst.isNull) {
+                delOptions.versionId = mst.versionId;
+                return cb(null, options, null, delOptions);
+            }
             return cb(null, options);
         }
         // versioning is enabled, create a new version

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -382,7 +382,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                 };
             }
             return versioningPreprocessing(bucketName,
-                destBucket, objectKey, objMD, null, log, (err, options) => {
+                destBucket, objectKey, objMD, log, (err, options) => {
                     if (err) {
                         // TODO: check AWS error when user requested a specific
                         // version before any versions have been put

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -356,7 +356,7 @@ function objectCopy(authInfo, request, sourceBucket,
         function getVersioningInfo(storeMetadataParams, destDataGetInfoArr,
             destObjMD, serverSideEncryption, destBucketMD, next) {
             return versioningPreprocessing(destBucketName,
-                destBucketMD, destObjectKey, destObjMD, null, log,
+                destBucketMD, destObjectKey, destObjMD, log,
                 (err, options) => {
                     if (err) {
                         log.debug('error processing versioning info',

--- a/tests/functional/aws-node-sdk/test/versioning/objectACL.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectACL.js
@@ -327,12 +327,9 @@ describe('versioned put and get object acl ::', () => {
             'version-enabled bucket where no version id is specified',
             done => {
                 const params = { Bucket: bucket, Key: key, ACL: 'public-read' };
-                utils.putObjectAcl(params, () => s3.listObjectVersions({ Bucket:
-                  bucket }, (err, data) => {
-                    assert.ifError(err, `listObjects err ${err}`);
-                    checkOneVersion(data, versionId);
-                    done();
-                }));
+                utils.putObjectAcl(params, () => {
+                    checkOneVersion(s3, bucket, versionId, done);
+                });
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/versioning/objectACL.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectACL.js
@@ -21,190 +21,198 @@ const nonExistingId = process.env.AWS_ON_AIR ?
     'MhhyTHhmZ4cxSi4Y9SMe5P7UJAz7HLJ9' :
     '3939393939393939393936493939393939393939756e6437';
 
-function _assertNoError(err, desc) {
-    assert.strictEqual(err, null, `Unexpected err ${desc}: ${err}`);
-}
+class _Utils {
+    constructor(s3) {
+        this.s3 = s3;
+    }
 
+    static assertNoError(err, desc) {
+        assert.strictEqual(err, null, `Unexpected err ${desc}: ${err}`);
+    }
 
-describe('versioned put and get object acl ::', () => {
-    withV4(sigCfg => {
-        const bucketUtil = new BucketUtility('default', sigCfg);
-        const s3 = bucketUtil.s3;
+    // need a wrapper because sdk apparently does not include version id in
+    // exposed data object for put/get acl methods
+    _wrapDataObject(method, params, callback) {
+        let request = undefined;
+        async.waterfall([
+            next => {
+                request = this.s3[method](params, next);
+            },
+            (data, next) => {
+                const responseHeaders = request.response
+                .httpResponse.headers;
+                const dataObj = Object.assign({
+                    VersionId: responseHeaders['x-amz-version-id'],
+                }, data);
+                return next(null, dataObj);
+            },
+        ], callback);
+    }
 
-        // need a wrapper because sdk apparently does not include version id in
-        // exposed data object for put/get acl methods
-        function _wrapDataObject(method, params, callback) {
-            let request = undefined;
-            async.waterfall([
-                next => {
-                    request = s3[method](params, next);
-                },
-                (data, next) => {
-                    const responseHeaders = request.response
-                    .httpResponse.headers;
-                    const dataObj = Object.assign({
-                        VersionId: responseHeaders['x-amz-version-id'],
-                    }, data);
-                    return next(null, dataObj);
-                },
-            ], callback);
+    getObjectAcl(params, callback) {
+        this._wrapDataObject('getObjectAcl', params, callback);
+    }
+
+    putObjectAcl(params, callback) {
+        this._wrapDataObject('putObjectAcl', params, callback);
+    }
+
+    putAndGetAcl(cannedAcl, versionId, expected, cb) {
+        const params = {
+            Bucket: bucket,
+            Key: key,
+            ACL: cannedAcl,
+        };
+        if (versionId) {
+            params.VersionId = versionId;
         }
-
-        function _getObjectAcl(params, callback) {
-            _wrapDataObject('getObjectAcl', params, callback);
-        }
-
-        function _putObjectAcl(params, callback) {
-            _wrapDataObject('putObjectAcl', params, callback);
-        }
-
-        function _putAndGetAcl(cannedAcl, versionId, expected, cb) {
-            const params = {
-                Bucket: bucket,
-                Key: key,
-                ACL: cannedAcl,
-            };
-            if (versionId) {
-                params.VersionId = versionId;
+        this.putObjectAcl(params, (err, data) => {
+            if (expected.error) {
+                assert.strictEqual(expected.error.code, err.code);
+                assert.strictEqual(expected.error.statusCode,
+                    err.statusCode);
+            } else {
+                _Utils.assertNoError(err,
+                    `putting object acl with version id: ${versionId}`);
+                assert.strictEqual(data.VersionId, expected.versionId,
+                    `expected version id '${expected.versionId}' in ` +
+                    `putacl res headers, got '${data.VersionId}' instead`);
             }
-            _putObjectAcl(params, (err, data) => {
+            delete params.ACL;
+            this.getObjectAcl(params, (err, data) => {
                 if (expected.error) {
                     assert.strictEqual(expected.error.code, err.code);
                     assert.strictEqual(expected.error.statusCode,
                         err.statusCode);
                 } else {
-                    _assertNoError(err, 'putting object acl with version id:' +
-                        `${versionId}`);
+                    _Utils.assertNoError(err,
+                        `getting object acl with version id: ${versionId}`);
                     assert.strictEqual(data.VersionId, expected.versionId,
                         `expected version id '${expected.versionId}' in ` +
-                        `putacl res headers, got '${data.VersionId}' instead`);
+                        `getacl res headers, got '${data.VersionId}'`);
+                    assert.strictEqual(data.Grants.length, 2);
                 }
-                delete params.ACL;
-                _getObjectAcl(params, (err, data) => {
-                    if (expected.error) {
-                        assert.strictEqual(expected.error.code, err.code);
-                        assert.strictEqual(expected.error.statusCode,
-                            err.statusCode);
-                    } else {
-                        _assertNoError(err,
-                            `getting object acl with version id: ${versionId}`);
-                        assert.strictEqual(data.VersionId, expected.versionId,
-                            `expected version id '${expected.versionId}' in ` +
-                            `getacl res headers, got '${data.VersionId}'`);
-                        assert.strictEqual(data.Grants.length, 2);
-                    }
-                    cb();
-                });
+                cb();
             });
-        }
+        });
+    }
+}
 
-        function _testBehaviorVersioningEnabledOrSuspended(versionIds) {
-            it('should return 405 MethodNotAllowed putting acl without ' +
-            'version id if latest version is a delete marker', done => {
-                const aclParams = {
-                    Bucket: bucket,
-                    Key: key,
-                    ACL: 'public-read-write',
-                };
-                s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
-                    assert.strictEqual(err, null,
-                        `Unexpected err deleting object: ${err}`);
-                    assert.strictEqual(data.DeleteMarker, 'true');
-                    assert(data.VersionId);
-                    _putObjectAcl(aclParams, err => {
-                        assert(err);
-                        assert.strictEqual(err.code, 'MethodNotAllowed');
-                        assert.strictEqual(err.statusCode, 405);
-                        done();
-                    });
-                });
-            });
+function _testBehaviorVersioningEnabledOrSuspended(utils, versionIds) {
+    const s3 = utils.s3;
 
-            it('should return 405 MethodNotAllowed putting acl with ' +
-            'version id if version specified is a delete marker', done => {
-                const aclParams = {
-                    Bucket: bucket,
-                    Key: key,
-                    ACL: 'public-read-write',
-                };
-                s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
-                    assert.strictEqual(err, null,
-                        `Unexpected err deleting object: ${err}`);
-                    assert.strictEqual(data.DeleteMarker, 'true');
-                    assert(data.VersionId);
-                    aclParams.VersionId = data.VersionId;
-                    _putObjectAcl(aclParams, err => {
-                        assert(err);
-                        assert.strictEqual(err.code, 'MethodNotAllowed');
-                        assert.strictEqual(err.statusCode, 405);
-                        done();
-                    });
-                });
+    it('should return 405 MethodNotAllowed putting acl without ' +
+    'version id if latest version is a delete marker', done => {
+        const aclParams = {
+            Bucket: bucket,
+            Key: key,
+            ACL: 'public-read-write',
+        };
+        s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
+            assert.strictEqual(err, null,
+                `Unexpected err deleting object: ${err}`);
+            assert.strictEqual(data.DeleteMarker, 'true');
+            assert(data.VersionId);
+            utils.putObjectAcl(aclParams, err => {
+                assert(err);
+                assert.strictEqual(err.code, 'MethodNotAllowed');
+                assert.strictEqual(err.statusCode, 405);
+                done();
             });
+        });
+    });
 
-            it('should return 404 NoSuchKey getting acl without ' +
-            'version id if latest version is a delete marker', done => {
-                const aclParams = {
-                    Bucket: bucket,
-                    Key: key,
-                };
-                s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
-                    assert.strictEqual(err, null,
-                        `Unexpected err deleting object: ${err}`);
-                    assert.strictEqual(data.DeleteMarker, 'true');
-                    assert(data.VersionId);
-                    _getObjectAcl(aclParams, err => {
-                        assert(err);
-                        assert.strictEqual(err.code, 'NoSuchKey');
-                        assert.strictEqual(err.statusCode, 404);
-                        done();
-                    });
-                });
+    it('should return 405 MethodNotAllowed putting acl with ' +
+    'version id if version specified is a delete marker', done => {
+        const aclParams = {
+            Bucket: bucket,
+            Key: key,
+            ACL: 'public-read-write',
+        };
+        s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
+            assert.strictEqual(err, null,
+                `Unexpected err deleting object: ${err}`);
+            assert.strictEqual(data.DeleteMarker, 'true');
+            assert(data.VersionId);
+            aclParams.VersionId = data.VersionId;
+            utils.putObjectAcl(aclParams, err => {
+                assert(err);
+                assert.strictEqual(err.code, 'MethodNotAllowed');
+                assert.strictEqual(err.statusCode, 405);
+                done();
             });
+        });
+    });
 
-            it('should return 405 MethodNotAllowed getting acl with ' +
-            'version id if version specified is a delete marker', done => {
-                const latestVersion = versionIds[versionIds.length - 1];
-                const aclParams = {
-                    Bucket: bucket,
-                    Key: key,
-                    VersionId: latestVersion,
-                };
-                s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
-                    assert.strictEqual(err, null,
-                        `Unexpected err deleting object: ${err}`);
-                    assert.strictEqual(data.DeleteMarker, 'true');
-                    assert(data.VersionId);
-                    aclParams.VersionId = data.VersionId;
-                    _getObjectAcl(aclParams, err => {
-                        assert(err);
-                        assert.strictEqual(err.code, 'MethodNotAllowed');
-                        assert.strictEqual(err.statusCode, 405);
-                        done();
-                    });
-                });
+    it('should return 404 NoSuchKey getting acl without ' +
+    'version id if latest version is a delete marker', done => {
+        const aclParams = {
+            Bucket: bucket,
+            Key: key,
+        };
+        s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
+            assert.strictEqual(err, null,
+                `Unexpected err deleting object: ${err}`);
+            assert.strictEqual(data.DeleteMarker, 'true');
+            assert(data.VersionId);
+            utils.getObjectAcl(aclParams, err => {
+                assert(err);
+                assert.strictEqual(err.code, 'NoSuchKey');
+                assert.strictEqual(err.statusCode, 404);
+                done();
             });
+        });
+    });
 
-            it('non-version specific put and get ACL should target latest ' +
-            'version AND return version ID in response headers', done => {
-                const latestVersion = versionIds[versionIds.length - 1];
-                const expectedRes = { versionId: latestVersion };
-                _putAndGetAcl('public-read', undefined, expectedRes, done);
+    it('should return 405 MethodNotAllowed getting acl with ' +
+    'version id if version specified is a delete marker', done => {
+        const latestVersion = versionIds[versionIds.length - 1];
+        const aclParams = {
+            Bucket: bucket,
+            Key: key,
+            VersionId: latestVersion,
+        };
+        s3.deleteObject({ Bucket: bucket, Key: key }, (err, data) => {
+            assert.strictEqual(err, null,
+                `Unexpected err deleting object: ${err}`);
+            assert.strictEqual(data.DeleteMarker, 'true');
+            assert(data.VersionId);
+            aclParams.VersionId = data.VersionId;
+            utils.getObjectAcl(aclParams, err => {
+                assert(err);
+                assert.strictEqual(err.code, 'MethodNotAllowed');
+                assert.strictEqual(err.statusCode, 405);
+                done();
             });
+        });
+    });
 
-            it('version specific put and get ACL should return version ID ' +
-            'in response headers', done => {
-                const firstVersion = versionIds[0];
-                const expectedRes = { versionId: firstVersion };
-                _putAndGetAcl('public-read', firstVersion, expectedRes, done);
-            });
+    it('non-version specific put and get ACL should target latest ' +
+    'version AND return version ID in response headers', done => {
+        const latestVersion = versionIds[versionIds.length - 1];
+        const expectedRes = { versionId: latestVersion };
+        utils.putAndGetAcl('public-read', undefined, expectedRes, done);
+    });
 
-            it('version specific put and get ACL (version id = "null") ' +
-            'should return version ID ("null") in response headers', done => {
-                const expectedRes = { versionId: 'null' };
-                _putAndGetAcl('public-read', 'null', expectedRes, done);
-            });
-        }
+    it('version specific put and get ACL should return version ID ' +
+    'in response headers', done => {
+        const firstVersion = versionIds[0];
+        const expectedRes = { versionId: firstVersion };
+        utils.putAndGetAcl('public-read', firstVersion, expectedRes, done);
+    });
+
+    it('version specific put and get ACL (version id = "null") ' +
+    'should return version ID ("null") in response headers', done => {
+        const expectedRes = { versionId: 'null' };
+        utils.putAndGetAcl('public-read', 'null', expectedRes, done);
+    });
+}
+
+describe('versioned put and get object acl ::', () => {
+    withV4(sigCfg => {
+        const bucketUtil = new BucketUtility('default', sigCfg);
+        const s3 = bucketUtil.s3;
+        const utils = new _Utils(s3);
 
         beforeEach(done => {
             bucket = `versioning-bucket-acl-${Date.now()}`;
@@ -228,25 +236,25 @@ describe('versioned put and get object acl ::', () => {
             it('should not return version id for non-version specific ' +
             'put and get ACL', done => {
                 const expectedRes = { versionId: undefined };
-                _putAndGetAcl('public-read', undefined, expectedRes, done);
+                utils.putAndGetAcl('public-read', undefined, expectedRes, done);
             });
 
             it('should not return version id for version specific ' +
             'put and get ACL (version id = "null")', done => {
                 const expectedRes = { versionId: undefined };
-                _putAndGetAcl('public-read', 'null', expectedRes, done);
+                utils.putAndGetAcl('public-read', 'null', expectedRes, done);
             });
 
             it('should return NoSuchVersion if attempting to put or get acl ' +
             'for non-existing version', done => {
                 const error = { code: 'NoSuchVersion', statusCode: 404 };
-                _putAndGetAcl('private', nonExistingId, { error }, done);
+                utils.putAndGetAcl('private', nonExistingId, { error }, done);
             });
 
             it('should return InvalidArgument if attempting to put/get acl ' +
             'for invalid hex string', done => {
                 const error = { code: 'InvalidArgument', statusCode: 400 };
-                _putAndGetAcl('private', invalidId, { error }, done);
+                utils.putAndGetAcl('private', invalidId, { error }, done);
             });
         });
 
@@ -275,7 +283,8 @@ describe('versioned put and get object acl ::', () => {
                 it('non-version specific put and get ACL should now ' +
                 'return version ID ("null") in response headers', done => {
                     const expectedRes = { versionId: 'null' };
-                    _putAndGetAcl('public-read', undefined, expectedRes, done);
+                    utils.putAndGetAcl('public-read', undefined, expectedRes,
+                    done);
                 });
             });
 
@@ -284,13 +293,13 @@ describe('versioned put and get object acl ::', () => {
                     const params = { Bucket: bucket, Key: key };
                     async.timesSeries(counter, (i, next) =>
                         s3.putObject(params, (err, data) => {
-                            _assertNoError(err, `putting version #${i}`);
+                            _Utils.assertNoError(err, `putting version #${i}`);
                             versionIds.push(data.VersionId);
                             next(err);
                         }), done);
                 });
 
-                _testBehaviorVersioningEnabledOrSuspended(versionIds);
+                _testBehaviorVersioningEnabledOrSuspended(utils, versionIds);
             });
         });
 
@@ -318,7 +327,7 @@ describe('versioned put and get object acl ::', () => {
             'version-enabled bucket where no version id is specified',
             done => {
                 const params = { Bucket: bucket, Key: key, ACL: 'public-read' };
-                _putObjectAcl(params, () => s3.listObjectVersions({ Bucket:
+                utils.putObjectAcl(params, () => s3.listObjectVersions({ Bucket:
                   bucket }, (err, data) => {
                     assert.ifError(err, `listObjects err ${err}`);
                     checkOneVersion(data, versionId);
@@ -352,7 +361,8 @@ describe('versioned put and get object acl ::', () => {
                 it('non-version specific put and get ACL should still ' +
                 'return version ID ("null") in response headers', done => {
                     const expectedRes = { versionId: 'null' };
-                    _putAndGetAcl('public-read', undefined, expectedRes, done);
+                    utils.putAndGetAcl('public-read', undefined, expectedRes,
+                    done);
                 });
             });
 
@@ -366,7 +376,8 @@ describe('versioned put and get object acl ::', () => {
                         }, err => callback(err)),
                         callback => async.timesSeries(counter, (i, next) =>
                             s3.putObject(params, (err, data) => {
-                                _assertNoError(err, `putting version #${i}`);
+                                _Utils.assertNoError(err,
+                                    `putting version #${i}`);
                                 versionIds.push(data.VersionId);
                                 next(err);
                             }), err => callback(err)),
@@ -377,7 +388,7 @@ describe('versioned put and get object acl ::', () => {
                     ], done);
                 });
 
-                _testBehaviorVersioningEnabledOrSuspended(versionIds);
+                _testBehaviorVersioningEnabledOrSuspended(utils, versionIds);
             });
         });
     });

--- a/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectDeleteTagging.js
@@ -85,14 +85,9 @@ describe('Delete object tagging with versioning', () => {
                     Bucket: bucketName,
                     Key: objectName,
                 }, err => next(err, versionId)),
-                (versionId, next) => s3.listObjectVersions({
-                    Bucket: bucketName,
-                }, (err, data) => next(err, data, versionId)),
-            ], (err, data, versionId) => {
-                assert.ifError(err, `Found unexpected err ${err}`);
-                checkOneVersion(data, versionId);
-                done();
-            });
+                (versionId, next) =>
+                    checkOneVersion(s3, bucketName, versionId, next),
+            ], done);
         });
 
         it('should be able to delete tag set with a version of id "null"',

--- a/tests/functional/aws-node-sdk/test/versioning/objectPutTagging.js
+++ b/tests/functional/aws-node-sdk/test/versioning/objectPutTagging.js
@@ -24,6 +24,7 @@ describe('Put object tagging with versioning', () => {
     withV4(sigCfg => {
         const bucketUtil = new BucketUtility('default', sigCfg);
         const s3 = bucketUtil.s3;
+
         beforeEach(done => s3.createBucket({ Bucket: bucketName }, done));
         afterEach(done => {
             removeAllVersions({ Bucket: bucketName }, err => {
@@ -75,14 +76,9 @@ describe('Put object tagging with versioning', () => {
                             Value: 'value1',
                         }] },
                 }, err => next(err, versionId)),
-                (versionId, next) => s3.listObjectVersions({
-                    Bucket: bucketName,
-                }, (err, data) => next(err, data, versionId)),
-            ], (err, data, versionId) => {
-                assert.ifError(err, `Found unexpected err ${err}`);
-                checkOneVersion(data, versionId);
-                done();
-            });
+                (versionId, next) =>
+                    checkOneVersion(s3, bucketName, versionId, next),
+            ], done);
         });
 
         it('should be able to put tag with a version of id "null"', done => {


### PR DESCRIPTION
We identified a bug where we overwrite just the master null version when we have the same null version stored in master and a separate version, resulting in two null versions with different versionIds.

That situation may arise when putting object tags or acls on an existing master null version (using metadata PUT option `versionId=<version id of master version>` will both overwrite the master version + create new version with that versionId), for example, and then putting a new null version.

The solution settled upon is to do a separate clean-up delete call to delete the existing null version(s) before putting a new null version.

As @jonathan-gramain noted in a previous versioning PR, the versioningPreprocessing function was getting a bit long and nested and due for a refactor. Review by commits is advised.

~~Tests are still WIP, they were initially written to debug.~~ Tests are updated