### PR TITLE
REFACTOR: do not require auth file if env variables are set

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -610,12 +610,14 @@ class Config {
             if (process.env.S3AUTH_CONFIG) {
                 authfile = process.env.S3AUTH_CONFIG;
             }
-            let authData = require(authfile);
+            let authData;
             if (process.env.SCALITY_ACCESS_KEY_ID &&
             process.env.SCALITY_SECRET_ACCESS_KEY) {
                 authData = buildAuthDataAccount(
                   process.env.SCALITY_ACCESS_KEY_ID,
                   process.env.SCALITY_SECRET_ACCESS_KEY);
+            } else {
+                authData = require(authfile);
             }
             if (validateAuthConfig(authData, this.log)) {
                 throw new Error('bad config: invalid auth config file.');


### PR DESCRIPTION
Small suggestion to avoid requiring the
conf/authdata.json file if custom credentials have
been set as container environment variables.