### PR TITLE
New docker envionment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 COPY . /usr/src/app
 
 RUN apt-get update \
-    && apt-get install -y python git build-essential --no-install-recommends \
+    && apt-get install -y jq python git build-essential --no-install-recommends \
     && npm install --production \
     && apt-get autoremove --purge -y python git build-essential \
     && rm -rf /var/lib/apt/lists/* \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,4 +47,32 @@ if [[ "$S3DATA" == "multiple" ]]; then
     export S3DATA="$S3DATA"
 fi
 
+JQ_FILTERS="."
+
+if [[ "$LISTEN_ADDR" ]]; then
+    JQ_FILTERS="$JQ_FILTERS | .metadataDaemon.bindAddress=\"$LISTEN_ADDR\""
+    JQ_FILTERS="$JQ_FILTERS | .dataDaemon.bindAddress=\"$LISTEN_ADDR\""
+    JQ_FILTERS="$JQ_FILTERS | .listenOn=[\"$LISTEN_ADDR:8000\"]"
+fi
+
+if [[ "$DATA_HOST" ]]; then
+    JQ_FILTERS="$JQ_FILTERS | .dataClient.host=\"$DATA_HOST\""
+fi
+
+if [[ "$METADATA_HOST" ]]; then
+    JQ_FILTERS="$JQ_FILTERS | .metadataClient.host=\"$METADATA_HOST\""
+fi
+
+if [[ "$REDIS_HOST" ]]; then
+    JQ_FILTERS="$JQ_FILTERS | .localCache.host=\"$REDIS_HOST\""
+    JQ_FILTERS="$JQ_FILTERS | .localCache.port=6379"
+fi
+
+if [[ "$REDIS_PORT" ]]; then
+    JQ_FILTERS="$JQ_FILTERS | .localCache.port=$REDIS_PORT"
+fi
+
+jq "$JQ_FILTERS" config.json > config.json.tmp
+mv config.json.tmp config.json
+
 exec "$@"

--- a/docs/DOCKER.rst
+++ b/docs/DOCKER.rst
@@ -105,6 +105,53 @@ certificates in a mounted volume
 More information about how to use S3 server with SSL
 `here <https://s3.scality.com/v1.0/page/scality-with-ssl>`__
 
+LISTEN\_ADDR
+^^^^^^^^^^^^
+
+This variable instructs the S3 server, and its data and metadata components
+to listen on the specified address. This allows starting the data or metadata
+servers as standalone services, for example.
+
+.. code:: shell
+
+    docker run -d --name s3server-data -p 9991:9991 -e LISTEN_ADDR=0.0.0.0
+    scality/s3server npm run start_dataserver
+
+
+DATA\_HOST and METADATA\_HOST
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These variables configure the data and metadata servers to use,
+usually when they are running on another host and only starting the stateless
+S3 REST server.
+
+.. code:: shell
+
+    docker run -d --name s3server -e DATA_HOST=s3server-data
+    -e METADATA_HOST=s3server-metadata scality/s3server npm run start_s3server
+
+REDIS\_HOST
+^^^^^^^^^^^
+
+Use this variable to connect to the redis cache server on another host than
+localhost.
+
+.. code:: shell
+
+    docker run -d --name s3server -p 8000:8000
+    -e REDIS_HOST=my-redis-server.example.com scality/s3server
+
+REDIS\_PORT
+^^^^^^^^^^^
+
+Use this variable to connect to the redis cache server on another port than
+the default 6379.
+
+.. code:: shell
+
+    docker run -d --name s3server -p 8000:8000
+    -e REDIS_PORT=6379 scality/s3server
+
 In production with Docker
 -------------------------
 


### PR DESCRIPTION
This change allows changing more configuration options through environment variables in the `docker-entrypoint.sh` script.

The generated image is testable at `scality/s3server:with-jq`

The primary motivation is to avoid having to generate and distribute configuration files to dynamically scheduled container environments such as swarm.