### PR TITLE
BF S3C-531 chordChos must be 1 digit string smaller than 7

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -24,8 +24,8 @@ function sproxydAssert(configSproxyd) {
     if (configSproxyd.chordCos !== undefined) {
         assert(typeof configSproxyd.chordCos === 'string',
             'bad config: sproxyd.chordCos must be a string');
-        assert(configSproxyd.chordCos.match(/^[0-9a-fA-F]{2}$/),
-            'bad config: sproxyd.chordCos must be a 2hex-chars string');
+        assert(configSproxyd.chordCos.match(/^[0-6]{1}$/),
+         'bad config: sproxyd.chordCos must be a digit smaller than 7');
         sproxydFields.push('chordCos');
     }
     if (configSproxyd.path !== undefined) {
@@ -90,8 +90,7 @@ function locationConstraintAssert(locationConstraints) {
 
 function cosParse(chordCos) {
     // Cos number should only be first digit of config value
-    const firstDigit = chordCos[0];
-    return Number.parseInt(firstDigit, 16);
+    return Number.parseInt(chordCos, 10);
 }
 /**
  * Reads from a config file and returns the content as a config object

--- a/tests/unit/testConfigs/cosParse.js
+++ b/tests/unit/testConfigs/cosParse.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const { cosParse } = require('../../../lib/Config');
 
-const dummyChordCos = '20';
+const dummyChordCos = '2';
 
 describe('cosParse', () => {
-    it('should return the first digit of a string number as an integer', () => {
+    it('should return the single digit of the string as an integer', () => {
         const parsed = cosParse(dummyChordCos);
         assert.strictEqual(parsed, 2);
     });

--- a/tests/unit/testConfigs/sproxydAssert.js
+++ b/tests/unit/testConfigs/sproxydAssert.js
@@ -37,17 +37,17 @@ describe('sproxydAssert', () => {
         },
         /bad config: sproxyd.chordCos must be a string/);
     });
-    it('should throw an error if chordCos is more than 2 digits', () => {
+    it('should throw an error if chordCos is more than 1 digit', () => {
         assert.throws(() => {
             sproxydAssert(makeSproxydConf(null, '200'));
         },
-        /bad config: sproxyd.chordCos must be a 2hex-chars string/);
+        /bad config: sproxyd.chordCos must be a digit smaller than 7/);
     });
-    it('should throw an error if chordCos includes non-hex digit', () => {
+    it('should throw an error if chordCos bigger than 7', () => {
         assert.throws(() => {
-            sproxydAssert(makeSproxydConf(null, '2z'));
+            sproxydAssert(makeSproxydConf(null, '7'));
         },
-        /bad config: sproxyd.chordCos must be a 2hex-chars string/);
+        /bad config: sproxyd.chordCos must be a digit smaller than 7/);
     });
     it('should throw an error if path is not a string', () => {
         assert.throws(() => {
@@ -62,7 +62,7 @@ describe('sproxydAssert', () => {
     });
     it('should return array containing "chordCos" if config contains chordCos',
         () => {
-            const sproxydArray = sproxydAssert(makeSproxydConf(null, '20'));
+            const sproxydArray = sproxydAssert(makeSproxydConf(null, '2'));
             assert.strictEqual(sproxydArray.indexOf('chordCos'), 0);
         });
     it('should return array containing "path" if config contains path', () => {
@@ -73,7 +73,7 @@ describe('sproxydAssert', () => {
     it('should return array of "bootstrap", "chordCos", and "path" if config ' +
         'contains all fields', () => {
         const sproxydArray = sproxydAssert(
-            makeSproxydConf(['localhost:8181'], '20', '/proxy/arc'));
+            makeSproxydConf(['localhost:8181'], '2', '/proxy/arc'));
         assert.strictEqual(sproxydArray.length, 3);
         assert.strictEqual(sproxydArray.indexOf('bootstrap') > -1, true);
         assert.strictEqual(sproxydArray.indexOf('chordCos') > -1, true);


### PR DESCRIPTION
When using the scality sproxyd storage, the chordCos should be a decimal integer smaller than 7 (bigger number are erasure coding and not replication.

Currently the chordCos is supposed to be a 2 hexadecimal digits string. This PR changes that.

