### PR TITLE
ft: update Backbeat routes format

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -23,9 +23,9 @@ function normalizeBackbeatRequest(req) {
     req.path = parsedUrl.pathname;
     const pathArr = req.path.split('/');
     req.query = parsedUrl.query;
-    req.bucketName = pathArr[3];
-    req.objectKey = pathArr[4];
-    req.resourceType = pathArr[5];
+    req.resourceType = pathArr[3];
+    req.bucketName = pathArr[4];
+    req.objectKey = pathArr[5];
     /* eslint-enable no-param-reassign */
 }
 
@@ -53,8 +53,8 @@ function _getRequestPayload(req, cb) {
 }
 
 /*
-PUT /_/backbeat/<bucket name>/<object key>/metadata
-PUT /_/backbeat/<bucket name>/<object key>/data
+PUT /_/backbeat/metadata/<bucket name>/<object key>
+PUT /_/backbeat/data/<bucket name>/<object key>
 */
 
 function putData(request, response, bucketInfo, objMd, log, callback) {

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -49,7 +49,7 @@ function makeBackbeatRequest(params, callback) {
         port: 8000,
         method,
         headers,
-        path: `/_/backbeat/${bucket}/${objectKey}/${resourceType}`,
+        path: `/_/backbeat/${resourceType}/${bucket}/${objectKey}`,
         requestBody,
         jsonResponse: true,
     };


### PR DESCRIPTION
This commit updates Backbeat routes format to gain flexibility on
the namespace.