### PR TITLE
FT: Create replication rule ID if not provided

### DIFF
--- a/lib/api/apiUtils/bucket/models/ReplicationConfiguration.js
+++ b/lib/api/apiUtils/bucket/models/ReplicationConfiguration.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const UUID = require('node-uuid');
 
 const { errors } = require('arsenal');
 
@@ -101,13 +102,13 @@ class ReplicationConfiguration {
             prefix: rule.Prefix[0],
             enabled: rule.Status[0] === 'Enabled',
         };
+        // ID is an optional property, but create one if not provided or is ''.
+        // We generate a 48-character alphanumeric, unique ID for the rule.
+        obj.id = rule.ID && rule.ID[0] !== '' ? rule.ID[0] :
+            Buffer.from(UUID.v4()).toString('base64');
         // StorageClass is an optional property.
         if (rule.Destination[0].StorageClass) {
             obj.storageClass = rule.Destination[0].StorageClass[0];
-        }
-        // ID is an optional property.
-        if (rule.ID) {
-            obj.id = rule.ID[0];
         }
         return obj;
     }


### PR DESCRIPTION
The ID property of a rule in the replication configuration is optional. However if a rule ID is omitted, we should generate a unique ID to store with the bucket replication metadata. That ID is then associated with the rule and should be accessible with the bucketGetReplication API.