### PR TITLE
FT: Add configurable replication storageClass to objectMD

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -221,6 +221,37 @@ class Config {
             this.replicationGroupId = 'RG001';
         }
 
+        this.replicationEndpoints = [];
+        if (config.replicationEndpoints) {
+            const { replicationEndpoints } = config;
+            assert(replicationEndpoints instanceof Array, 'bad config: ' +
+                '`replicationEndpoints` property must be an array');
+            replicationEndpoints.forEach(replicationEndpoint => {
+                assert.strictEqual(typeof replicationEndpoint, 'object',
+                    'bad config: `replicationEndpoints` property must be an ' +
+                    'array of objects');
+                const { name, endpoint } = replicationEndpoint;
+                assert.notStrictEqual(name, undefined, 'bad config: each ' +
+                    'object of `replicationEndpoints` array must have a ' +
+                    '`name` property');
+                assert.strictEqual(typeof name, 'string', 'bad config: ' +
+                    '`name` property of object in `replicationEndpoints` ' +
+                    'must be a string');
+                assert.notStrictEqual(name, '', 'bad config: `name` property ' +
+                    "of object in `replicationEndpoints` must not be ''");
+                assert.notStrictEqual(endpoint, undefined, 'bad config: each ' +
+                    'object of `replicationEndpoints` array must have an ' +
+                    '`endpoint` property');
+                assert.strictEqual(typeof endpoint, 'string', 'bad config: ' +
+                    '`endpoint` property of object in `replicationEndpoints` ' +
+                    'must be a string');
+                assert.notStrictEqual(endpoint, '', 'bad config: `endpoint` ' +
+                    'property of object in `replicationEndpoints` must not ' +
+                    "be ''");
+            });
+            this.replicationEndpoints = replicationEndpoints;
+        }
+
         // legacy
         if (config.regions !== undefined) {
             throw new Error('bad config: regions key is deprecated. ' +

--- a/lib/api/apiUtils/bucket/models/ReplicationConfiguration.js
+++ b/lib/api/apiUtils/bucket/models/ReplicationConfiguration.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const UUID = require('node-uuid');
 
+const config = require('../../../../Config').config;
 const { errors, s3middleware, s3routes } = require('arsenal');
 const escapeForXml = s3middleware.escapeForXml;
 const { isValidBucketName } = s3routes.routesUtils;
@@ -262,7 +263,10 @@ class ReplicationConfiguration {
      * @return {boolean} `true` if valid, otherwise `false`
      */
     static _isValidStorageClass(storageClass) {
-        return validStorageClasses.includes(storageClass);
+        const replicationEndpoints = config.replicationEndpoints
+            .map(endpoint => endpoint.name);
+        return replicationEndpoints.includes(storageClass) ||
+            validStorageClasses.includes(storageClass);
     }
 
     /**


### PR DESCRIPTION
Allow including a custom array of replicationEndpoints in the `config.json`, any of which would be considered valid when putting the replicationConfiguration.