### PR TITLE
FIX: return NotImplemented put version to external data

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -16,6 +16,9 @@ const validateWebsiteHeader = require('./websiteServing')
     .validateWebsiteHeader;
 const externalBackends = constants.externalBackends;
 
+const externalVersioningErrorMessage = 'We do not currently support putting ' +
+'a versioned object to a location-constraint of type AWS or Azure.';
+
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
     metadataStoreParams, dataToDelete, deleteLog, requestMethod, callback) {
@@ -120,10 +123,28 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             callback(backendInfoObj.err);
         });
     }
+
     const backendInfo = backendInfoObj.backendInfo;
     const location = backendInfo.getControllingLocationConstraint();
     const locationType = config.locationConstraints[location].type;
     metadataStoreParams.dataStoreName = location;
+
+    // NOTE: remove the following when we will support putting a
+    // versioned object to a location-constraint of type AWS or Azure.
+    if (locationType && externalBackends[locationType]) {
+        const vcfg = bucketMD.getVersioningConfiguration();
+        const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
+
+        if (isVersionedObj) {
+            log.debug(externalVersioningErrorMessage,
+              { method: 'createAndStoreObject', error: errors.NotImplemented });
+            return process.nextTick(() => {
+                callback(errors.NotImplemented.customizeDescription(
+                  externalVersioningErrorMessage));
+            });
+        }
+    }
+
     /* eslint-disable camelcase */
     const dontSkipBackend = externalBackends;
     /* eslint-enable camelcase */

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -15,6 +15,9 @@ const validateWebsiteHeader = require('./apiUtils/object/websiteServing')
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 
+const externalVersioningErrorMessage = 'We do not currently support putting ' +
+'a versioned object to a location-constraint of type AWS or Azure.';
+
 /*
 Sample xml response:
 <?xml version='1.0' encoding='UTF-8'?>
@@ -201,6 +204,24 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
             (err, dataBackendResObj) => {
                 if (err) {
                     return callback(err);
+                }
+              // NOTE: remove the following when we will support putting a
+              // versioned object to a location-constraint of type AWS or Azure.
+                if (locConstraint &&
+                  config.locationConstraints[locConstraint] &&
+                  config.locationConstraints[locConstraint].type &&
+                  constants.externalBackends[config.locationConstraints
+                    [locConstraint].type]
+                ) {
+                    const vcfg = destinationBucket.getVersioningConfiguration();
+                    const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
+                    if (isVersionedObj) {
+                        log.debug(externalVersioningErrorMessage,
+                        { method: 'multipleBackendGateway',
+                        error: errors.NotImplemented });
+                        return callback(errors.NotImplemented
+                        .customizeDescription(externalVersioningErrorMessage));
+                    }
                 }
                 if (dataBackendResObj) {
                     // dataBackendResObj will be returned in data backend

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -24,6 +24,8 @@ const { config } = require('../Config');
 
 const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
+const externalVersioningErrorMessage = 'We do not currently support putting ' +
+'a versioned object to a location-constraint of type AWS or Azure.';
 
 /**
  * Preps metadata to be saved (based on copy or replace request header)
@@ -307,12 +309,25 @@ function objectCopy(authInfo, request, sourceBucket,
             // also skip if 0 byte object, unless location constraint is an
             // external backend and differs from source, in which case put
             // metadata to backend
-            if (dataLocator.length === 0) {
-                let locationType;
-                if (storeMetadataParams.metaHeaders[locationHeader]) {
-                    locationType = config.locationConstraints
-                        [storeMetadataParams.metaHeaders[locationHeader]].type;
+            let locationType;
+            if (storeMetadataParams.metaHeaders[locationHeader]) {
+                locationType = config.locationConstraints
+                    [storeMetadataParams.metaHeaders[locationHeader]].type;
+            }
+            // NOTE: remove the following when we will support putting a
+            // versioned object to a location-constraint of type AWS or Azure.
+            if (constants.externalBackends[locationType]) {
+                const vcfg = destBucketMD.getVersioningConfiguration();
+                const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
+                if (isVersionedObj) {
+                    log.debug(externalVersioningErrorMessage,
+                    { method: 'multipleBackendGateway',
+                    error: errors.NotImplemented });
+                    return next(errors.NotImplemented.customizeDescription(
+                      externalVersioningErrorMessage), destBucketMD);
                 }
+            }
+            if (dataLocator.length === 0) {
                 if (!storeMetadataParams.locationMatch &&
                 constants.externalBackends[locationType]) {
                     return data.put(null, null, storeMetadataParams.size,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
@@ -7,6 +7,7 @@ const { config } = require('../../../../../../lib/Config');
 const { getRealAwsConfig } = require('../../support/awsConfig');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
+const { versioningEnabled } = require('../../../lib/utility/versioning-util');
 
 const awsLocation = 'aws-test';
 const bucket = 'buckettestmultiplebackendput';
@@ -199,6 +200,24 @@ describe('MultipleBackend put object', function testSuite() {
                     setTimeout(() => {
                         awsGetCheck(key, correctMD5, correctMD5, () => done());
                     }, awsTimeout);
+                });
+            });
+
+            it('should return error NotImplemented putting a ' +
+            'version to AWS', done => {
+                s3.putBucketVersioning({
+                    Bucket: bucket,
+                    VersioningConfiguration: versioningEnabled,
+                }, err => {
+                    assert.equal(err, null, 'Expected success, ' +
+                        `got error ${err}`);
+                    const params = { Bucket: bucket, Key: key,
+                        Body: body,
+                        Metadata: { 'scal-location-constraint': awsLocation } };
+                    s3.putObject(params, err => {
+                        assert.strictEqual(err.code, 'NotImplemented');
+                        done();
+                    });
                 });
             });
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -12,6 +12,7 @@ const azureLocation = 'azuretest';
 const keyObject = 'putazure';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();
+const { versioningEnabled } = require('../../../lib/utility/versioning-util');
 
 const normalBody = Buffer.from('I am a body', 'utf8');
 const normalMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -111,6 +112,26 @@ describeF() {
                             azureGetCheck(this.test.keyName,
                               key.MD5, azureMetadata,
                             () => done()), azureTimeout);
+                    });
+                });
+            });
+
+            it('should return error NotImplemented putting a ' +
+            'version to Azure', function itF(done) {
+                s3.putBucketVersioning({
+                    Bucket: azureContainerName,
+                    VersioningConfiguration: versioningEnabled,
+                }, err => {
+                    assert.equal(err, null, 'Expected success, ' +
+                        `got error ${err}`);
+                    const params = { Bucket: azureContainerName,
+                        Key: this.test.keyName,
+                        Body: normalBody,
+                        Metadata: { 'scal-location-constraint':
+                        azureLocation } };
+                    s3.putObject(params, err => {
+                        assert.strictEqual(err.code, 'NotImplemented');
+                        done();
                     });
                 });
             });


### PR DESCRIPTION
This PR returns error `NotImplemented` when putting a version to external data backend (ie AWS/AZURE)