### PR TITLE
fix: update replication configuration format

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -237,24 +237,26 @@ class Config {
                 assert.strictEqual(typeof replicationEndpoint, 'object',
                     'bad config: `replicationEndpoints` property must be an ' +
                     'array of objects');
-                const { name, endpoint } = replicationEndpoint;
-                assert.notStrictEqual(name, undefined, 'bad config: each ' +
+                const { site, servers } = replicationEndpoint;
+                assert.notStrictEqual(site, undefined, 'bad config: each ' +
                     'object of `replicationEndpoints` array must have a ' +
-                    '`name` property');
-                assert.strictEqual(typeof name, 'string', 'bad config: ' +
-                    '`name` property of object in `replicationEndpoints` ' +
+                    '`site` property');
+                assert.strictEqual(typeof site, 'string', 'bad config: ' +
+                    '`site` property of object in `replicationEndpoints` ' +
                     'must be a string');
-                assert.notStrictEqual(name, '', 'bad config: `name` property ' +
+                assert.notStrictEqual(site, '', 'bad config: `site` property ' +
                     "of object in `replicationEndpoints` must not be ''");
-                assert.notStrictEqual(endpoint, undefined, 'bad config: each ' +
-                    'object of `replicationEndpoints` array must have an ' +
-                    '`endpoint` property');
-                assert.strictEqual(typeof endpoint, 'string', 'bad config: ' +
-                    '`endpoint` property of object in `replicationEndpoints` ' +
-                    'must be a string');
-                assert.notStrictEqual(endpoint, '', 'bad config: `endpoint` ' +
-                    'property of object in `replicationEndpoints` must not ' +
-                    "be ''");
+                assert.notStrictEqual(servers, undefined, 'bad config: each ' +
+                    'object of `replicationEndpoints` array must have a ' +
+                    '`servers` property');
+                assert(servers instanceof Array, 'bad config: ' +
+                    '`servers` property of object in `replicationEndpoints` ' +
+                    'must be an array');
+                servers.forEach(item => {
+                    assert(typeof item === 'string' && item !== '',
+                    'bad config: each item of `replicationEndpoints:servers` ' +
+                    'must be a non-empty string');
+                });
             });
             this.replicationEndpoints = replicationEndpoints;
         }


### PR DESCRIPTION
This commit updates the replication configuration format that gets
written to config.json. This format updates the properties from
name/endpoint to site/servers.