### PR TITLE
COMPAT: Set part size as content-length

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -160,6 +160,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                         corsHeaders);
                 }
                 const { start, size } = partObj;
+                responseMetaHeaders['Content-Length'] = size;
                 const partRange = [start, start + size - 1];
                 dataLocator = setPartRanges(dataLocator, partRange);
             } else {

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -29,6 +29,10 @@ function checkError(err, code) {
     assert.strictEqual(err.code, code);
 }
 
+function checkContentLength(contentLengthHeader, expectedSize) {
+    assert.strictEqual(Number.parseInt(contentLengthHeader, 10), expectedSize);
+}
+
 function dateFromNow(diff) {
     const d = new Date();
     d.setHours(d.getHours() + diff);
@@ -690,6 +694,7 @@ describe('GET object', () => {
                         checkNoError(err);
                         return requestGet({ PartNumber: num }, (err, data) => {
                             checkNoError(err);
+                            checkContentLength(data.ContentLength, partSize);
                             const expected = Buffer.alloc(partSize).fill(num);
                             assert.deepStrictEqual(data.Body, expected);
                             return done();
@@ -703,6 +708,7 @@ describe('GET object', () => {
                         checkNoError(err);
                         return requestGet({ PartNumber: num }, (err, data) => {
                             checkNoError(err);
+                            checkContentLength(data.ContentLength, partSize);
                             const expected = Buffer.alloc(partSize)
                                 .fill(unOrderedPartNumbers[num - 1]);
                             assert.deepStrictEqual(data.Body, expected);
@@ -752,6 +758,7 @@ describe('GET object', () => {
                 }, err => {
                     checkNoError(err);
                     return requestGet({ PartNumber: '1' }, (err, data) => {
+                        checkContentLength(data.ContentLength, 10);
                         const expected = new Buffer(10).fill(0);
                         assert.deepStrictEqual(data.Body, expected);
                         done();


### PR DESCRIPTION
For a `getObject` request with a `PartNumber` param specified, we want to return the part's size as content length, and not the entire object's size.