### PR TITLE
ft: add endpoint for backbeat w/ docker swarm

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
     "restEndpoints": {
         "localhost": "us-east-1",
         "127.0.0.1": "us-east-1",
+        "cloudserver-front": "us-east-1",
         "s3.docker.test": "us-east-1",
         "127.0.0.2": "us-east-1",
         "s3.amazonaws.com": "us-east-1"


### PR DESCRIPTION
Add a static endpoint named cloudserver-front, which backbeat uses to
contact the local S3 when deployed with docker swarm.
