### PR TITLE
implement dataStoreETag

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -148,8 +148,11 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             // place the retrieval info here into a single element array
             const { key, dataStoreName, dataStoreType, dataStoreETag } =
                 dataGetInfo;
+            const prefixedDataStoreETag = dataStoreETag
+                      ? `1:${dataStoreETag}`
+                      : `1:${calculatedHash}`;
             const dataGetInfoArr = [{ key, size, start: 0, dataStoreName,
-                dataStoreType, dataStoreETag }];
+                dataStoreType, dataStoreETag: prefixedDataStoreETag }];
             if (cipherBundle) {
                 dataGetInfoArr[0].cryptoScheme = cipherBundle.cryptoScheme;
                 dataGetInfoArr[0].cipheredDataKey =

--- a/lib/api/apiUtils/object/storeObject.js
+++ b/lib/api/apiUtils/object/storeObject.js
@@ -29,9 +29,6 @@ function checkHashMatchMD5(stream, hashedStream, dataRetrievalInfo, log, cb) {
         data.batchDelete(dataRetrievalInfo, null, null, log);
         return cb(errors.BadDigest);
     }
-    if (completedHash) {
-        hashedStream.removeAllListeners('hashed');
-    }
     return cb(null, dataRetrievalInfo, completedHash);
 }
 
@@ -71,16 +68,8 @@ function dataStore(objectContext, cipherBundle, stream, size,
             log.trace('dataStore: backend stored key', {
                 dataRetrievalInfo,
             });
-            hashedStream.on('hashed', () => {
-                log.trace('hashed event emitted');
-                return checkHashMatchMD5(stream, hashedStream,
-                    dataRetrievalInfo, log, cb);
-            });
-            if (hashedStream.completedHash) {
-                return checkHashMatchMD5(stream, hashedStream,
-                    dataRetrievalInfo, log, cb);
-            }
-            return undefined;
+            return checkHashMatchMD5(stream, hashedStream,
+                                     dataRetrievalInfo, log, cb);
         });
 }
 

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -300,6 +300,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                                 .toString('hex');
                             partETag = `${buffered}`;
                         }
+                        const dataStoreETag = `${i + 1}:${partETag}`;
                         partETag = `"${partETag}"`;
                         // If the list of parts sent with
                         // the complete multipartupload request contains
@@ -351,6 +352,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                                 size: pieceSize,
                                 start: calculatedSize,
                                 dataStoreName: location.dataStoreName,
+                                dataStoreETag,
                                 cryptoScheme: location.sseCryptoScheme,
                                 cipheredDataKey: location.sseCipheredDataKey,
                             };

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -389,6 +389,7 @@ function objectCopy(authInfo, request, sourceBucket,
                                 key: partRetrievalInfo.key,
                                 dataStoreName: partRetrievalInfo.
                                     dataStoreName,
+                                dataStoreETag: part.dataStoreETag,
                                 start: part.start,
                                 size: part.size,
                             };

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -296,7 +296,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                                     return data.put(cipherBundle, hashedStream,
                                         numberPartSize, dataStoreContext,
                                         backendInfo, log,
-                                        (error, partRetrievalInfo) => {
+                                        (error, partRetrievalInfo,
+                                        hashedStream) => {
                                             if (error) {
                                                 log.debug('error putting ' +
                                                 'encrypted part', { error });
@@ -306,6 +307,8 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                                                 key: partRetrievalInfo.key,
                                                 dataStoreName: partRetrievalInfo
                                                     .dataStoreName,
+                                                dataStoreETag: hashedStream
+                                                    .completedHash,
                                                 // Do not include part start
                                                 // here since will change in
                                                 // final MPU object
@@ -328,7 +331,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                         // without a cipherBundle
                         return data.put(null, hashedStream, numberPartSize,
                         dataStoreContext, backendInfo,
-                        log, (error, partRetrievalInfo) => {
+                        log, (error, partRetrievalInfo, hashedStream) => {
                             if (error) {
                                 log.debug('error putting object part',
                                 { error });
@@ -337,6 +340,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
                             const partResult = {
                                 key: partRetrievalInfo.key,
                                 dataStoreName: partRetrievalInfo.dataStoreName,
+                                dataStoreETag: hashedStream.completedHash,
                                 size: part.size,
                             };
                             locations.push(partResult);

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -68,55 +68,76 @@ function _retryDelete(objectGetInfo, log, count, cb) {
     });
 }
 
+function _put(cipherBundle, value, valueSize,
+              keyContext, backendInfo, log, cb) {
+    assert.strictEqual(typeof valueSize, 'number');
+    log.debug('sending put to datastore', { implName, keyContext,
+                                            method: 'put' });
+    let hashedStream = null;
+    if (value) {
+        hashedStream = new MD5Sum();
+        value.pipe(hashedStream);
+    }
+
+    if (implName === 'multipleBackends') {
+        // Need to send backendInfo to client.put and
+        // client.put will provide dataRetrievalInfo so no
+        // need to construct here
+        /* eslint-disable no-param-reassign */
+        keyContext.cipherBundle = cipherBundle;
+        return client.put(hashedStream,
+               valueSize, keyContext, backendInfo, log.getSerializedUids(),
+               (err, dataRetrievalInfo) => {
+                   if (err) {
+                       log.error('put error from datastore',
+                                 { error: err, implName });
+                       return cb(errors.InternalError);
+                   }
+                   return cb(null, dataRetrievalInfo, hashedStream);
+               });
+    }
+    /* eslint-enable no-param-reassign */
+
+    let writeStream = hashedStream;
+    if (cipherBundle && cipherBundle.cipher) {
+        writeStream = cipherBundle.cipher;
+        hashedStream.pipe(writeStream);
+    }
+
+    return client.put(writeStream, valueSize, keyContext,
+                      log.getSerializedUids(), (err, key) => {
+                          if (err) {
+                              log.error('put error from datastore',
+                                        { error: err, implName });
+                              return cb(errors.InternalError);
+                          }
+                          const dataRetrievalInfo = {
+                              key,
+                              dataStoreName: implName,
+                          };
+                          return cb(null, dataRetrievalInfo, hashedStream);
+                      });
+}
+
 const data = {
     put: (cipherBundle, value, valueSize, keyContext, backendInfo, log, cb) => {
-        assert.strictEqual(typeof valueSize, 'number');
-        log.debug('sending put to datastore', { implName, keyContext,
-                                                method: 'put' });
-        let hashedStream = null;
-        if (value) {
-            hashedStream = new MD5Sum();
-            value.pipe(hashedStream);
-        }
-
-        if (implName === 'multipleBackends') {
-            // Need to send backendInfo to client.put and
-            // client.put will provide dataRetrievalInfo so no
-            // need to construct here
-            /* eslint-disable no-param-reassign */
-            keyContext.cipherBundle = cipherBundle;
-            return client.put(hashedStream,
-                valueSize, keyContext, backendInfo, log.getSerializedUids(),
-                (err, dataRetrievalInfo) => {
-                    if (err) {
-                        log.error('put error from datastore',
-                                 { error: err, implName });
-                        return cb(errors.InternalError);
-                    }
-                    return cb(null, dataRetrievalInfo, hashedStream);
-                });
-        }
-        /* eslint-enable no-param-reassign */
-
-        let writeStream = hashedStream;
-        if (cipherBundle && cipherBundle.cipher) {
-            writeStream = cipherBundle.cipher;
-            hashedStream.pipe(writeStream);
-        }
-
-        return client.put(writeStream, valueSize, keyContext,
-            log.getSerializedUids(), (err, key) => {
-                if (err) {
-                    log.error('put error from datastore',
-                             { error: err, implName });
-                    return cb(errors.InternalError);
-                }
-                const dataRetrievalInfo = {
-                    key,
-                    dataStoreName: implName,
-                };
-                return cb(null, dataRetrievalInfo, hashedStream);
-            });
+        _put(cipherBundle, value, valueSize, keyContext, backendInfo, log,
+             (err, dataRetrievalInfo, hashedStream) => {
+                 if (err) {
+                     return cb(err);
+                 }
+                 if (hashedStream) {
+                     if (hashedStream.completedHash) {
+                         return cb(null, dataRetrievalInfo, hashedStream);
+                     }
+                     hashedStream.on('hashed', () => {
+                         hashedStream.removeAllListeners('hashed');
+                         return cb(null, dataRetrievalInfo, hashedStream);
+                     });
+                     return undefined;
+                 }
+                 return cb(null, dataRetrievalInfo);
+             });
     },
 
     get: (objectGetInfo, response, log, cb) => {

--- a/tests/unit/api/objectGet.js
+++ b/tests/unit/api/objectGet.js
@@ -88,6 +88,7 @@ describe('objectGet API', () => {
                             start: 0,
                             size: 12,
                             dataStoreName: 'mem',
+                            dataStoreETag: `1:${correctMD5}`,
                         }]);
                             done();
                         });
@@ -182,22 +183,28 @@ describe('objectGet API', () => {
                         post: completeBody,
                     };
                     completeMultipartUpload(authInfo, completeRequest,
-                        log, next);
+                                            log, err => {
+                                                next(err, calculatedHash);
+                                            });
                 },
             ],
-            () => {
+            (err, calculatedHash) => {
+                assert.strictEqual(err, null);
                 objectGet(authInfo, testGetRequest, false, log,
                 (err, dataGetInfo) => {
+                    assert.strictEqual(err, null);
                     assert.deepStrictEqual(dataGetInfo,
                         [{
                             key: 1,
                             dataStoreName: 'mem',
+                            dataStoreETag: `1:${calculatedHash}`,
                             size: 5242880,
                             start: 0,
                         },
                         {
                             key: 2,
                             dataStoreName: 'mem',
+                            dataStoreETag: `2:${calculatedHash}`,
                             size: 12,
                             start: 5242880,
                         }]);

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -157,6 +157,7 @@ function putMPU(key, body, cb) {
         partLocations: [{
             key: 1,
             dataStoreName: 'mem',
+            dataStoreETag: `1:${calculatedHash}`,
         }],
         key: partKey,
     };


### PR DESCRIPTION
Each element in the location array contains the ETag of its part.
the Etag is prefixed by the part number followed by a colon (```:```),
this permit to recursively track the origin of the parts in the case of a
multi part object built from multipart object put by copy.