### PR TITLE
DOCKER: add env var for multiple data backends

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -16,6 +16,15 @@ environment variables on the docker run command line.
 
 ### Environment Variables
 
+#### S3DATA=multiple
+
+This runs Scality S3 server with multiple data backends.
+[More info](https://github.com/scality/S3#run-it-with-multiple-data-backends)
+
+```shell
+docker run -d --name s3server -p 8000:8000 -e S3DATA=multiple scality/s3server
+```
+
 #### HOST_NAME
 
 This variable specifies a host name.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,4 +43,8 @@ if [[ "$SSL" ]]; then
     fi
 fi
 
+if [[ "$S3DATA" == "multiple" ]]; then
+    export S3DATA="$S3DATA"
+fi
+
 exec "$@"


### PR DESCRIPTION
Docker environment variable to run Scality S3 server with multiple data backends.