### PR TITLE
bf: refuse backbeat PUT if bucket is not versioned

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -201,6 +201,15 @@ function routeBackbeat(clientIP, request, response, log) {
                                              request.resourceType });
                 return next(errors.MethodNotAllowed);
             }
+            const versioningConfig = bucketInfo.getVersioningConfiguration();
+            if (!versioningConfig || versioningConfig.Status !== 'Enabled') {
+                log.debug('bucket versioning is not enabled',
+                          { method: request.method,
+                            bucketName: request.bucketName,
+                            objectKey: request.objectKey,
+                            resourceType: request.resourceType });
+                return next(errors.InvalidBucketState);
+            }
             return backbeatRoutes[request.method][request.resourceType](
                 request, response, bucketInfo, objMd, log, next);
         }],


### PR DESCRIPTION
Both data and metadata routes now return InvalidBucketState (as HTTP 409)
if bucket versioning is not enabled, to prevent various issues linked with
putting versions on a non-versioned bucket.
