### PR TITLE
Include bucket, object and version counts in reports

### DIFF
--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -8,6 +8,7 @@ const { config } = require('../../Config');
 
 const errors = arsenal.errors;
 const MetadataFileClient = arsenal.storage.metadata.MetadataFileClient;
+const versionSep = arsenal.versioning.VersioningConstants.VersionId.Separator;
 
 const METASTORE = '__metastore';
 
@@ -311,6 +312,60 @@ class BucketFileInterface {
 
     getDiskUsage(cb) {
         return this.mdDB.getDiskUsage(cb);
+    }
+
+    countItems(log, cb) {
+        const params = {};
+        const extension = new arsenal.algorithms.list.Basic(params, log);
+        const requestParams = extension.genMDParams();
+
+        const res = {
+            objects: 0,
+            versions: 0,
+            buckets: 0,
+        };
+        let cbDone = false;
+
+        this.mdDB.rawListKeys(requestParams, (err, stream) => {
+            if (err) {
+                return cb(err);
+            }
+            stream
+                .on('data', e => {
+                    if (!e.includes(METASTORE)) {
+                        if (e.includes(constants.usersBucket)) {
+                            res.buckets++;
+                        } else {
+                            if (e.includes(versionSep)) {
+                                res.versions++;
+                            } else {
+                                res.objects++;
+                            }
+                        }
+                    }
+                })
+                .on('error', err => {
+                    if (!cbDone) {
+                        cbDone = true;
+                        const logObj = {
+                            error: err,
+                            errorMessage: err.message,
+                            errorStack: err.stack,
+                        };
+                        log.error('error listing objects', logObj);
+                        cb(errors.InternalError);
+                    }
+                })
+                .on('end', () => {
+                    if (!cbDone) {
+                        cbDone = true;
+                        return cb(null, res);
+                    }
+                    return undefined;
+                });
+            return undefined;
+        });
+        return undefined;
     }
 }
 

--- a/lib/metadata/wrapper.js
+++ b/lib/metadata/wrapper.js
@@ -227,6 +227,18 @@ const metadata = {
         }
         return client.getDiskUsage(cb);
     },
+
+    countItems: (log, cb) => {
+        if (!client.countItems) {
+            log.debug('returning zero item counts as fallback', { implName });
+            return cb(null, {
+                buckets: 0,
+                objects: 0,
+                versions: 0,
+            });
+        }
+        return client.countItems(log, cb);
+    },
 };
 
 module.exports = metadata;

--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -22,6 +22,26 @@ function isAuthorized(clientIP, req) {
         req.headers['x-scal-report-token'] === config.reportToken;
 }
 
+const itemScanRefreshDelay = 1000 * 30 * 60; // 30 minutes
+let lastItemScanTime = undefined;
+let lastItemScanResult = undefined;
+
+function countItems(log, cb) {
+    // The value is cached, as scanning all the dataset can be I/O intensive
+    if (lastItemScanTime === undefined ||
+        (Date.now() - lastItemScanTime) > itemScanRefreshDelay) {
+        return metadata.countItems(log, (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            lastItemScanTime = Date.now();
+            lastItemScanResult = res;
+            return cb(null, res);
+        });
+    }
+    return process.nextTick(cb, null, lastItemScanResult);
+}
+
 function getGitVersion(cb) {
     fs.readFile('.git/HEAD', 'ascii', (err, val) => {
         if (err && err.code === 'ENOENT') {
@@ -97,6 +117,7 @@ function reportHandler(clientIP, req, res, log) {
         getMDDiskUsage: cb => metadata.getDiskUsage(log, cb),
         getDataDiskUsage: cb => data.getDiskUsage(log, cb),
         getVersion: cb => getGitVersion(cb),
+        getObjectCount: cb => countItems(log, cb),
     },
     (err, results) => {
         if (err) {
@@ -113,6 +134,7 @@ function reportHandler(clientIP, req, res, log) {
                 dataDiskUsage: results.getDataDiskUsage,
                 serverVersion: results.getVersion,
                 systemStats: getSystemStats(),
+                itemCounts: results.getObjectCount,
 
                 config: cleanup(config),
             };

--- a/tests/functional/report/checkRoutes.js
+++ b/tests/functional/report/checkRoutes.js
@@ -13,6 +13,7 @@ const reportAttributes = [
     'dataDiskUsage',
     'serverVersion',
     'systemStats',
+    'itemCounts',
 ];
 
 function options(token = 'report-token-1') {


### PR DESCRIPTION
This change adds object, bucket and version counts to the report handler. Only implemented for bucketfile, which counts by inspecting all keys in the root DB.