### PR TITLE
Fix batch delete param

### DIFF
--- a/lib/api/apiUtils/object/storeObject.js
+++ b/lib/api/apiUtils/object/storeObject.js
@@ -39,13 +39,14 @@ function checkHashMatchMD5(stream, hashedStream, dataRetrievalInfo, log, cb) {
     const contentMD5 = stream.contentMD5;
     const completedHash = hashedStream.completedHash;
     if (contentMD5 && completedHash && contentMD5 !== completedHash) {
-        log.debug('contentMD5 and completedHash do not match', {
+        log.debug('contentMD5 and completedHash do not match, deleting data', {
             method: 'storeObject::dataStore',
             completedHash,
             contentMD5,
         });
-        log.trace('contentMD5 does not match, deleting data');
-        data.batchDelete(dataRetrievalInfo, log);
+        const dataToDelete = [];
+        dataToDelete.push(dataRetrievalInfo);
+        data.batchDelete(dataToDelete, log);
         return cb(errors.BadDigest);
     }
     if (completedHash) {


### PR DESCRIPTION
batchDelete expects the first param to be an array, but was being passed an object, which caused misleading orphan keys to not be deleted if the completedHash did not match.

Addresses JIRA S3C-709