### PR TITLE
bf: immutable optim option on S3 sproxyd client

### DIFF
--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -31,6 +31,8 @@ function parseLC() {
                 // Might also be undefined, but there is a default path set
                 // in sproxydclient as well
                 path: locationObj.details.connector.sproxyd.path,
+                // enable immutable optim for all objects
+                immutable: true,
             });
             clients[location].clientType = 'scality';
         }


### PR DESCRIPTION
This is a new option in scality/sproxydclient that explicitly enables
immutable optims, because they are now disabled by default it's now
necessary to provide the option.

Goes along with PR https://github.com/scality/sproxydclient/pull/119
