### PR TITLE
[backbeat] bf: sanity check on header presence

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -58,8 +58,16 @@ PUT /_/backbeat/<bucket name>/<object key>/data
 */
 
 function putData(request, response, bucketInfo, objMd, log, callback) {
-    const canonicalID = request.headers['x-scal-canonicalId'];
-    const contentMd5 = request.headers['content-md5'];
+    const canonicalID = request.headers['x-scal-canonical-id'];
+    if (canonicalID === undefined) {
+        log.error('bad request: missing x-scal-canonical-id header');
+        return callback(errors.BadRequest);
+    }
+    const contentMD5 = request.headers['content-md5'];
+    if (contentMD5 === undefined) {
+        log.error('bad request: missing content-md5 header');
+        return callback(errors.BadRequest);
+    }
     const context = {
         bucketName: request.bucketName,
         owner: canonicalID,
@@ -83,7 +91,7 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
             if (err) {
                 return callback(err);
             }
-            if (contentMd5 !== md5) {
+            if (contentMD5 !== md5) {
                 return callback(errors.BadDigest);
             }
             const { key, dataStoreName } = retrievalInfo;


### PR DESCRIPTION
ensure x-scal-canonical-id and content-md5 headers are provided in the `PUT .../data` backbeat route.
