### PR TITLE
RF: Use separate locationConfig.json for testing

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,8 +3,8 @@
     "listenOn": [],
     "replicationGroupId": "RG001",
     "restEndpoints": {
-        "localhost": "file",
-        "127.0.0.1": "file",
+        "localhost": "us-east-1",
+        "127.0.0.1": "us-east-1",
         "s3.docker.test": "us-east-1",
         "127.0.0.2": "us-east-1",
         "s3.amazonaws.com": "us-east-1"

--- a/docs/GETTING_STARTED.rst
+++ b/docs/GETTING_STARTED.rst
@@ -115,7 +115,7 @@ You can run the unit tests with the following command:
 You can run the multiple backend unit tests with:
 
 .. code:: shell
-
+    CI=true S3DATA=multiple npm start
     npm run multiple_backend_test
 
 You can run the linter with:
@@ -125,6 +125,12 @@ You can run the linter with:
     npm run lint
 
 Running functional tests locally:
+
+For the AWS backend and Azure backend tests to pass locally,
+you must modify tests/locationConfigTests.json so that aws-test
+specifies a bucketname of a bucket you have access to based on
+your credentials profile and modify azureTest with details
+for your Azure account.
 
 The test suite requires additional tools, **s3cmd** and **Redis**
 installed in the environment the tests are running in.
@@ -154,8 +160,8 @@ instance port (``6379`` by default)
 
 .. code:: shell
 
-    npm run mem_backend
-    npm run ft_test
+    CI=true npm run mem_backend
+    CI=true npm run ft_test
 
 Configuration
 -------------

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -115,6 +115,10 @@ class Config {
         if (process.env.S3_LOCATION_FILE !== undefined) {
             this.locationConfigPath = process.env.S3_LOCATION_FILE;
         }
+        if (process.env.CI === 'true' && !process.env.S3_END_TO_END) {
+            this.locationConfigPath = path.join(__dirname,
+                '../tests/locationConfigTests.json');
+        }
 
         // Read config automatically
         this._getConfig();

--- a/locationConfig.json
+++ b/locationConfig.json
@@ -4,44 +4,79 @@
         "legacyAwsBehavior": true,
         "details": {}
     },
-    "file": {
+    "us-east-2": {
         "type": "file",
         "legacyAwsBehavior": false,
         "details": {}
     },
-    "dataFile": {
+    "us-west-1": {
         "type": "file",
         "legacyAwsBehavior": false,
         "details": {}
     },
-    "mem": {
-        "type": "mem",
+    "us-west-2": {
+        "type": "file",
         "legacyAwsBehavior": false,
         "details": {}
     },
-    "scality-us-west-1": {
-        "type": "mem",
+    "ca-central-1": {
+        "type": "file",
         "legacyAwsBehavior": false,
         "details": {}
     },
-    "aws-test": {
-        "type": "aws_s3",
-        "legacyAwsBehavior": true,
-        "details": {
-            "awsEndpoint": "s3.amazonaws.com",
-            "bucketName": "multitester555",
-            "bucketMatch": true,
-            "credentialsProfile": "default"
-        }
+    "cn-north-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
     },
-    "azuretest": {
-        "type": "azure",
-        "legacyAwsBehavior": true,
-        "details": {
-          "azureBlobEndpoint": "",
-          "bucketMatch": true,
-          "azureBlobSAS": "",
-          "azureContainerName": "s3test"
-        }
+    "ap-south-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "ap-northeast-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "ap-northeast-2": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "ap-southeast-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "ap-southeast-2": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "eu-central-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "eu-west-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "eu-west-2": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "EU": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "sa-east-1": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "start_dmd": "npm-run-all --parallel start_mdserver start_dataserver",
     "start_utapi": "node lib/utapi/utapi.js",
     "utapi_replay": "node lib/utapi/utapiReplay.js",
-    "test": "S3BACKEND=mem mocha --recursive tests/unit",
-    "multiple_backend_test": "S3BACKEND=mem S3DATA=multiple mocha --recursive tests/multipleBackend",
-    "unit_coverage": "mkdir -p coverage/unit/ && S3BACKEND=mem MOCHA_FILE=$CIRCLE_TEST_REPORTS/unit/unit.xml istanbul cover --dir coverage/unit _mocha -- --reporter mocha-junit-reporter --recursive tests/unit"
+    "test": "CI=true S3BACKEND=mem mocha --recursive tests/unit",
+    "multiple_backend_test": "CI=true S3BACKEND=mem S3DATA=multiple mocha --recursive tests/multipleBackend",
+    "unit_coverage": "CI=true mkdir -p coverage/unit/ && S3BACKEND=mem MOCHA_FILE=$CIRCLE_TEST_REPORTS/unit/unit.xml istanbul cover --dir coverage/unit _mocha -- --reporter mocha-junit-reporter --recursive tests/unit"
   }
 }

--- a/tests/functional/aws-node-sdk/test/bucket/getLocation.js
+++ b/tests/functional/aws-node-sdk/test/bucket/getLocation.js
@@ -88,7 +88,11 @@ describeSkipAWS('GET bucket location ', () => {
                     assert.strictEqual(err, null, 'Error creating bucket: ' +
                         `${err}`);
                     const host = request.service.endpoint.hostname;
-                    const endpoint = config.restEndpoints[host];
+                    let endpoint = config.restEndpoints[host];
+                    // s3 actually returns '' for us-east-1
+                    if (endpoint === 'us-east-1') {
+                        endpoint = '';
+                    }
                     s3.getBucketLocation({ Bucket: bucketName },
                     (err, data) => {
                         assert.strictEqual(err, null, 'Expected succes, ' +

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
@@ -432,7 +432,11 @@ describe('MultipleBackend put based on request endpoint',
                     assert.strictEqual(err, null, 'Expected succes, ' +
                         `got error ${JSON.stringify(err)}`);
                     const host = request.service.endpoint.hostname;
-                    const endpoint = config.restEndpoints[host];
+                    let endpoint = config.restEndpoints[host];
+                    // s3 returns '' for us-east-1
+                    if (endpoint === 'us-east-1') {
+                        endpoint = '';
+                    }
                     s3.getBucketLocation({ Bucket: bucket }, (err, data) => {
                         assert.strictEqual(err, null, 'Expected succes, ' +
                             `got error ${JSON.stringify(err)}`);

--- a/tests/functional/s3cmd/tests.js
+++ b/tests/functional/s3cmd/tests.js
@@ -254,8 +254,13 @@ describe('s3cmd putBucket', () => {
         exec(['mb', `s3://${bucket}`], done);
     });
 
+    // scality-us-west-1 is NOT using legacyAWSBehvior
+    // in test location config and in end to end so this test should
+    // pass by returning error. If legacyAWSBehvior, request
+    // would return a 200
     it('put the same bucket, should fail', done => {
-        exec(['mb', `s3://${bucket}`], done, 13);
+        exec(['mb', `s3://${bucket}`,
+        '--bucket-location=scality-us-west-1'], done, 13);
     });
 
     it('put an invalid bucket, should fail', done => {
@@ -804,10 +809,11 @@ describeSkipIfE2E('If no location is sent with the request', () => {
     afterEach(done => {
         exec(['rb', `s3://${bucket}`], done);
     });
-    // WARNING: change "file" to another locationConstraint depending
+    // WARNING: change "us-east-1" to another locationConstraint depending
     // on the restEndpoints (./config.json)
     it('endpoint should be used to determine the locationConstraint', done => {
-        checkRawOutput(['info', `s3://${bucket}`], 'Location', 'file', 'stdout',
+        checkRawOutput(['info', `s3://${bucket}`], 'Location', 'us-east-1',
+        'stdout',
         foundIt => {
             assert(foundIt);
             done();

--- a/tests/functional/s3curl/tests.js
+++ b/tests/functional/s3curl/tests.js
@@ -187,16 +187,14 @@ describe('s3curl put delete buckets', () => {
                 });
         });
 
-        // note that if the locationContraint[location].legacyAWSBehvior is set
-        // to true, this call will return a 200 in conformance with AWS behavior
-        it('should not be able to put a bucket with a name ' +
+        it('should return 409 error in new regions and 200 in us-east-1 ' +
+            '(legacyAWSBehvior) when try to put a bucket with a name ' +
             'already being used', done => {
-            provideRawOutput(
-                ['--createBucket', '--', bucketPath, '-v'],
-                (httpCode, rawOutput) => {
-                    assert.strictEqual(httpCode, '409 CONFLICT');
-                    assertError(rawOutput.stdout, 'BucketAlreadyOwnedByYou',
-                        done);
+            provideRawOutput(['--createBucket', '--', bucketPath, '-v'],
+                httpCode => {
+                    assert(httpCode === '200 OK'
+                    || httpCode === '409 CONFLICT');
+                    done();
                 });
         });
 

--- a/tests/locationConfigTests.json
+++ b/tests/locationConfigTests.json
@@ -1,0 +1,48 @@
+
+{
+    "us-east-1": {
+        "type": "file",
+        "legacyAwsBehavior": true,
+        "details": {}
+    },
+    "file": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "dataFile": {
+        "type": "file",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "mem": {
+        "type": "mem",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "scality-us-west-1": {
+        "type": "mem",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
+    "aws-test": {
+        "type": "aws_s3",
+        "legacyAwsBehavior": true,
+        "details": {
+            "awsEndpoint": "s3.amazonaws.com",
+            "bucketName": "multitester555",
+            "bucketMatch": true,
+            "credentialsProfile": "default"
+        }
+    },
+    "azuretest": {
+        "type": "azure",
+        "legacyAwsBehavior": true,
+        "details": {
+          "azureBlobEndpoint": "https://mystique.blob.core.fake.net",
+          "bucketMatch": true,
+          "azureBlobSAS": "sv=2015-04-05&sr=b&si=tutorial-policy-635959936345100803&sig=9aCzs76n0E7y5BpEi2GvsSv433BZa22leDOZXX%2BXXIU%3D",
+          "azureContainerName": "s3test"
+        }
+    }
+}

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -410,15 +410,15 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
         });
     });
 
-    it('should not return error on abort of MPU that does not exist', done => {
-        // this is because the S3 default bucket location is 'file' and
-        // legacyAwsBehavior is false
+    it('should return error on abort of MPU that does not exist', done => {
+        // legacyAwsBehavior is true (otherwise, there would be no error)
         const delParams = Object.assign({
             url: `/fakekey?uploadId=${fakeUploadId}`,
             query: { fakeUploadId } }, deleteParams);
         delParams.objectKey = 'fakekey';
         multipartDelete(authInfo, delParams, log, err => {
-            assert.equal(err, null, `Error aborting MPU: ${err}`);
+            assert.equal(err, errors.NoSuchUpload,
+                `Error aborting MPU: ${err}`);
             done();
         });
     });


### PR DESCRIPTION
Separating the locationConfig for testing will make
it easier for users to start s3 server since they will
not have to deal with configuring Azure or AWS backends.
