### PR TITLE
bf: decode URI in backbeat routes

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -17,10 +17,15 @@ auth.setHandler(vault);
 const NAMESPACE = 'default';
 const CIPHER = null; // replication/lifecycle does not work on encrypted objects
 
+function _decodeURI(uri) {
+    // do the same decoding than in S3 server
+    return decodeURIComponent(uri.replace(/\+/g, ' '));
+}
+
 function normalizeBackbeatRequest(req) {
     /* eslint-disable no-param-reassign */
     const parsedUrl = url.parse(req.url, true);
-    req.path = parsedUrl.pathname;
+    req.path = _decodeURI(parsedUrl.pathname);
     const pathArr = req.path.split('/');
     req.query = parsedUrl.query;
     req.resourceType = pathArr[3];


### PR DESCRIPTION
URIs received were not decoded at all in backbeat /data and /metadata
routes, so the object key was keeping the encoded characters
as-is. Then the key was applied a second URL encoding pass in the
target URL, leading to the object being replicated with a different
object key.

Fix by applying the same decoding than in S3 server to the original
URL received, with '+' replaced by ' ' prior to decoding
percent-encoded characters.
