### PR TITLE
provide pushMetric with objects

### DIFF
--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -523,6 +523,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         pushMetric('completeMultipartUpload', log, {
             authInfo,
             bucket: bucketName,
+            keys: [objectKey],
         });
         return callback(null, xml, resHeaders);
     });

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -170,6 +170,7 @@ function initiateMultipartUpload(authInfo, request, log, callback) {
                         pushMetric('initiateMultipartUpload', log, {
                             authInfo,
                             bucket: bucketName,
+                            keys: [objectKey],
                         });
                         return callback(null, xml, corsHeaders);
                     });

--- a/lib/api/multiObjectDelete.js
+++ b/lib/api/multiObjectDelete.js
@@ -480,9 +480,11 @@ function multiObjectDelete(authInfo, request, log, callback) {
         }
         const xml = _formatXML(quietSetting, errorResults,
             successfullyDeleted);
+        const deletedKeys = successfullyDeleted.map(item => item.key);
         pushMetric('multiObjectDelete', log, {
             authInfo,
             bucket: bucketName,
+            keys: deletedKeys,
             byteLength: totalContentLengthDeleted,
             numberOfObjects: numOfObjectsRemoved,
         });

--- a/lib/api/multipartDelete.js
+++ b/lib/api/multipartDelete.js
@@ -145,6 +145,7 @@ function multipartDelete(authInfo, request, log, callback) {
                     pushMetric('abortMultipartUpload', log, {
                         authInfo,
                         bucket: bucketName,
+                        keys: [objectKey],
                         byteLength: partSizeSum,
                     });
                     return next(null, destBucket);

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -551,6 +551,7 @@ function objectCopy(authInfo, request, sourceBucket,
         pushMetric('copyObject', log, {
             authInfo,
             bucket: destBucketName,
+            keys: [destObjectKey],
             newByteLength: sourceObjSize,
             oldByteLength: isVersioned ? null : destObjPrevSize,
         });

--- a/lib/api/objectDelete.js
+++ b/lib/api/objectDelete.js
@@ -141,13 +141,14 @@ function objectDelete(authInfo, request, log, cb) {
                     result.versionId : versionIdUtils.encode(result.versionId);
             }
             pushMetric('putDeleteMarkerObject', log, { authInfo,
-                bucket: bucketName });
+                bucket: bucketName, keys: [objectKey] });
         } else {
             log.end().addDefaultFields({
                 contentLength: objectMD['content-length'],
             });
             pushMetric('deleteObject', log, { authInfo, bucket: bucketName,
-                byteLength: objectMD['content-length'], numberOfObjects: 1 });
+                keys: [objectKey], byteLength: objectMD['content-length'],
+                numberOfObjects: 1 });
         }
         return cb(err, resHeaders);
     });

--- a/lib/api/objectDeleteTagging.js
+++ b/lib/api/objectDeleteTagging.js
@@ -97,6 +97,7 @@ function objectDeleteTagging(authInfo, request, log, callback) {
             pushMetric('deleteObjectTagging', log, {
                 authInfo,
                 bucket: bucketName,
+                keys: [objectKey],
             });
             const verCfg = bucket.getVersioningConfiguration();
             additionalResHeaders['x-amz-version-id'] =

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -114,6 +114,7 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             pushMetric('putObject', log, {
                 authInfo,
                 bucket: bucketName,
+                keys: [objectKey],
                 newByteLength,
                 oldByteLength: isVersionedObj ? null : oldByteLength,
             });

--- a/lib/api/objectPutACL.js
+++ b/lib/api/objectPutACL.js
@@ -299,6 +299,7 @@ function objectPutACL(authInfo, request, log, cb) {
         pushMetric('putObjectAcl', log, {
             authInfo,
             bucket: bucketName,
+            keys: [objectKey],
         });
         return cb(null, resHeaders);
     });

--- a/lib/api/objectPutCopyPart.js
+++ b/lib/api/objectPutCopyPart.js
@@ -453,6 +453,7 @@ function objectPutCopyPart(authInfo, request, sourceBucket,
         // TODO push metric for objectPutCopyPart
         // pushMetric('putObjectCopyPart', log, {
         //      bucket: destBucketName,
+        //      keys: [objectKey],
         // });
         return callback(null, xml, additionalHeaders);
     });

--- a/lib/api/objectPutPart.js
+++ b/lib/api/objectPutPart.js
@@ -340,6 +340,7 @@ function objectPutPart(authInfo, request, streamingV4Params, log,
         pushMetric('uploadPart', log, {
             authInfo,
             bucket: bucketName,
+            keys: [objectKey],
             newByteLength: size,
             oldByteLength: prevObjectSize,
         });

--- a/lib/api/objectPutTagging.js
+++ b/lib/api/objectPutTagging.js
@@ -104,6 +104,7 @@ function objectPutTagging(authInfo, request, log, callback) {
             pushMetric('putObjectTagging', log, {
                 authInfo,
                 bucket: bucketName,
+                keys: [objectKey],
             });
             const verCfg = bucket.getVersioningConfiguration();
             additionalResHeaders['x-amz-version-id'] =

--- a/lib/utapi/utilities.js
+++ b/lib/utapi/utilities.js
@@ -193,10 +193,11 @@ function listMetrics(metricType) {
  * @return {function} - `utapi.pushMetric`
  */
 function pushMetric(action, log, metricObj) {
-    const { bucket, byteLength, newByteLength, oldByteLength, numberOfObjects,
-        authInfo } = metricObj;
+    const { bucket, keys, byteLength, newByteLength,
+            oldByteLength, numberOfObjects, authInfo } = metricObj;
     const utapiObj = {
         bucket,
+        keys,
         byteLength,
         newByteLength,
         oldByteLength,


### PR DESCRIPTION
Provide pushMetric with objects on the methods with storage side effects

The purpose of this PR is to permit other services accessing the same data set to keep their states consistent