### PR TITLE
fix: missing mpu bucket prefix

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -32,6 +32,12 @@ const constants = {
     oldSplitter: 'splitterfornow',
     usersBucket: 'users..bucket',
     oldUsersBucket: 'namespaceusersbucket',
+    // MPU Bucket Prefix is used to create the name of the shadow
+    // bucket used for multipart uploads.  There is one shadow mpu
+    // bucket per bucket and its name is the mpuBucketPrefix followed
+    // by the name of the final destination bucket for the object
+    // once the multipart upload is complete.
+    mpuBucketPrefix: 'mpuShadowBucket',
     blacklistedPrefixes: { bucket: [], object: [] },
     // PublicId is used as the canonicalID for a request that contains
     // no authentication information.  Requestor can access

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -95,6 +95,10 @@ describe('Multipart Upload API', () => {
         cleanup();
     });
 
+    it('mpuBucketPrefix should be a defined constant', () => {
+        assert(constants.mpuBucketPrefix,
+            'Expected mpuBucketPrefix to be defined');
+    });
 
     it('should initiate a multipart upload', done => {
         bucketPut(authInfo, bucketPutRequest, log, () => {
@@ -107,6 +111,8 @@ describe('Multipart Upload API', () => {
                         assert.strictEqual(json.InitiateMultipartUploadResult
                             .Key[0], objectKey);
                         assert(json.InitiateMultipartUploadResult.UploadId[0]);
+                        assert(metadata.buckets.get(mpuBucket)._name,
+                            mpuBucket);
                         const mpuKeys = metadata.keyMaps.get(mpuBucket);
                         assert.strictEqual(mpuKeys.size, 1);
                         assert(mpuKeys.keys().next().value


### PR DESCRIPTION
The constant was accidentally deleted when extracting routes to Arsenal, causing the mpu bucket prefix to default to "undefined". Thanks to @bennettbuchanan for noticing the bug.