### PR TITLE
Chore: eslint modules upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bluebird": "^3.3.1",
     "eslint": "4.6.0",
     "eslint-config-airbnb-base": "12.0.0",
-    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-config-scality": "scality/Guidelines",
     "eslint-plugin-import": "2.7.0",
     "istanbul": "1.0.0-alpha.2",
     "istanbul-api": "1.0.0-alpha.13",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
   },
   "devDependencies": {
     "bluebird": "^3.3.1",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.0",
-    "eslint-config-scality": "scality/Guidelines",
+    "eslint": "4.6.0",
+    "eslint-config-airbnb-base": "12.0.0",
+    "eslint-config-scality": "scality/Guidelines#chore/upgradeEslint",
+    "eslint-plugin-import": "2.7.0",
     "istanbul": "1.0.0-alpha.2",
     "istanbul-api": "1.0.0-alpha.13",
     "lolex": "^1.4.0",


### PR DESCRIPTION
Eslint upgrade will be in 2 steps:
- First add lint changes, drop package version changes and make sure new linter changes are compatible with the old eslint versions.
- Second, add this PR that has the version upgrades and merge after confirming first PR changes convert nicely

This should be merged after https://github.com/scality/S3/pull/895