### PR TITLE
Add tests for AWS object copy

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -4,6 +4,7 @@ const { errors, versioning, s3middleware } = require('arsenal');
 const getMetaHeaders = s3middleware.userMetadata.getMetaHeaders;
 const validateHeaders = s3middleware.validateConditionalHeaders;
 
+const constants = require('../../constants');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const locationConstraintCheck
     = require('./apiUtils/object/locationConstraintCheck');
@@ -19,8 +20,10 @@ const removeAWSChunked = require('./apiUtils/object/removeAWSChunked');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
 const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
     .validateWebsiteHeader;
+const { config } = require('../Config');
 
 const versionIdUtils = versioning.VersionID;
+const locationHeader = constants.objectLocationConstraintHeader;
 
 /**
  * Preps metadata to be saved (based on copy or replace request header)
@@ -84,6 +87,14 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
         });
         return { error: userMetadata };
     }
+    // If metadataDirective is 'COPY' and location constraint header is
+    // specified, new location constraint should override source object's
+    if (whichMetadata === 'COPY' && headers[locationHeader]) {
+        userMetadata[locationHeader] = headers[locationHeader];
+    }
+    // If location constraint header is not included, locations match
+    const locationMatch = headers[locationHeader] ?
+        sourceObjMD[locationHeader] === headers[locationHeader] : true;
 
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will
@@ -123,6 +134,7 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
         taggingCopy,
         replicationInfo: getReplicationInfo(objectKey, destBucketMD, false,
             sourceObjMD['content-length']),
+        locationMatch,
     };
 
     // In case whichMetadata === 'REPLACE' but contentType is undefined in copy
@@ -277,20 +289,52 @@ function objectCopy(authInfo, request, sourceBucket,
             destObjMD, next) {
             const serverSideEncryption = destBucketMD.getServerSideEncryption();
 
-            // skip if source and dest the same or 0 byte object
-            // still send along serverSideEncryption info so algo
-            // and masterKeyId stored properly in metadata
-            if (sourceIsDestination || dataLocator.length === 0) {
-                return next(null, storeMetadataParams, dataLocator, destObjMD,
-                    serverSideEncryption, destBucketMD);
-            }
-
             const backendInfoObj = locationConstraintCheck(request,
                 storeMetadataParams.metaHeaders, destBucketMD, log);
             if (backendInfoObj.err) {
                 return next(backendInfoObj.err);
             }
             const backendInfo = backendInfoObj.backendInfo;
+
+            // skip if source and dest and location constraint the same
+            // still send along serverSideEncryption info so algo
+            // and masterKeyId stored properly in metadata
+            if (sourceIsDestination && storeMetadataParams.locationMatch) {
+                return next(null, storeMetadataParams, dataLocator, destObjMD,
+                    serverSideEncryption, destBucketMD);
+            }
+
+            // also skip if 0 byte object, unless location constraint is an
+            // external backend and differs from source, in which case put
+            // metadata to backend
+            if (dataLocator.length === 0) {
+                let locationType;
+                if (storeMetadataParams.metaHeaders[locationHeader]) {
+                    locationType = config.locationConstraints
+                        [storeMetadataParams.metaHeaders[locationHeader]].type;
+                }
+                if (!storeMetadataParams.locationMatch &&
+                constants.externalBackends[locationType]) {
+                    return data.put(null, null, storeMetadataParams.size,
+                        dataStoreContext, backendInfo,
+                        log, (error, objectRetrievalInfo) => {
+                            if (error) {
+                                return next(error, destBucketMD);
+                            }
+                            const putResult = {
+                                key: objectRetrievalInfo.key,
+                                dataStoreName: objectRetrievalInfo.
+                                    dataStoreName,
+                                size: storeMetadataParams.size,
+                            };
+                            const putResultArr = [putResult];
+                            return next(null, storeMetadataParams, putResultArr,
+                                destObjMD, serverSideEncryption, destBucketMD);
+                        });
+                }
+                return next(null, storeMetadataParams, dataLocator, destObjMD,
+                    serverSideEncryption, destBucketMD);
+            }
 
             // dataLocator is an array.  need to get and put all parts
             // For now, copy 1 part at a time. Could increase the second
@@ -335,7 +379,6 @@ function objectCopy(authInfo, request, sourceBucket,
                         }
                         // Copied object is not encrypted so just put it
                         // without a cipherBundle
-
                         return data.put(null, stream, part.size,
                         dataStoreContext, backendInfo,
                         log, (error, partRetrievalInfo) => {

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -27,14 +27,24 @@ class AwsClient {
         const uploadParams = {
             Bucket: this._awsBucketName,
             Key: awsKey,
-            Body: stream,
             Metadata: keyContext.metaHeaders,
             ContentLength: size,
         };
         if (keyContext.cipherBundle) {
             uploadParams.ServerSideEncryption = 'AES256';
         }
-
+        if (!stream) {
+            return this._client.putObject(uploadParams, err => {
+                if (err) {
+                    const log = createLogger(reqUids);
+                    log.error('err from data backend',
+                    { error: err, dataStoreName: this._dataStoreName });
+                    return callback(errors.InternalError);
+                }
+                return callback(null, awsKey);
+            });
+        }
+        uploadParams.Body = stream;
         return this._client.upload(uploadParams,
            err => {
                if (err) {
@@ -62,6 +72,7 @@ class AwsClient {
         const stream = request.createReadStream().on('error', err => {
             log.error('error streaming data from AWS', { error: err,
                 dataStoreName: this._dataStoreName });
+            return callback(err);
         });
         return callback(null, stream);
     }

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -54,8 +54,11 @@ const data = {
         assert.strictEqual(typeof valueSize, 'number');
         log.debug('sending put to datastore', { implName, keyContext,
                                                 method: 'put' });
-        const hashedStream = new MD5Sum();
-        value.pipe(hashedStream);
+        let hashedStream = null;
+        if (value) {
+            hashedStream = new MD5Sum();
+            value.pipe(hashedStream);
+        }
 
         if (implName === 'multipleBackends') {
             // Need to send backendInfo to client.put and

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy.js
@@ -1,0 +1,252 @@
+const assert = require('assert');
+const async = require('async');
+const AWS = require('aws-sdk');
+const withV4 = require('../support/withV4');
+const BucketUtility = require('../../lib/utility/bucket-util');
+const constants = require('../../../../../constants');
+const { config } = require('../../../../../lib/Config');
+const { getRealAwsConfig } = require('../support/awsConfig');
+const { createEncryptedBucketPromise } =
+    require('../../lib/utility/createEncryptedBucket');
+
+const awsLocation = 'aws-test';
+const bucket = 'buckettestmultiplebackendobjectcopy';
+const key = `somekey-${Date.now()}`;
+const copyKey = `copyKey-${Date.now()}`;
+const body = Buffer.from('I am a body', 'utf8');
+const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
+const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';
+const locMetaHeader = constants.objectLocationConstraintHeader.substring(11);
+
+let bucketUtil;
+let s3;
+let awsS3;
+const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
+    || process.env.S3_END_TO_END) ? describe.skip : describe;
+
+const copyParamBase = {
+    Bucket: bucket,
+    Key: copyKey,
+    CopySource: `/${bucket}/${key}`,
+};
+
+function putSourceObj(location, isEmptyObj, cb) {
+    const sourceParams = { Bucket: bucket, Key: key,
+        Metadata: {
+            'scal-location-constraint': location,
+            'test-header': 'copyme',
+        },
+    };
+    if (!isEmptyObj) {
+        sourceParams.Body = body;
+    }
+    s3.putObject(sourceParams, (err, result) => {
+        assert.equal(err, null, `Error putting source object: ${err}`);
+        if (isEmptyObj) {
+            assert.strictEqual(result.ETag, `"${emptyMD5}"`);
+        } else {
+            assert.strictEqual(result.ETag, `"${correctMD5}"`);
+        }
+        cb();
+    });
+}
+
+function assertGetObjects(sourceKey, sourceBucket, sourceLoc, destKey,
+destBucket, destLoc, awsKey, mdDirective, isEmptyObj, callback) {
+    const awsBucket =
+        config.locationConstraints[awsLocation].details.bucketName;
+    const sourceGetParams = { Bucket: sourceBucket, Key: sourceKey };
+    const destGetParams = { Bucket: destBucket, Key: destKey };
+    const awsParams = { Bucket: awsBucket, Key: awsKey };
+
+    async.series([
+        cb => s3.getObject(sourceGetParams, cb),
+        cb => s3.getObject(destGetParams, cb),
+        cb => awsS3.getObject(awsParams, cb),
+    ], (err, results) => {
+        assert.equal(err, null, `Error in assertGetObjects: ${err}`);
+
+        const [sourceRes, destRes, awsRes] = results;
+        if (isEmptyObj) {
+            assert.strictEqual(sourceRes.ETag, `"${emptyMD5}"`);
+            assert.strictEqual(destRes.ETag, `"${emptyMD5}"`);
+            assert.strictEqual(awsRes.ETag, `"${emptyMD5}"`);
+        } else {
+            if (process.env.ENABLE_KMS_ENCRYPTION === 'true') {
+                assert.strictEqual(sourceRes.ServerSideEncryption, 'AES256');
+                assert.strictEqual(destRes.ServerSideEncryption, 'AES256');
+                assert.strictEqual(awsRes.ServerSideEncryption, 'AES256');
+            } else {
+                assert.strictEqual(sourceRes.ETag, `"${correctMD5}"`);
+                assert.strictEqual(destRes.ETag, `"${correctMD5}"`);
+                assert.deepStrictEqual(sourceRes.Body, destRes.Body);
+                assert.strictEqual(awsRes.ETag, `"${correctMD5}"`);
+                assert.deepStrictEqual(sourceRes.Body, awsRes.Body);
+            }
+        }
+        if (mdDirective === 'COPY') {
+            assert.deepStrictEqual(sourceRes.Metadata['test-header'],
+                destRes.Metadata['test-header']);
+        }
+        assert.strictEqual(sourceRes.ContentLength, destRes.ContentLength);
+        assert.strictEqual(sourceRes.Metadata[locMetaHeader], sourceLoc);
+        assert.strictEqual(destRes.Metadata[locMetaHeader], destLoc);
+        callback();
+    });
+}
+
+describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
+    this.timeout(250000);
+    withV4(sigCfg => {
+        beforeEach(() => {
+            bucketUtil = new BucketUtility('default', sigCfg);
+            s3 = bucketUtil.s3;
+            const awsConfig = getRealAwsConfig(awsLocation);
+            awsS3 = new AWS.S3(awsConfig);
+            process.stdout.write('Creating bucket\n');
+            if (process.env.ENABLE_KMS_ENCRYPTION === 'true') {
+                s3.createBucketAsync = createEncryptedBucketPromise;
+            }
+            return s3.createBucketAsync({ Bucket: bucket })
+            .catch(err => {
+                process.stdout.write(`Error creating bucket: ${err}\n`);
+                throw err;
+            });
+        });
+
+        afterEach(() => {
+            process.stdout.write('Emptying bucket\n');
+            return bucketUtil.empty(bucket)
+            .then(() => {
+                process.stdout.write('Deleting bucket\n');
+                return bucketUtil.deleteOne(bucket);
+            })
+            .catch(err => {
+                process.stdout.write(`Error in afterEach: ${err}\n`);
+                throw err;
+            });
+        });
+
+        it('should copy an object from mem to AWS', done => {
+            putSourceObj('mem', false, () => {
+                const copyParams = Object.assign({
+                    MetadataDirective: 'REPLACE',
+                    Metadata: {
+                        'scal-location-constraint': 'aws-test',
+                    } }, copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                        'aws-test', copyKey, 'REPLACE', false, done);
+                });
+            });
+        });
+
+        it('should copy an object from AWS to mem', done => {
+            putSourceObj('aws-test', false, () => {
+                const copyParams = Object.assign({
+                    MetadataDirective: 'REPLACE',
+                    Metadata: {
+                        'scal-location-constraint': 'mem',
+                    } }, copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, 'aws-test', copyKey, bucket,
+                        'mem', key, 'REPLACE', false, done);
+                });
+            });
+        });
+
+        it('should copy an object from mem to AWS and retain metadata',
+        done => {
+            putSourceObj('mem', false, () => {
+                const copyParams = Object.assign({
+                    MetadataDirective: 'COPY',
+                    Metadata: {
+                        'scal-location-constraint': 'aws-test',
+                    } }, copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                        'aws-test', copyKey, 'COPY', false, done);
+                });
+            });
+        });
+
+        it('should copy an object on AWS', done => {
+            putSourceObj('aws-test', false, () => {
+                const copyParams = Object.assign({ MetadataDirective: 'COPY' },
+                    copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, 'aws-test', copyKey, bucket,
+                        'aws-test', copyKey, 'COPY', false, done);
+                });
+            });
+        });
+
+        it('should copy a 0-byte object from mem to AWS', done => {
+            putSourceObj('mem', true, () => {
+                const copyParams = Object.assign({ MetadataDirective: 'REPLACE',
+                    Metadata: {
+                        'scal-location-constraint': 'aws-test',
+                    } }, copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${emptyMD5}"`);
+                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                        'aws-test', copyKey, 'REPLACE', true, done);
+                });
+            });
+        });
+
+        it('should copy a 0-byte object on AWS', done => {
+            putSourceObj('aws-test', true, () => {
+                const copyParams = Object.assign({ MetadataDirective: 'COPY' },
+                    copyParamBase);
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${emptyMD5}"`);
+                    assertGetObjects(key, bucket, 'aws-test', copyKey, bucket,
+                        'aws-test', copyKey, 'COPY', true, done);
+                });
+            });
+        });
+
+        it('should return error if AWS source object has ' +
+        'been deleted', done => {
+            putSourceObj('aws-test', false, () => {
+                const awsBucket =
+                    config.locationConstraints[awsLocation].details.bucketName;
+                awsS3.deleteObject({ Bucket: awsBucket, Key: key }, err => {
+                    assert.equal(err, null, 'Error deleting object from AWS: ' +
+                        `${err}`);
+                    const copyParams = { Bucket: bucket, Key: copyKey,
+                        CopySource: `/${bucket}/${key}`,
+                        MetadataDirective: 'COPY',
+                    };
+                    s3.copyObject(copyParams, err => {
+                        assert.strictEqual(err.code, 'InternalError');
+                        done();
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds tests for objectCopy API with AWS backend. ~~Nothing had to be added to the API itself, but~~ a minor change was included because it directly impacted the testing. This is adding an error return on a GET call to AWS.
New features include 0-byte object support and copying objects across backends while retaining all other metadata.