### PR TITLE
FX: external backend ENCRYPTION

### DIFF
--- a/docs/ARCHITECTURE.rst
+++ b/docs/ARCHITECTURE.rst
@@ -937,3 +937,53 @@ Algorithms
 The algorithms for each listing type can be found in the open-source
 `scality/Arsenal <https://github.com/scality/Arsenal>`__ repository, in
 `lib/algos/list <https://github.com/scality/Arsenal/tree/master/lib/algos/list>`__.
+
+Encryption
+===========
+
+With CloudServer, there are two possible methods of at-rest encryption.
+(1) We offer bucket level encryption where Scality CloudServer itself handles at-rest
+encryption for any object that is in an 'encrypted' bucket, regardless of what
+the location-constraint for the data is and
+(2) If the location-constraint specified for the data is of type AWS,
+you can choose to use AWS server side encryption.
+
+Note: bucket level encryption is not available on the standard AWS
+S3 protocol, so normal AWS S3 clients will not provide the option to send a
+header when creating a bucket. We have created a simple tool to enable you
+to easily create an encrypted bucket.
+
+Example:
+--------
+
+Creating encrypted bucket using our encrypted bucket tool in the bin directory
+
+.. code:: shell
+
+    ./create_encrypted_bucket.js -a accessKey1 -k verySecretKey1 -b bucketname -h localhost -p 8000
+
+
+AWS backend
+------------
+
+With real AWS S3 as a location-constraint, you have to configure the
+location-constraint as follows
+
+.. code:: json
+
+    "aws-test": {
+        "type": "aws_s3",
+        "legacyAwsBehavior": true,
+        "details": {
+            "serverSideEncryption": true,
+            ...
+        }
+    },
+
+Then, every time an object is put to that data location, we pass the following
+header to AWS: ``x-amz-server-side-encryption: AES256``
+
+Note: due to these options, it is possible to configure encryption by both
+CloudServer and AWS S3 (if you put an object to a CloudServer bucket which has
+the encryption flag AND the location-constraint for the data is AWS S3 with
+serverSideEncryption set to true).

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -57,6 +57,12 @@ function locationConstraintAssert(locationConstraints) {
             === 'boolean',
             'bad config: locationConstraints[region]' +
             '.legacyAwsBehavior is mandatory and must be a boolean');
+        if (locationConstraints[l].details.serverSideEncryption !== undefined) {
+            assert(typeof locationConstraints[l].details.serverSideEncryption
+              === 'boolean',
+              'bad config: locationConstraints[region]' +
+              '.details.serverSideEncryption must be a boolean');
+        }
         assert(typeof locationConstraints[l].details
             === 'object',
             'bad config: locationConstraints[region].details is ' +

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -11,6 +11,7 @@ class AwsClient {
         this._awsBucketName = config.awsBucketName;
         this._bucketMatch = config.bucketMatch;
         this._dataStoreName = config.dataStoreName;
+        this._serverSideEncryption = config.serverSideEncryption;
         this._client = new AWS.S3(this._s3Params);
     }
 
@@ -31,7 +32,7 @@ class AwsClient {
             Metadata: keyContext.metaHeaders,
             ContentLength: size,
         };
-        if (keyContext.cipherBundle) {
+        if (this._serverSideEncryption) {
             uploadParams.ServerSideEncryption = 'AES256';
         }
         if (keyContext.tagging) {

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -68,6 +68,7 @@ function parseLC() {
                 s3Params,
                 awsBucketName: locationObj.details.bucketName,
                 bucketMatch: locationObj.details.bucketMatch,
+                serverSideEncryption: locationObj.details.serverSideEncryption,
                 dataStoreName: location,
             });
             clients[location].clientType = 'aws_s3';

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -25,11 +25,9 @@ const multipleBackendGateway = {
         }
 
         let writeStream = hashedStream;
-        if (client.clientType !== 'aws_s3') {
-            if (keyContext.cipherBundle && keyContext.cipherBundle.cipher) {
-                writeStream = keyContext.cipherBundle.cipher;
-                hashedStream.pipe(writeStream);
-            }
+        if (keyContext.cipherBundle && keyContext.cipherBundle.cipher) {
+            writeStream = keyContext.cipherBundle.cipher;
+            hashedStream.pipe(writeStream);
         }
 
         if (keyContext.tagging) {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "start_utapi": "node lib/utapi/utapi.js",
     "utapi_replay": "node lib/utapi/utapiReplay.js",
     "test": "CI=true S3BACKEND=mem mocha --recursive tests/unit",
-    "multiple_backend_test": "CI=true S3BACKEND=mem S3DATA=multiple mocha --recursive tests/multipleBackend",
+    "multiple_backend_test": "CI=true S3BACKEND=mem S3DATA=multiple mocha -t 20000 --recursive tests/multipleBackend",
     "unit_coverage": "CI=true mkdir -p coverage/unit/ && S3BACKEND=mem MOCHA_FILE=$CIRCLE_TEST_REPORTS/unit/unit.xml istanbul cover --dir coverage/unit _mocha -- --reporter mocha-junit-reporter --recursive tests/unit"
   }
 }

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging.js
@@ -154,6 +154,9 @@ function mpuWaterfall(params, cb) {
 
 describeSkipIfNotMultiple('Object tagging with multiple backends',
 function testSuite() {
+    if (!process.env.S3_END_TO_END) {
+        this.retries(2);
+    }
     this.timeout(80000);
     withV4(sigCfg => {
         beforeEach(() => {

--- a/tests/locationConfigTests.json
+++ b/tests/locationConfigTests.json
@@ -25,6 +25,17 @@
         "legacyAwsBehavior": false,
         "details": {}
     },
+    "aws-test-encryption": {
+        "type": "aws_s3",
+        "legacyAwsBehavior": true,
+        "details": {
+            "awsEndpoint": "s3.amazonaws.com",
+            "bucketName": "multitester555",
+            "bucketMatch": true,
+            "credentialsProfile": "default",
+            "serverSideEncryption": true
+        }
+    },
     "aws-test": {
         "type": "aws_s3",
         "legacyAwsBehavior": true,

--- a/tests/multipleBackend/backendHealthcheckResponse.js
+++ b/tests/multipleBackend/backendHealthcheckResponse.js
@@ -17,11 +17,16 @@ describe('Healthcheck response', () => {
         });
     });
     it('should return result for every location constraint in ' +
-    'locationConfig', done => {
+    'locationConfig and at least one of every external locations', done => {
         clientCheck(log, (err, results) => {
             locConstraints.forEach(constraint => {
-                assert.notEqual(Object.keys(results).
-                    indexOf(constraint), -1);
+                if (Object.keys(results).indexOf(constraint) === -1) {
+                    const locationType = config.locationConstraints
+                    [constraint].type;
+                    assert(Object.keys(results).some(result =>
+                      config.locationConstraints[result].type
+                        === locationType));
+                }
             });
             done();
         });


### PR DESCRIPTION
In s3server we have bucket level encryption. 
AWS S3 has object level encryption. 
When we did the AWS backend on s3server, we decided to rely on AWS S3's object level encryption (instead of our own) so that encrypted objects would be readable if accessed directly from AWS S3. Now that we are bringing Azure into the picture, this gets complicated since Azure encryption is at the account level and s3server will not be messing with the account level settings.  

To make things consistent and to best carry-out the intent of users:

1) If a user creates an encrypted bucket, we always do the encryption on a put to this bucket (even if going to the azure or aws backends).

2) When setting up a locationConfig entry for the aws backend, we will allow them to set an option of "serverSideEncryption: true".  If they set this option, any time we put to this location constraint, we will send the appropriate headers to AWS so that they encrypt.

NOTE: I could not find any documentation about the CloudServer Encryption 