### PR TITLE
ft: limit user metadata to 2 KB

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -68,6 +68,11 @@ const constants = {
     maximumAllowedPartSize: process.env.MPU_TESTING === 'yes' ? 104857600 :
         5368709120,
 
+    // AWS states max size for user-defined metadata (x-amz-meta- headers) is
+    // 2 KB: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+    // In testing, AWS seems to allow up to 88 more bytes, so we do the same.
+    maximumMetaHeadersSize: 2136,
+
     // hex digest of sha256 hash of empty string:
     emptyStringHash: crypto.createHash('sha256')
         .update('', 'binary').digest('hex'),

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -66,6 +66,13 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
 
     const metaHeaders = isDeleteMarker ? [] :
         utils.getMetaHeaders(request.headers);
+    if (metaHeaders instanceof Error) {
+        log.debug('user metadata validation failed', {
+            error: metaHeaders,
+            method: 'createAndStoreObject',
+        });
+        return process.nextTick(() => callback(metaHeaders));
+    }
     log.trace('meta headers', { metaHeaders, method: 'objectPut' });
     const objectKeyContext = {
         bucketName,

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -75,6 +75,13 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
         return callback(err);
     }
     const metaHeaders = utils.getMetaHeaders(request.headers);
+    if (metaHeaders instanceof Error) {
+        log.debug('user metadata validation failed', {
+            error: metaHeaders,
+            method: 'createAndStoreObject',
+        });
+        return process.nextTick(() => callback(metaHeaders));
+    }
     // Generate uniqueID without dashes so that routing not messed up
     const uploadId = UUID.v4().replace(/-/g, '');
     // TODO: Add this as a utility function for all object put requests

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -73,6 +73,13 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
     const userMetadata = whichMetadata === 'COPY' ?
         utils.getMetaHeaders(sourceObjMD) :
         utils.getMetaHeaders(headers);
+    if (userMetadata instanceof Error) {
+        log.debug('user metadata validation failed', {
+            error: userMetadata,
+            method: 'objectCopy',
+        });
+        return { error: userMetadata };
+    }
 
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will

--- a/lib/services.js
+++ b/lib/services.js
@@ -159,7 +159,7 @@ const services = {
             md.setTags(validationTagRes);
         }
 
-        // Store user provided metadata.  TODO: limit size.
+        // Store user provided metadata.
         // For multipart upload this also serves to transfer
         // over metadata originally sent with the initiation
         // of the multipart upload (for instance, ACL's).

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const url = require('url');
 const crypto = require('crypto');
-const { ipCheck } = require('arsenal');
+const { ipCheck, errors } = require('arsenal');
 
 const { config } = require('./Config');
 const constants = require('../constants');
@@ -206,15 +206,23 @@ utils.validateWebsiteHeader = function validateWebsiteHeader(header) {
 /**
  * Pull user provided meta headers from request headers
  * @param {object} headers - headers attached to the http request (lowercased)
- * @return {object} all user meta headers
+ * @return {(object|Error)} all user meta headers or MetadataTooLarge
  */
 utils.getMetaHeaders = function getMetaHeaders(headers) {
     const metaHeaders = Object.create(null);
-    Object.keys(headers).filter(h => (h.startsWith('x-amz-meta-') ||
-    h.startsWith('x-amz-website'))).forEach(k => {
+    let totalLength = 0;
+    const metaHeaderKeys = Object.keys(headers).filter(h =>
+        h.startsWith('x-amz-meta-'));
+    const validHeaders = metaHeaderKeys.every(k => {
+        totalLength += k.length;
+        totalLength += headers[k].length;
         metaHeaders[k] = headers[k];
+        return (totalLength <= constants.maximumMetaHeadersSize);
     });
-    return metaHeaders;
+    if (validHeaders) {
+        return metaHeaders;
+    }
+    return errors.MetadataTooLarge;
 };
 
 /**

--- a/tests/functional/aws-node-sdk/lib/utility/genMaxSizeMetaHeaders.js
+++ b/tests/functional/aws-node-sdk/lib/utility/genMaxSizeMetaHeaders.js
@@ -1,0 +1,17 @@
+const constants = require('../../../../../constants');
+
+function genMaxSizeMetaHeaders() {
+    const metaHeaders = {};
+    const counter = 8;
+    const bytesPerHeader =
+        (constants.maximumMetaHeadersSize / counter);
+    for (let i = 0; i < counter; i++) {
+        const key = `header${i}`;
+        const valueLength = bytesPerHeader -
+            ('x-amz-meta-'.length + key.length);
+        metaHeaders[key] = '0'.repeat(valueLength);
+    }
+    return metaHeaders;
+}
+
+module.exports = genMaxSizeMetaHeaders;

--- a/tests/functional/aws-node-sdk/test/object/initiateMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/initiateMPU.js
@@ -1,9 +1,13 @@
 const assert = require('assert');
+const async = require('async');
 
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
+const genMaxSizeMetaHeaders
+    = require('../../lib/utility/genMaxSizeMetaHeaders');
 
 const bucket = `initiatempubucket${Date.now()}`;
+const key = 'key';
 
 describe('Initiate MPU', () => {
     withV4(sigCfg => {
@@ -25,10 +29,38 @@ describe('Initiate MPU', () => {
         it('should return InvalidRedirectLocation if initiate MPU ' +
         'with x-amz-website-redirect-location header that does not start ' +
         'with \'http://\', \'https://\' or \'/\'', done => {
-            const params = { Bucket: bucket, Key: 'key',
+            const params = { Bucket: bucket, Key: key,
                 WebsiteRedirectLocation: 'google.com' };
             s3.createMultipartUpload(params, err => {
                 assert.strictEqual(err.code, 'InvalidRedirectLocation');
+                assert.strictEqual(err.statusCode, 400);
+                done();
+            });
+        });
+
+        it('should return error if initiating MPU w/ > 2KB user-defined md',
+        done => {
+            const metadata = genMaxSizeMetaHeaders();
+            const params = { Bucket: bucket, Key: key, Metadata: metadata };
+            async.waterfall([
+                next => s3.createMultipartUpload(params, (err, data) => {
+                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                    next(null, data.UploadId);
+                }),
+                (uploadId, next) => s3.abortMultipartUpload({
+                    Bucket: bucket,
+                    Key: key,
+                    UploadId: uploadId,
+                }, err => {
+                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                    // add one more byte to push over limit for next call
+                    metadata.header0 = `${metadata.header0}${'0'}`;
+                    next();
+                }),
+                next => s3.createMultipartUpload(params, next),
+            ], err => {
+                assert(err, 'Expected err but did not find one');
+                assert.strictEqual(err.code, 'MetadataTooLarge');
                 assert.strictEqual(err.statusCode, 400);
                 done();
             });

--- a/tests/functional/aws-node-sdk/test/object/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/object/objectCopy.js
@@ -4,6 +4,8 @@ const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 
 const { taggingTests } = require('../../lib/utility/tagging');
+const genMaxSizeMetaHeaders
+    = require('../../lib/utility/genMaxSizeMetaHeaders');
 
 const sourceBucketName = 'supersourcebucket8102016';
 const sourceObjName = 'supersourceobject';
@@ -344,6 +346,52 @@ describe('Object Copy', () => {
                         successCopyCheck(err, res, originalMetadata,
                             sourceBucketName, destObjName, done)
                     );
+            });
+
+        it('should not return error if copying object w/ > ' +
+        '2KB user-defined md and COPY directive',
+            done => {
+                const metadata = genMaxSizeMetaHeaders();
+                const params = {
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    MetadataDirective: 'COPY',
+                    Metadata: metadata,
+                };
+                s3.copyObject(params, err => {
+                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                    // add one more byte to be over the limit
+                    metadata.header0 = `${metadata.header0}${'0'}`;
+                    s3.copyObject(params, err => {
+                        assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                        done();
+                    });
+                });
+            });
+
+        it('should return error if copying object w/ > 2KB ' +
+        'user-defined md and REPLACE directive',
+            done => {
+                const metadata = genMaxSizeMetaHeaders();
+                const params = {
+                    Bucket: destBucketName,
+                    Key: destObjName,
+                    CopySource: `${sourceBucketName}/${sourceObjName}`,
+                    MetadataDirective: 'REPLACE',
+                    Metadata: metadata,
+                };
+                s3.copyObject(params, err => {
+                    assert.strictEqual(err, null, `Unexpected err: ${err}`);
+                    // add one more byte to be over the limit
+                    metadata.header0 = `${metadata.header0}${'0'}`;
+                    s3.copyObject(params, err => {
+                        assert(err, 'Expected err but did not find one');
+                        assert.strictEqual(err.code, 'MetadataTooLarge');
+                        assert.strictEqual(err.statusCode, 400);
+                        done();
+                    });
+                });
             });
 
         it('should copy an object from a source to the same destination ' +


### PR DESCRIPTION
http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html

AWS limits user-provided metadata to 2 KB. Now that we are implementing AWS and other backends, we should be consistent in the amount of user metadata we allow during puts.