### PR TITLE
Fix credentials profile assignment

### DIFF
--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -56,8 +56,9 @@ function parseLC() {
             // ~/.aws/credentials file or include the accessKeyId and
             // secretAccessKey directly in the locationConfig
             if (locationObj.details.credentialsProfile) {
-                s3Params.credentials = new AWS.SharedIniFileCredentials({
+                const credentials = new AWS.SharedIniFileCredentials({
                     profile: locationObj.details.credentialsProfile });
+                AWS.config.credentials = credentials;
             } else {
                 s3Params.accessKeyId =
                     locationObj.details.credentials.accessKey;

--- a/tests/functional/aws-node-sdk/test/support/awsConfig.js
+++ b/tests/functional/aws-node-sdk/test/support/awsConfig.js
@@ -17,7 +17,8 @@ function getAwsCredentials(profile, credFile) {
 
 function getRealAwsConfig(profile) {
     const credentials = getAwsCredentials(profile, '/.aws/credentials');
-    const realAwsConfig = { credentials, signatureVersion: 'v4' };
+    AWS.config.credentials = credentials;
+    const realAwsConfig = { signatureVersion: 'v4' };
 
     return realAwsConfig;
 }


### PR DESCRIPTION
If using a credential profile with AWS instead of directly using accessKey/secretKey, the credentials have to be assigned to the global AWS config, not passed as part of the S3 config params