### PR TITLE
FT: Allow updating account data on the fly

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { EventEmitter } = require('events');
 const fs = require('fs');
 const path = require('path');
 
@@ -104,8 +105,9 @@ function cosParse(chordCos) {
 /**
  * Reads from a config file and returns the content as a config object
  */
-class Config {
+class Config extends EventEmitter {
     constructor() {
+        super();
         /*
          * By default, the config file is "config.json" at the root.
          * It can be overridden using the S3_CONFIG_FILE environment var.
@@ -722,11 +724,17 @@ class Config {
     _verifyRedisPassword(password) {
         return typeof password === 'string';
     }
+
+    setAuthDataAccounts(accounts) {
+        this.authData.accounts = accounts;
+        this.emit('authdata-update');
+    }
 }
 
 module.exports = {
     sproxydAssert,
     locationConstraintAssert,
     cosParse,
+    ConfigObject: Config,
     config: new Config(),
 };

--- a/lib/auth/vault.js
+++ b/lib/auth/vault.js
@@ -9,6 +9,9 @@ let client;
 let implName;
 
 if (config.backends.auth === 'mem') {
+    config.on('authdata-update', () => {
+        backend.refreshAuthData(config.authData);
+    });
     client = backend;
     implName = 'vaultMem';
 } else {

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -3,4 +3,18 @@ describe('Config', () => {
         require('../../lib/Config');
         done();
     });
+
+    it('should emit an event when auth data is updated', done => {
+        const { ConfigObject } = require('../../lib/Config');
+        const config = new ConfigObject();
+        let emitted = false;
+        config.on('authdata-update', () => {
+            emitted = true;
+        });
+        config.setAuthDataAccounts([]);
+        if (emitted) {
+            return done();
+        }
+        return done(new Error('authdata-update event was not emitted'));
+    });
 });


### PR DESCRIPTION
This allows dynamically updating the accounts portion of the in-memory auth backend data, by calling `config.setAuthDataAccounts(accounts)` with an account list as defined in conf/authdata.json.