### PR TITLE
FT: Add replication information to object MD

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -10,6 +10,7 @@ const { dataStore } = require('./storeObject');
 const locationConstraintCheck = require('./locationConstraintCheck');
 const { versioningPreprocessing } = require('./versioning');
 const removeAWSChunked = require('./removeAWSChunked');
+const { buildReplicationInfoForObject } = require('./replication');
 const { config } = require('../../../Config');
 const validateWebsiteHeader = require('./websiteServing')
     .validateWebsiteHeader;
@@ -109,6 +110,9 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         metadataStoreParams.expires = request.headers.expires;
         metadataStoreParams.tagging = request.headers['x-amz-tagging'];
     }
+
+    buildReplicationInfoForObject(metadataStoreParams, objectKey, bucketMD,
+        isDeleteMarker);
 
     const backendInfoObj =
         locationConstraintCheck(request, null, bucketMD, log);

--- a/lib/api/apiUtils/object/replication.js
+++ b/lib/api/apiUtils/object/replication.js
@@ -1,0 +1,57 @@
+/**
+ * Check that a bucket replication rule applies for the given object key. If it
+ * does, assign replication information to the given object.
+ * @param {object} obj - The object to set replicationInfo for
+ * @param {string} objKey - The key of the object
+ * @param {object} bucketMD - The bucket metadata
+ * @param {array} content - The content type that should be replicated
+ * @return {undefined}
+ */
+function buildReplicationInfo(obj, objKey, bucketMD, content) {
+    const config = bucketMD.getReplicationConfiguration();
+    // If bucket does not have a replication configuration, do not replicate.
+    if (config) {
+        const rule = config.rules.find(rule => objKey.startsWith(rule.prefix));
+        if (rule) {
+            // eslint-disable-next-line no-param-reassign
+            obj.replicationInfo = {
+                status: 'PENDING',
+                content,
+                destination: config.destination,
+                storageClass: rule.storageClass || '',
+            };
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Set the object replicationInfo to replicate data and metadata, or only
+ * metadata if the object is a delete marker
+ * @param {object} obj - The object to set replicationInfo for
+ * @param {string} objKey - The key of the object
+ * @param {object} bucketMD - The bucket metadata
+ * @param {boolean} isDeleteMarker - Whether the object is a deleteMarker
+ * @return {undefined}
+ */
+function buildReplicationInfoForObject(obj, objKey, bucketMD, isDeleteMarker) {
+    // Delete markers have no data, so we only replicate metadata.
+    const content = isDeleteMarker ? ['METADATA'] : ['DATA', 'METADATA'];
+    return buildReplicationInfo(obj, objKey, bucketMD, content);
+}
+
+/**
+ * Set the object replicationInfo to replicate only metadata
+ * @param {object} obj - The object to set replicationInfo for
+ * @param {string} objKey - The key of the object
+ * @param {object} bucketMD - The bucket metadata
+ * @return {undefined}
+ */
+function buildReplicationInfoForObjectMD(obj, objKey, bucketMD) {
+    return buildReplicationInfo(obj, objKey, bucketMD, ['METADATA']);
+}
+
+module.exports = {
+    buildReplicationInfoForObject,
+    buildReplicationInfoForObjectMD,
+};

--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -8,6 +8,8 @@ const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
+const { buildReplicationInfoForObjectMD } =
+    require('./apiUtils/object/replication');
 
 /**
  * Object Delete Tagging - Delete tag set from an object
@@ -68,6 +70,7 @@ function objectDeleteTagging(authInfo, request, log, callback) {
             objectMD.tags = {};
             const params = objectMD.versionId ? { versionId:
               objectMD.versionId } : {};
+            buildReplicationInfoForObjectMD(objectMD, objectKey, bucket);
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
             log, err =>
                 next(err, bucket, objectMD));

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -6,6 +6,8 @@ const { decodeVersionId, getVersionIdResHeader } =
 
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const { buildReplicationInfoForObjectMD } =
+    require('./apiUtils/object/replication');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { parseTagXml } = require('./apiUtils/object/tagging');
@@ -74,6 +76,7 @@ function objectPutTagging(authInfo, request, log, callback) {
             objectMD.tags = tags;
             const params = objectMD.versionId ? { versionId:
               objectMD.versionId } : {};
+            buildReplicationInfoForObjectMD(objectMD, objectKey, bucket);
             metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params,
             log, err =>
                 next(err, bucket, objectMD));

--- a/lib/metadata/acl.js
+++ b/lib/metadata/acl.js
@@ -1,5 +1,7 @@
 const { errors } = require('arsenal');
 
+const { buildReplicationInfoForObjectMD } =
+    require('../api/apiUtils/object/replication');
 const aclUtils = require('../utilities/aclUtils');
 const constants = require('../../constants');
 const metadata = require('../metadata/wrapper');
@@ -16,6 +18,7 @@ const acl = {
         log.trace('updating object acl in metadata');
         // eslint-disable-next-line no-param-reassign
         objectMD.acl = addACLParams;
+        buildReplicationInfoForObjectMD(objectMD, objectKey, bucket);
         metadata.putObjectMD(bucket.getName(), objectKey, objectMD, params, log,
             cb);
     },

--- a/lib/metadata/models/object/ObjectMD.js
+++ b/lib/metadata/models/object/ObjectMD.js
@@ -53,6 +53,12 @@ module.exports = class ObjectMD {
             'isDeleteMarker': '',
             'versionId': undefined, // If no versionId, it should be undefined
             'tags': {},
+            'replicationInfo': {
+                status: '',
+                content: [],
+                destination: '',
+                storageClass: '',
+            },
         };
     }
 
@@ -568,6 +574,32 @@ module.exports = class ObjectMD {
      */
     getTags() {
         return this._data.tags;
+    }
+
+    /**
+     * Set replication information
+     *
+     * @param {object} replicationInfo - replication information object
+     * @return {ObjectMD} itself
+     */
+    setReplicationInfo(replicationInfo) {
+        const { status, content, destination, storageClass } = replicationInfo;
+        this._data.replicationInfo = {
+            status,
+            content,
+            destination,
+            storageClass: storageClass || '',
+        };
+        return this;
+    }
+
+    /**
+     * Get replication information
+     *
+     * @return {object} replication object
+     */
+    getReplicationInfo() {
+        return this._data.replicationInfo;
     }
 
     /**

--- a/lib/services.js
+++ b/lib/services.js
@@ -92,8 +92,8 @@ const services = {
         const { objectKey, authInfo, size, contentMD5, metaHeaders,
             contentType, cacheControl, contentDisposition, contentEncoding,
             expires, multipart, headers, overrideMetadata, log,
-            lastModifiedDate, versioning, versionId, tagging, taggingCopy }
-            = params;
+            lastModifiedDate, versioning, versionId, tagging, taggingCopy,
+            replicationInfo } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -124,6 +124,9 @@ const services = {
         }
         if (headers && headers['x-amz-website-redirect-location']) {
             md.setRedirectLocation(headers['x-amz-website-redirect-location']);
+        }
+        if (replicationInfo) {
+            md.setReplicationInfo(replicationInfo);
         }
         // options to send to metadata to create or overwrite versions
         // when putting the object MD

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -1,0 +1,276 @@
+const assert = require('assert');
+const async = require('async');
+
+const BucketInfo = require('../../../lib/metadata/BucketInfo');
+
+const { cleanup, DummyRequestLogger, makeAuthInfo, TaggingConfigTester } =
+    require('../helpers');
+const { metadata } = require('../../../lib/metadata/in_memory/metadata');
+const DummyRequest = require('../DummyRequest');
+const objectDelete = require('../../../lib/api/objectDelete');
+const objectPut = require('../../../lib/api/objectPut');
+const objectPutACL = require('../../../lib/api/objectPutACL');
+const objectPutTagging = require('../../../lib/api/objectPutTagging');
+const objectDeleteTagging = require('../../../lib/api/objectDeleteTagging');
+
+const log = new DummyRequestLogger();
+const canonicalID = 'accessKey1';
+const authInfo = makeAuthInfo(canonicalID);
+const ownerID = authInfo.getCanonicalID();
+const namespace = 'default';
+const bucketName = 'source-bucket';
+const bucketARN = `arn:aws:s3:::${bucketName}`;
+const storageClassType = 'STANDARD';
+const keyA = 'key-A';
+const keyB = 'key-B';
+
+const deleteReq = new DummyRequest({
+    bucketName,
+    namespace,
+    objectKey: keyA,
+    headers: {},
+    url: `/${bucketName}/${keyA}`,
+});
+
+const objectACLReq = {
+    bucketName,
+    namespace,
+    objectKey: keyA,
+    headers: {
+        'x-amz-grant-read': `id=${ownerID}`,
+        'x-amz-grant-read-acp': `id=${ownerID}`,
+    },
+    url: `/${bucketName}/${keyA}?acl`,
+    query: { acl: '' },
+};
+
+// Get an object request with the given key.
+function getObjectPutReq(key) {
+    return new DummyRequest({
+        bucketName,
+        namespace,
+        objectKey: key,
+        headers: {},
+        url: `/${bucketName}/${key}`,
+    }, Buffer.from('body content', 'utf8'));
+}
+
+const taggingPutReq = new TaggingConfigTester()
+    .createObjectTaggingRequest('PUT', bucketName, keyA);
+const taggingDeleteReq = new TaggingConfigTester()
+    .createObjectTaggingRequest('DELETE', bucketName, keyA);
+
+const emptyReplicationMD = {
+    status: '',
+    content: [],
+    destination: '',
+    storageClass: '',
+};
+
+// Check that the object key has the expected replication information.
+function checkObjectReplicationInfo(key, expected) {
+    const objectMD = metadata.keyMaps.get(bucketName).get(key);
+    assert.deepStrictEqual(objectMD.replicationInfo, expected);
+}
+
+// Put the object key and check the replication information.
+function putObjectAndCheckMD(key, expected, cb) {
+    return objectPut(authInfo, getObjectPutReq(key), undefined, log, err => {
+        if (err) {
+            return cb(err);
+        }
+        checkObjectReplicationInfo(key, expected);
+        return cb();
+    });
+}
+
+// Create the bucket in metadata.
+function createBucket() {
+    metadata
+        .buckets.set(bucketName, new BucketInfo(bucketName, ownerID, '', ''));
+    metadata.keyMaps.set(bucketName, new Map);
+}
+
+// Create the bucket in metadata with versioning and a replication config.
+function createBucketWithReplication(hasStorageClass) {
+    createBucket();
+    const config = {
+        role: 'arn:partition:service::account-id:resourcetype/resource',
+        destination: 'arn:aws:s3:::source-bucket',
+        rules: [{
+            prefix: keyA,
+            enabled: true,
+            id: 'test-id',
+        }],
+    };
+    if (hasStorageClass) {
+        config.rules[0].storageClass = storageClassType;
+    }
+    Object.assign(metadata.buckets.get(bucketName), {
+        _versioningConfiguration: { status: 'Enabled' },
+        _replicationConfiguration: config,
+    });
+}
+
+describe('Replication object MD without bucket replication config', () => {
+    beforeEach(() => {
+        cleanup();
+        createBucket();
+    });
+
+    afterEach(() => cleanup());
+
+    it('should not update object metadata', done =>
+        putObjectAndCheckMD(keyA, emptyReplicationMD, done));
+
+    it('should not update object metadata if putting object ACL', done =>
+        async.series([
+            next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+            next => objectPutACL(authInfo, objectACLReq, log, next),
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            checkObjectReplicationInfo(keyA, emptyReplicationMD);
+            return done();
+        }));
+
+    describe('Object tagging', () => {
+        beforeEach(done => async.series([
+            next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+            next => objectPutTagging(authInfo, taggingPutReq, log, next),
+        ], err => done(err)));
+
+        it('should not update object metadata if putting tag', done => {
+            checkObjectReplicationInfo(keyA, emptyReplicationMD);
+            return done();
+        });
+
+        it('should not update object metadata if deleting tag', done =>
+            async.series([
+                // Put a new version to update replication MD content array.
+                next => putObjectAndCheckMD(keyA, emptyReplicationMD, next),
+                next => objectDeleteTagging(authInfo, taggingDeleteReq, log,
+                    next),
+            ], err => {
+                if (err) {
+                    return done(err);
+                }
+                checkObjectReplicationInfo(keyA, emptyReplicationMD);
+                return done();
+            }));
+    });
+});
+
+[true, false].forEach(hasStorageClass => {
+    describe('Replication object MD with bucket replication config ' +
+    `${hasStorageClass ? 'with' : 'without'} storage class`, () => {
+        const replicationMD = {
+            status: 'PENDING',
+            content: ['DATA', 'METADATA'],
+            destination: bucketARN,
+            storageClass: '',
+        };
+        const newReplicationMD = hasStorageClass ? Object.assign(replicationMD,
+            { storageClass: storageClassType }) : replicationMD;
+        const replicateMetadataOnly = Object.assign({}, newReplicationMD,
+            { content: ['METADATA'] });
+
+        beforeEach(() => {
+            cleanup();
+            createBucketWithReplication(hasStorageClass);
+        });
+
+        afterEach(() => cleanup());
+
+        it('should update metadata when replication config prefix matches ' +
+        'an object key', done =>
+            putObjectAndCheckMD(keyA, newReplicationMD, done));
+
+        it('should update metadata when replication config prefix matches ' +
+        'the start of an object key', done =>
+            putObjectAndCheckMD(`${keyA}abc`, newReplicationMD, done));
+
+        it('should not update metadata when replication config prefix does ' +
+        'not match the start of an object key', done =>
+            putObjectAndCheckMD(`abc${keyA}`, emptyReplicationMD, done));
+
+        it('should not update metadata when replication config prefix does ' +
+        'not apply', done =>
+            putObjectAndCheckMD(keyB, emptyReplicationMD, done));
+
+        it("should update status to 'PENDING' if putting a new version", done =>
+            putObjectAndCheckMD(keyA, newReplicationMD, err => {
+                if (err) {
+                    return done(err);
+                }
+                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                // Update metadata to a status after replication has occurred.
+                objectMD.replicationInfo.status = 'COMPLETED';
+                return putObjectAndCheckMD(keyA, newReplicationMD, done);
+            }));
+
+        it("should update status to 'PENDING' and content to '['METADATA']' " +
+            'if putting object ACL', done =>
+            async.series([
+                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                next => objectPutACL(authInfo, objectACLReq, log, next),
+            ], err => {
+                if (err) {
+                    return done(err);
+                }
+                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                return done();
+            }));
+
+        it('should update metadata if putting a delete marker', done =>
+            async.series([
+                next => putObjectAndCheckMD(keyA, newReplicationMD, err => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                    // Set metadata to a status after replication has occurred.
+                    objectMD.replicationInfo.status = 'COMPLETED';
+                    return next();
+                }),
+                next => objectDelete(authInfo, deleteReq, log, next),
+            ], err => {
+                if (err) {
+                    return done(err);
+                }
+                const objectMD = metadata.keyMaps.get(bucketName).get(keyA);
+                assert.strictEqual(objectMD.isDeleteMarker, true);
+                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                return done();
+            }));
+
+        describe('Object tagging', () => {
+            beforeEach(done => async.series([
+                next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                next => objectPutTagging(authInfo, taggingPutReq, log, next),
+            ], err => done(err)));
+
+            it("should update status to 'PENDING' and content to " +
+                "'['METADATA']'if putting tag", done => {
+                checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                return done();
+            });
+
+            it("should update status to 'PENDING' and content to " +
+                "'['METADATA']' if deleting tag", done =>
+                async.series([
+                    // Put a new version to update replication MD content array.
+                    next => putObjectAndCheckMD(keyA, newReplicationMD, next),
+                    next => objectDeleteTagging(authInfo, taggingDeleteReq, log,
+                        next),
+                ], err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    checkObjectReplicationInfo(keyA, replicateMetadataOnly);
+                    return done();
+                }));
+        });
+    });
+});

--- a/tests/unit/metadata/models/object.js
+++ b/tests/unit/metadata/models/object.js
@@ -72,6 +72,19 @@ describe('ObjectMD class setters/getters', () => {
         ['Tags', {
             key: 'value',
         }],
+        ['Tags', null, {}],
+        ['ReplicationInfo', null, {
+            status: '',
+            content: [],
+            destination: '',
+            storageClass: '',
+        }],
+        ['ReplicationInfo', {
+            status: 'PENDING',
+            content: ['DATA', 'METADATA'],
+            destination: 'destination-bucket',
+            storageClass: 'STANDARD',
+        }],
     ].forEach(test => {
         const property = test[0];
         const testValue = test[1];


### PR DESCRIPTION
Add property `replicationInfo` to an object's metadata. Set the values conditionally for Backbeat to know which objects need to be replicated and whether to replicate the object data and/or metadata.