### PR TITLE
FIX: change AWS encryption type

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -32,7 +32,7 @@ class AwsClient {
             ContentLength: size,
         };
         if (keyContext.cipherBundle) {
-            uploadParams.ServerSideEncryption = 'aws:kms';
+            uploadParams.ServerSideEncryption = 'AES256';
         }
 
         return this._client.upload(uploadParams,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put.js
@@ -51,7 +51,7 @@ function awsGetCheck(objectKey, s3MD5, awsMD5, cb) {
             if (process.env.ENABLE_KMS_ENCRYPTION === 'true') {
                 // doesn't check ETag because it's different
                 // with every PUT with encryption
-                assert.strictEqual(res.ServerSideEncryption, 'aws:kms');
+                assert.strictEqual(res.ServerSideEncryption, 'AES256');
             } else {
                 assert.strictEqual(res.ETag, `"${awsMD5}"`);
             }


### PR DESCRIPTION
Changes encryption type used on AWS backend to 'AES256' to match Scality S3 encryption type.