### PR TITLE
FT: add AWS/Azure customize error description

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk');
 const MD5Sum = s3middleware.MD5Sum;
 const createLogger = require('../multipleBackendLogger');
 const { prepareStream } = require('../../api/apiUtils/object/prepareStream');
+const logHelper = require('./utils').logHelper;
 
 class AwsClient {
     constructor(config) {
@@ -41,9 +42,12 @@ class AwsClient {
             return this._client.putObject(uploadParams, err => {
                 if (err) {
                     const log = createLogger(reqUids);
-                    log.error('err from data backend',
-                    { error: err, dataStoreName: this._dataStoreName });
-                    return callback(errors.InternalError);
+                    logHelper(log, 'error', 'err from data backend',
+                      err, this._dataStoreName);
+                    return callback(errors.InternalError
+                      .customizeDescription('Error returned from ' +
+                      `AWS: ${err.message}`)
+                    );
                 }
                 return callback(null, awsKey);
             });
@@ -54,9 +58,12 @@ class AwsClient {
            err => {
                if (err) {
                    const log = createLogger(reqUids);
-                   log.error('err from data backend',
-                   { error: err, dataStoreName: this._dataStoreName });
-                   return callback(errors.InternalError);
+                   logHelper(log, 'error', 'err from data backend',
+                     err, this._dataStoreName);
+                   return callback(errors.InternalError
+                     .customizeDescription('Error returned from ' +
+                     `AWS: ${err.message}`)
+                   );
                }
                return callback(null, awsKey);
            });
@@ -75,8 +82,8 @@ class AwsClient {
               { responseHeaders: response.httpResponse.headers });
         });
         const stream = request.createReadStream().on('error', err => {
-            log.error('error streaming data from AWS', { error: err,
-                dataStoreName: this._dataStoreName });
+            logHelper(log, 'error', 'error streaming data from AWS',
+              err, this._dataStoreName);
             return callback(err);
         });
         return callback(null, stream);
@@ -92,9 +99,12 @@ class AwsClient {
         return this._client.deleteObject(params, err => {
             if (err) {
                 const log = createLogger(reqUids);
-                log.error('error deleting object from datastore',
-                { error: err, implName: this._clientType });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'error deleting object from ' +
+                'datastore', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             return callback();
         });
@@ -139,9 +149,12 @@ class AwsClient {
             Metadata: metaHeaders };
         return this._client.createMultipartUpload(params, (err, mpuResObj) => {
             if (err) {
-                log.error('err from data backend',
-                { error: err, dataStore: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'err from data backend',
+                  err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             return callback(null, mpuResObj);
         });
@@ -164,9 +177,12 @@ class AwsClient {
             PartNumber: partNumber };
         return this._client.uploadPart(params, (err, partResObj) => {
             if (err) {
-                log.error('err from data backend on uploadPart',
-                { error: err.message, dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'err from data backend ' +
+                  'on uploadPart', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             // Because we manually add quotes to ETag later, remove quotes here
             const noQuotesETag =
@@ -188,10 +204,12 @@ class AwsClient {
             PartNumberMarker: partNumberMarker, MaxParts: maxParts };
         return this._client.listParts(params, (err, partList) => {
             if (err) {
-                log.error('err from data backend on listPart',
-                { error: err.message, stack: err.stack,
-                    dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'err from data backend on listPart',
+                  err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             // build storedParts object to mimic Scality S3 backend returns
             const storedParts = {};
@@ -239,24 +257,28 @@ class AwsClient {
         (err, completeMpuRes) => {
             if (err) {
                 if (mpuError[err.code]) {
-                    log.trace('err from data backend on completeMPU',
-                    { error: err,
-                        dataStoreName: this._dataStoreName });
+                    logHelper(log, 'trace', 'err from data backend on ' +
+                    'completeMPU', err, this._dataStoreName);
                     return callback(errors[err.code]);
                 }
-                log.error('err from data backend on completeMPU',
-                { error: err, dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'err from data backend on ' +
+                'completeMPU', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             // need to get content length of new object to store
             // in our metadata
             return this._client.headObject({ Bucket: awsBucket, Key: awsKey },
             (err, objHeaders) => {
                 if (err) {
-                    log.trace('err from data backend on headObject',
-                    { error: err,
-                        dataStoreName: this._dataStoreName });
-                    return callback(errors.InternalError);
+                    logHelper(log, 'trace', 'err from data backend on ' +
+                    'headObject', err, this._dataStoreName);
+                    return callback(errors.InternalError
+                      .customizeDescription('Error returned from ' +
+                      `AWS: ${err.message}`)
+                    );
                 }
                 completeObjData.eTag = completeMpuRes.ETag;
                 completeObjData.contentLength = objHeaders.ContentLength;
@@ -273,10 +295,13 @@ class AwsClient {
         };
         return this._client.abortMultipartUpload(abortParams, err => {
             if (err) {
-                log.error('There was an error aborting the MPU on AWS S3. You' +
-                    ' should abort directly on AWS S3 using the same uploadId.',
-                { error: err, dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'There was an error aborting ' +
+                'the MPU on AWS S3. You should abort directly on AWS S3 ' +
+                'using the same uploadId.', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             return callback();
         });
@@ -297,9 +322,12 @@ class AwsClient {
         });
         return this._client.putObjectTagging(tagParams, err => {
             if (err) {
-                log.error('error from data backend on putObjectTagging',
-                { error: err.message, dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'error from data backend on ' +
+                  'putObjectTagging', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             return callback();
         });
@@ -314,9 +342,12 @@ class AwsClient {
         }
         return this._client.deleteObjectTagging(tagParams, err => {
             if (err) {
-                log.error('error from data backend on deleteObjectTagging',
-                { error: err.message, dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'error from data backend on ' +
+                'deleteObjectTagging', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `AWS: ${err.message}`)
+                );
             }
             return callback();
         });

--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -1,6 +1,7 @@
 const { errors } = require('arsenal');
 const azure = require('azure-storage');
 const createLogger = require('../multipleBackendLogger');
+const logHelper = require('./utils').logHelper;
 
 class AzureClient {
     constructor(config) {
@@ -53,7 +54,6 @@ class AzureClient {
     }
 
     put(stream, size, keyContext, reqUids, callback) {
-        const log = createLogger(reqUids);
         const azureKey = this._createAzureKey(keyContext.bucketName,
             keyContext.objectKey, this._bucketMatch);
         const options = { metadata:
@@ -62,10 +62,13 @@ class AzureClient {
         this._client.createBlockBlobFromStream(this._azureContainerName,
           azureKey, stream, size, options, err => {
               if (err) {
-                  log.error('err from Azure PUT data backend',
-                  { error: err.message, stack: err.stack,
-                    dataStoreName: this._dataStoreName });
-                  return callback(errors.InternalError);
+                  const log = createLogger(reqUids);
+                  logHelper(log, 'error', 'err from Azure PUT data backend',
+                    err, this._dataStoreName);
+                  return callback(errors.InternalError
+                    .customizeDescription('Error returned from ' +
+                    `Azure: ${err.message}`)
+                  );
               }
               return callback(null, azureKey);
           });
@@ -81,9 +84,8 @@ class AzureClient {
           azureStreamingOptions, err => {
               if (err) {
                   const log = createLogger(reqUids);
-                  log.error('err from Azure GET data backend',
-                  { error: err.message, stack: err.stack,
-                    dataStoreName: this._dataStoreName });
+                  logHelper(log, 'error', 'err from Azure GET data backend',
+                    err, this._dataStoreName);
                   return callback(errors.InternalError);
               }
               return callback();
@@ -98,10 +100,11 @@ class AzureClient {
         err => {
             if (err) {
                 const log = createLogger(reqUids);
-                log.error('error deleting object from Azure datastore',
-                { error: err.message, stack: err.stack,
-                  dataStoreName: this._dataStoreName });
-                return callback(errors.InternalError);
+                logHelper(log, 'error', 'error deleting object from ' +
+                  'Azure datastore', err, this._dataStoreName);
+                return callback(errors.InternalError
+                  .customizeDescription('Error returned from ' +
+                  `Azure: ${err.message}`));
             }
             return callback();
         });

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -1,0 +1,8 @@
+const utils = {
+    logHelper(log, level, description, error, dataStoreName) {
+        log[level](description, { error: error.message, stack: error.stack,
+          dataStoreName });
+    },
+};
+
+module.exports = utils;

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -387,7 +387,11 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                     url: `/${objectKey}?uploadId=${uploadId}`,
                     query: { uploadId } }, listRequest);
                 listParts(authInfo, listParams, log, err => {
-                    assert.deepStrictEqual(err, errors.InternalError);
+                    assert.deepStrictEqual(err, errors.InternalError
+                      .customizeDescription('Error returned from AWS: ' +
+                      'The specified upload does not exist. The upload ID ' +
+                      'may be invalid, or the upload may have been aborted ' +
+                      'or completed.'));
                     done();
                 });
             });


### PR DESCRIPTION
This PR includes for all of the Azure and AWS errors a "customizeDescription" so the user will instantly see the AWS/Azure error without having to look in the logs.