### PR TITLE
Fix AWS creds in testing

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/get.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get.js
@@ -76,7 +76,7 @@ describe('Multiple backend get object', function testSuite() {
         describeSkipIfNotMultiple('with objects in all available backends ' +
             '(mem/file/AWS)', () => {
             before(() => {
-                const awsConfig = getRealAwsConfig('default');
+                const awsConfig = getRealAwsConfig(awsLocation);
                 awsS3 = new AWS.S3(awsConfig);
 
                 process.stdout.write('Putting object to mem\n');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put.js
@@ -107,7 +107,7 @@ describe('MultipleBackend put object', function testSuite() {
         describeSkipIfNotMultiple('with set location from "x-amz-meta-scal-' +
             'location-constraint" header', () => {
             before(() => {
-                const awsConfig = getRealAwsConfig('default');
+                const awsConfig = getRealAwsConfig(awsLocation);
                 awsS3 = new AWS.S3(awsConfig);
             });
 

--- a/tests/functional/aws-node-sdk/test/support/awsConfig.js
+++ b/tests/functional/aws-node-sdk/test/support/awsConfig.js
@@ -1,6 +1,7 @@
 const AWS = require('aws-sdk');
 const fs = require('fs');
 const path = require('path');
+const { config } = require('../../../../../lib/Config');
 
 function getAwsCredentials(profile, credFile) {
     const filename = path.join(process.env.HOME, credFile);
@@ -15,8 +16,11 @@ function getAwsCredentials(profile, credFile) {
     return new AWS.SharedIniFileCredentials({ profile, filename });
 }
 
-function getRealAwsConfig(profile) {
-    const credentials = getAwsCredentials(profile, '/.aws/credentials');
+function getRealAwsConfig(awsLocation) {
+    const cp =
+        config.locationConstraints[awsLocation].details.credentialsProfile
+        || 'default';
+    const credentials = getAwsCredentials(cp, '/.aws/credentials');
     const realAwsConfig = { credentials, signatureVersion: 'v4' };
 
     return realAwsConfig;

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -3,6 +3,8 @@ const AWS = require('aws-sdk');
 const { parseString } = require('xml2js');
 const { errors } = require('arsenal');
 
+const { getRealAwsConfig } =
+    require('../functional/aws-node-sdk/test/support/awsConfig');
 const { cleanup, DummyRequestLogger, makeAuthInfo, versioningTestUtils } =
     require('../unit/helpers');
 const DummyRequest = require('../unit/DummyRequest');
@@ -23,7 +25,9 @@ const completeMultipartUpload =
     require('../../lib/api/completeMultipartUpload');
 const fakeUploadId = 'fakeuploadid';
 
-const s3 = new AWS.S3();
+const awsLocation = 'aws-test';
+const awsConfig = getRealAwsConfig(awsLocation);
+const s3 = new AWS.S3(awsConfig);
 const log = new DummyRequestLogger();
 
 const splitter = constants.splitter;
@@ -32,7 +36,6 @@ const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
-const awsLocation = 'aws-test';
 const awsBucket = config.locationConstraints[awsLocation].details.bucketName;
 const smallBody = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -14,8 +14,12 @@ const objectPutPart = require('../../lib/api/objectPutPart');
 const DummyRequest = require('../unit/DummyRequest');
 const { metadata } = require('../../lib/metadata/in_memory/metadata');
 const constants = require('../../constants');
+const { getRealAwsConfig } =
+    require('../functional/aws-node-sdk/test/support/awsConfig');
 
-const s3 = new AWS.S3();
+const awsLocation = 'aws-test';
+const awsConfig = getRealAwsConfig(awsLocation);
+const s3 = new AWS.S3(awsConfig);
 
 const splitter = constants.splitter;
 const log = new DummyRequestLogger();
@@ -24,7 +28,6 @@ const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 const bucketName = 'bucketname';
 
-const awsLocation = 'aws-test';
 const objectName = 'objectName';
 const body1 = Buffer.from('I am a body', 'utf8');
 const body2 = Buffer.from('I am a body with a different ETag', 'utf8');


### PR DESCRIPTION
Allows multiple backend tests to be run with credential profile specified in locationConfig, instead of defaulting to 'default'