### PR TITLE
Fix BucketFileInterface::internalListObject unit test.

### DIFF
--- a/tests/unit/metadata/bucketfile/backend.js
+++ b/tests/unit/metadata/bucketfile/backend.js
@@ -72,6 +72,11 @@ describe('BucketFileInterface::internalListObject', alldone => {
 
     Object.keys(extensions).forEach(listingType => {
         it(`listing max ${MAX_KEYS} keys using ${listingType}`, done => {
+            if (listingType === 'DelimiterTools') {
+                done();
+                return;
+            }
+
             const params = { listingType, maxKeys: MAX_KEYS };
             // assertion to check if extensions work with maxKeys is in Reader
             bucketfile.internalListObject('foo', params, logger, done);


### PR DESCRIPTION
Since delimiterTools are exported in Arsenal in the algorithms.list
export, the test BucketFileInterface::internalListObject is broken.
This test iterates on all the elements of this export, expected them to
be list constructor.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
