### PR TITLE
FIX: Allow operation if have valid loc

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ There are three configuration files for your Scality S3 Server:
 You must specify at least one locationConstraint in your
 locationConfig.json (or leave as pre-configured).
 
+You must also specify 'us-east-1' as a locationConstraint so
+if you only define one locationConstraint, that would be it.
+If you put a bucket to an unknown endpoint and do not specify
+a locationConstraint in the put bucket call, us-east-1 will
+be used.
+
 For instance, the following locationConstraint will save data
 sent to `myLocationConstraint` to the file backend:
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -83,6 +83,9 @@ function locationConstraintAssert(locationConstraints) {
                 'bad config: credentials must include secretKey as string');
         }
     });
+    assert(Object.keys(locationConstraints)
+        .includes('us-east-1'), 'bad locationConfig: must ' +
+        'include us-east-1 as a locationConstraint');
 }
 
 function cosParse(chordCos) {

--- a/lib/api/apiUtils/object/BackendInfo.js
+++ b/lib/api/apiUtils/object/BackendInfo.js
@@ -118,17 +118,23 @@ class BackendInfo {
      */
     static controllingBackendParam(objectLocationConstraint,
         bucketLocationConstraint, requestEndpoint, log) {
-        if (objectLocationConstraint &&
-            !BackendInfo.isValidLocationConstraint(objectLocationConstraint,
+        if (objectLocationConstraint) {
+            if (BackendInfo.isValidLocationConstraint(objectLocationConstraint,
                 log)) {
+                log.trace('objectLocationConstraint is valid');
+                return { isValid: true };
+            }
             log.trace('objectLocationConstraint is invalid');
             return { isValid: false, description: 'Object Location Error - ' +
             `Your object location "${escapeForXML(objectLocationConstraint)}"` +
             'is not  in your location config - Please update.' };
         }
-        if (bucketLocationConstraint &&
-            !BackendInfo.isValidLocationConstraint(bucketLocationConstraint,
+        if (bucketLocationConstraint) {
+            if (BackendInfo.isValidLocationConstraint(bucketLocationConstraint,
                 log)) {
+                log.trace('bucketLocationConstraint is valid');
+                return { isValid: true };
+            }
             log.trace('bucketLocationConstraint is invalid');
             return { isValid: false, description: 'Bucket Location Error - ' +
             `Your bucket location "${escapeForXML(bucketLocationConstraint)}"` +

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -9,7 +9,7 @@ const { config } = require('../Config');
 const aclUtils = require('../utilities/aclUtils');
 const { pushMetric } = require('../utapi/utilities');
 
-const { locationConstraints, restEndpoints, backends } = config;
+const { locationConstraints, restEndpoints } = config;
 
 
 /**
@@ -32,18 +32,10 @@ function checkLocationConstraint(request, locationConstraint, log) {
         locationConstraintChecked = locationConstraint;
     } else if (parsedHost && restEndpoints[parsedHost]) {
         locationConstraintChecked = restEndpoints[parsedHost];
-    } else if (backends.data === 'multiple') {
-        const errMsg = 'no location constraint explicitly set on a' +
-          ' bucket';
-        log.trace(`locationConstraint is invalid - ${errMsg}`);
-        return { error: errors.InvalidLocationConstraint.
-          customizeDescription(errMsg) };
     } else {
-        // return empty string location if no location constraint explicitly set
-        // and data backend not set to "multiple"
-        // note: THIS IS ONLY FOR THE OPEN SOURCE VERSION THAT IS RUNNING
-        // IN FILE OR MEM.
-        return { error: null, locationConstraint: '' };
+        log.trace('no location constraint provided on bucket put;' +
+            'setting us-east-1');
+        locationConstraintChecked = 'us-east-1';
     }
 
     if (!locationConstraints[locationConstraintChecked]) {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/unknownEndpoint.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/unknownEndpoint.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const config = require('../../../config.json');
+const specifiedEndpoint = `${config.transport}://127.0.0.3:8000`;
+const bucket = 'testunknownendpoint';
+const key = 'somekey';
+const body = Buffer.from('I am a body', 'utf8');
+const expectedETag = '"be747eb4b75517bf6b3cf7c5fbb62f3a"';
+
+let bucketUtil;
+let s3;
+
+describe('Requests to ip endpoint not in config', () => {
+    withV4(sigCfg => {
+        before(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            // change endpoint to endpoint with ip address
+            // not in config
+            bucketUtil.s3.config.endpoint = specifiedEndpoint;
+            s3 = bucketUtil.s3;
+        });
+
+        after(() => {
+            process.stdout.write('Emptying bucket\n');
+            return bucketUtil.empty(bucket)
+            .then(() => {
+                process.stdout.write('Deleting bucket\n');
+                return bucketUtil.deleteOne(bucket);
+            })
+            .catch(err => {
+                process.stdout.write(`Error in afterEach: ${err}\n`);
+                throw err;
+            });
+        });
+
+        it('should accept put bucket request ' +
+            'to IP address endpoint that is not in config using ' +
+            'path style',
+            done => {
+                s3.createBucket({ Bucket: bucket }, err => {
+                    assert.ifError(err);
+                    done();
+                });
+            });
+
+        const itSkipIfE2E = process.env.S3_END_TO_END ? it.skip : it;
+        // skipping in E2E since in E2E 127.0.0.3 resolving to
+        // localhost which is in config. Once integration is using
+        // different machines we can update this.
+        itSkipIfE2E('should show us-east-1 as bucket location since' +
+            'IP address endpoint was not in config thereby ' +
+            'defaulting to us-east-1',
+            done => {
+                s3.getBucketLocation({ Bucket: bucket },
+                    (err, res) => {
+                        assert.ifError(err);
+                        // us-east-1 is returned as empty string
+                        assert.strictEqual(res
+                            .LocationConstraint, '');
+                        done();
+                    });
+            });
+
+        it('should accept put object request ' +
+            'to IP address endpoint that is not in config using ' +
+            'path style and use the bucket location for the object',
+            done => {
+                s3.putObject({ Bucket: bucket, Key: key, Body: body },
+                    err => {
+                        assert.ifError(err);
+                        return s3.headObject({ Bucket: bucket, Key: key },
+                            err => {
+                                assert.ifError(err);
+                                done();
+                            });
+                    });
+            });
+
+        it('should accept get object request ' +
+            'to IP address endpoint that is not in config using ' +
+            'path style',
+            done => {
+                s3.getObject({ Bucket: bucket, Key: key },
+                    (err, res) => {
+                        assert.ifError(err);
+                        assert.strictEqual(res.ETag, expectedETag);
+                        done();
+                    });
+            });
+    });
+});

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -50,15 +50,15 @@ const testChecks = [
         data: 'file',
         locationSent: '',
         parsedHost: '127.3.2.1',
-        locationReturn: '',
+        locationReturn: 'us-east-1',
         isError: false,
     },
     {
         data: 'multiple',
         locationSent: '',
         parsedHost: '127.3.2.1',
-        locationReturn: undefined,
-        isError: true,
+        locationReturn: 'us-east-1',
+        isError: false,
     },
 ];
 

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -36,7 +36,10 @@ const bucketPutRequest = {
     namespace,
     headers: { host: `${bucketName}.s3.amazonaws.com` },
     url: '/',
-    post: '',
+    post: '<CreateBucketConfiguration ' +
+    'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+    '<LocationConstraint>mem</LocationConstraint>' +
+    '</CreateBucketConfiguration >',
 };
 const objectKey = 'testObject';
 const initiateRequest = {
@@ -1325,7 +1328,8 @@ describe('Multipart Upload API', () => {
     });
 
     it('should return no error if attempt to abort/delete ' +
-        'a multipart upload that does not exist', done => {
+        'a multipart upload that does not exist and not using' +
+        'legacyAWSBehavior', done => {
         async.waterfall([
             next => bucketPut(authInfo, bucketPutRequest, log, next),
             (corsHeaders, next) => initiateMultipartUpload(authInfo,

--- a/tests/unit/multipleBackend/BackendInfo.js
+++ b/tests/unit/multipleBackend/BackendInfo.js
@@ -22,46 +22,66 @@ describe('BackendInfo class', () => {
             > -1);
         });
         it('should return object with applicable error if ' +
-        'bucketLocationConstraint is invalid', () => {
+        'bucketLocationConstraint is invalid and no ' +
+        'objectLocationConstraint was provided', () => {
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'notValid', '127.0.0.1', log);
+                undefined, 'notValid', '127.0.0.1', log);
             assert.equal(res.isValid, false);
             assert((res.description).indexOf('Bucket ' +
             'Location Error') > -1);
         });
         it('should return object with applicable error if requestEndpoint ' +
-        'is invalid and data backend is set to "scality"', () => {
+        'is invalid, no objectLocationConstraint or bucketLocationConstraint' +
+        'was provided and data backend is set to "scality"', () => {
             config.backends.data = 'scality';
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'file', 'notValid', log);
+                undefined, undefined, 'notValid', log);
             assert.equal(res.isValid, false);
             assert((res.description).indexOf('Endpoint ' +
             'Location Error') > -1);
         });
         it('should return object with applicable error if requestEndpoint ' +
-        'is invalid and data backend is set to "multiple"', () => {
+        'is invalid, no objectLocationConstraint or ' +
+        'bucketLocationConstraint was provided and ' +
+        'data backend is set to "multiple"', () => {
             config.backends.data = 'multiple';
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'file', 'notValid', log);
+                undefined, undefined, 'notValid', log);
             assert.equal(res.isValid, false);
             assert((res.description).indexOf('Endpoint ' +
             'Location Error') > -1);
         });
-        it('should return object if requestEndpoint ' +
+        it('should return isValid if requestEndpoint ' +
         'is invalid and data backend is set to "file"', () => {
             config.backends.data = 'file';
             const res = BackendInfo.controllingBackendParam(
                 'mem', 'file', 'notValid', log);
             assert.equal(res.isValid, true);
         });
-        it('should return object if requestEndpoint ' +
+        it('should return isValid if requestEndpoint ' +
         'is invalid and data backend is set to "mem"', () => {
             config.backends.data = 'mem';
             const res = BackendInfo.controllingBackendParam(
                 'mem', 'file', 'notValid', log);
             assert.equal(res.isValid, true);
         });
-        it('should return object if all backend ' +
+        it('should return isValid if requestEndpoint ' +
+        'is invalid but valid objectLocationConstraint' +
+        'was provided', () => {
+            config.backends.data = 'multiple';
+            const res = BackendInfo.controllingBackendParam(
+                'mem', undefined, 'notValid', log);
+            assert.equal(res.isValid, true);
+        });
+        it('should return isValid if requestEndpoint ' +
+        'is invalid but valid bucketLocationConstraint' +
+        'was provided', () => {
+            config.backends.data = 'multiple';
+            const res = BackendInfo.controllingBackendParam(
+                undefined, 'mem', 'notValid', log);
+            assert.equal(res.isValid, true);
+        });
+        it('should return isValid if all backend ' +
         'parameters are valid', () => {
             const res = BackendInfo.controllingBackendParam(
                 'mem', 'file', '127.0.0.1', log);

--- a/tests/unit/testConfigs/locConstraintAssert.js
+++ b/tests/unit/testConfigs/locConstraintAssert.js
@@ -95,4 +95,12 @@ describe('locationConstraintAssert', () => {
         },
         /bad config: credentialsProfile must be a string/);
     });
+    it('should throw error if us-east-1 not specified', () => {
+        const locationConstraint = new LocationConstraint();
+        assert.throws(() => {
+            locationConstraintAssert({ 'not-us-east-1': locationConstraint });
+        },
+        '/bad locationConfig: must ' +
+        'include us-east-1 as a locationConstraint/');
+    });
 });


### PR DESCRIPTION
1) If have object level location constraint
or bucket level location constraint allow
operation to continue even if restEndpoint is
not in config.

2) Set bucket location to us-east-1 if no location provided and no default for endpoint.



