### PR TITLE
ft: propogate redis password from config

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -148,9 +148,15 @@ class Config {
                 'config: invalid host for localCache. host must be a string');
             assert(typeof config.localCache.port === 'number',
                 'config: invalid port for localCache. port must be a number');
+            if (config.localCache.password !== undefined) {
+                assert(this._verifyRedisPassword(config.localCache.password),
+                    'config: invalid password for localCache. password must' +
+                    ' be a string');
+            }
             this.localCache = {
                 host: config.localCache.host,
                 port: config.localCache.port,
+                password: config.localCache.password,
             };
         }
 
@@ -201,6 +207,13 @@ class Config {
                     'bad config: redis.port must be a number');
                 this.utapi.redis.host = config.utapi.redis.host;
                 this.utapi.redis.port = config.utapi.redis.port;
+            }
+            if (config.utapi.redis.password !== undefined) {
+                assert(
+                    this._verifyRedisPassword(config.utapi.redis.password),
+                    'config: invalid password for utapi redis. password' +
+                    ' must be a string');
+                this.utapi.redis.password = config.utapi.redis.password;
             }
             if (config.utapi.metrics) {
                 this.utapi.metrics = config.utapi.metrics;
@@ -379,6 +392,10 @@ class Config {
             metadataPath,
         };
         return config;
+    }
+
+    _verifyRedisPassword(password) {
+        return typeof password === 'string';
     }
 }
 

--- a/lib/RedisClient.js
+++ b/lib/RedisClient.js
@@ -7,11 +7,13 @@ export default class RedisClient {
     * @constructor
     * @param {string} host - Redis host
     * @param {number} port - Redis port
+    * @param {string} password - Redis password
     */
-    constructor(host, port) {
+    constructor(host, port, password) {
         this._client = new Redis({
             host,
             port,
+            password,
         });
         this._client.on('error', err =>
             logger.trace('error from redis', {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -26,7 +26,7 @@ const routeMap = {
 let localCacheClient;
 if (_config.localCache) {
     localCacheClient = new RedisClient(_config.localCache.host,
-        _config.localCache.port);
+        _config.localCache.port, _config.localCache.password);
 }
 // stats client
 const STATS_INTERVAL = 5; // 5 seconds


### PR DESCRIPTION
This commit takes the optional Redis password defined in the config and
propagates the config to localCache and Utapi.