### PR TITLE
FIX: Get obj part when originally copied from MPU

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -154,15 +154,35 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 }
             }
             if (partNumber) {
-                const partObj = objMD.location[partNumber - 1];
-                if (partObj === undefined) {
+                const locations = [];
+                for (let i = 0; i < objMD.location.length; i++) {
+                    const { dataStoreETag } = objMD.location[i];
+                    // Location objects prior to GA7.1 do not include the
+                    // dataStoreETag field so we cannot find the part range
+                    if (dataStoreETag === undefined) {
+                        return callback(errors.NotImplemented
+                            .customizeDescription('PartNumber parameter for ' +
+                            'this object is not supported'));
+                    }
+                    const locationPartNumber =
+                        Number(dataStoreETag.slice(':')[0], 10);
+                    // Get all parts that belong to the requested part number
+                    if (partNumber === locationPartNumber) {
+                        locations.push(objMD.location[i]);
+                    } else if (locationPartNumber > partNumber) {
+                        break;
+                    }
+                }
+                if (locations.length === 0) {
                     return callback(errors.InvalidPartNumber, null,
                         corsHeaders);
                 }
-                const { start, size } = partObj;
-                responseMetaHeaders['Content-Length'] = size;
-                const partRange = [start, start + size - 1];
-                dataLocator = setPartRanges(dataLocator, partRange);
+                const { start } = locations[0];
+                const endLocation = locations[locations.length - 1];
+                const end = endLocation.start + endLocation.size;
+                responseMetaHeaders['Content-Length'] = end - start;
+                const partByteRange = [start, end];
+                dataLocator = setPartRanges(dataLocator, partByteRange);
             } else {
                 dataLocator = setPartRanges(dataLocator, byteRange);
             }


### PR DESCRIPTION
When getting an object's part that was originally copied from an MPU, we need to dynamically search the `objMD.location` array to retrieve all locations that comprise the object part. 

We then use those locations to calculate the byte range which defines the part, return those bytes as the body and set the body size as the content-length.

✅  Tested with `AWS_ON_AIR=true`.