### PR TITLE
cleanup: generalize internal routes handling

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,8 +4,8 @@ const cluster = require('cluster');
 const arsenal = require('arsenal');
 
 const logger = require('./utilities/logger');
-const { healthcheckHandler, clientCheck }
-    = require('./utilities/healthcheckHandler');
+const { internalHandlers } = require('./utilities/internalHandlers');
+const { clientCheck } = require('./utilities/healthcheckHandler');
 const _config = require('./Config').config;
 const { unsupportedQueries, blacklistedPrefixes } = require('../constants');
 const api = require('./api/api');
@@ -63,7 +63,7 @@ class S3Server {
         req.socket.setNoDelay();
         const params = {
             api,
-            healthcheckHandler,
+            internalHandlers,
             statsClient,
             allEndpoints,
             websiteEndpoints,

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -74,19 +74,18 @@ function checkIP(clientIP) {
         _config.healthChecks.allowFrom, clientIP);
 }
 
-/*
-* Checks if client IP address is allowed to make http request to
-* S3 server. Defines function 'healthcheckEndHandler', which is
-* called if IP not allowed or passed as callback.
-* @param {object} clientIP - IP address of client
-* @param {boolean} deep - true if healthcheck will check backends
-* @param {object} req - http request object
-* @param {object} res - http response object
-* @param {object} log - werelogs logger instance
-* @param {object} statsClient - StatsClient Instance
-*/
-function healthcheckHandler(clientIP, deep, req, res, log,
-    statsClient) {
+/**
+ * Checks if client IP address is allowed to make http request to
+ * S3 server. Defines function 'healthcheckEndHandler', which is
+ * called if IP not allowed or passed as callback.
+ * @param {object} clientIP - IP address of client
+ * @param {object} req - http request object
+ * @param {object} res - http response object
+ * @param {object} log - werelogs logger instance
+ * @param {object} statsClient - StatsClient Instance
+ * @return {undefined}
+ */
+function healthcheckHandler(clientIP, req, res, log, statsClient) {
     function healthcheckEndHandler(err, results) {
         writeResponse(res, err, log, results, error => {
             if (error) {
@@ -99,8 +98,9 @@ function healthcheckHandler(clientIP, deep, req, res, log,
     if (!checkIP(clientIP)) {
         return healthcheckEndHandler(errors.AccessDenied, []);
     }
+    const deep = (req.url === '/_/healthcheck/deep');
     return routeHandler(deep, req, res, log, statsClient,
-        healthcheckEndHandler);
+                        healthcheckEndHandler);
 }
 
 module.exports = {

--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -1,0 +1,9 @@
+const { healthcheckHandler } = require('./healthcheckHandler');
+
+const internalHandlers = {
+    healthcheck: healthcheckHandler,
+};
+
+module.exports = {
+    internalHandlers,
+};


### PR DESCRIPTION
Every url starting with '/_/' is now routed through a registered internal service handler in the routing code, instead of being specifically checked for a particular service. This will be useful to integrate backbeat routes properly in the next step.

Dependency on Arsenal PR https://github.com/scality/Arsenal/pull/274
