### PR TITLE
FIX: Only stream from one data location at a time.

### DIFF
--- a/lib/routes/routesUtils.js
+++ b/lib/routes/routesUtils.js
@@ -1,6 +1,5 @@
-import { readySetStream } from 'ready-set-stream';
-
 import data from '../data/wrapper';
+import retrieveData from '../utilities/retrieveData';
 
 /**
  * setCommonResponseHeaders - Set HTTP response headers
@@ -359,7 +358,7 @@ const routesUtils = {
                 httpCode: response.statusCode,
             });
         });
-        return readySetStream(parsedLocations, data.get, response, log);
+        return retrieveData(parsedLocations, data.get, response, log);
     },
 };
 

--- a/lib/utilities/retrieveData.js
+++ b/lib/utilities/retrieveData.js
@@ -1,0 +1,31 @@
+export default function retrieveData(locations, dataRetrievalFn,
+    response, logger, errorHandlerFn) {
+    if (locations.length === 0) {
+        return response.end();
+    }
+    if (errorHandlerFn === undefined) {
+        // eslint-disable-next-line
+        errorHandlerFn = () => { response.connection.destroy(); };
+    }
+    const current = locations.shift();
+    return dataRetrievalFn(current, logger,
+        (err, readable) => {
+            if (err) {
+                logger.error('failed to get object', {
+                    error: err,
+                    method: 'retrieveData',
+                });
+                return errorHandlerFn(err);
+            }
+            readable.on('error', err => {
+                logger.error('error piping data from source');
+                errorHandlerFn(err);
+            });
+            readable.on('end', () => {
+                process.nextTick(retrieveData,
+                locations, dataRetrievalFn, response, logger);
+            });
+            readable.pipe(response, { end: false });
+            return undefined;
+        });
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "level-sublevel": "^6.5.4",
     "multilevel": "^7.3.0",
     "node-uuid": "^1.4.3",
-    "ready-set-stream": "1.0.7",
     "sproxydclient": "scality/sproxydclient#rel/6.3",
     "utapi": "scality/utapi#rel/6.3",
     "utf8": "~2.1.1",


### PR DESCRIPTION
S3C-429
Prevent memory problems by no longer double buffering.

(cherry picked from commit 1ae15540d5e29bebce7244252599eea44288826f
with modifications to resolve conflicts)
