### PR TITLE
FIX: COPY-AWS: using datastore key

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -40,7 +40,7 @@ const externalVersioningErrorMessage = 'We do not currently support putting ' +
  * @param {object} log - logger object
  * @return {object}
  * - (storeMetadataParams
- * - sourceLocation {string} - location type of the source
+ * - sourceLocationConstraintName {string} - location type of the source
  * - OR error
  */
 function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
@@ -98,10 +98,10 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
     if (whichMetadata === 'COPY' && headers[locationHeader]) {
         userMetadata[locationHeader] = headers[locationHeader];
     }
-    const sourceLocation = sourceObjMD[locationHeader];
+    const sourceLocationConstraintName = sourceObjMD[locationHeader];
     // If location constraint header is not included, locations match
     const locationMatch = headers[locationHeader] ?
-        sourceLocation === headers[locationHeader] : true;
+        sourceLocationConstraintName === headers[locationHeader] : true;
 
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will
@@ -149,7 +149,7 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
     if (!storeMetadataParams.contentType) {
         storeMetadataParams.contentType = sourceObjMD['content-type'];
     }
-    return { storeMetadataParams, sourceLocation };
+    return { storeMetadataParams, sourceLocationConstraintName };
 }
 
 /**
@@ -261,7 +261,7 @@ function objectCopy(authInfo, request, sourceBucket,
                         return next(errors.PreconditionFailed, destBucketMD);
                     }
                     const { storeMetadataParams, error: metadataError,
-                    sourceLocation } =
+                    sourceLocationConstraintName } =
                         _prepMetadata(sourceObjMD, request.headers,
                             sourceIsDestination, authInfo, destObjectKey,
                             destBucketMD, log);
@@ -293,11 +293,11 @@ function objectCopy(authInfo, request, sourceBucket,
                         }
                     }
                     return next(null, storeMetadataParams, dataLocator,
-                        destBucketMD, destObjMD, sourceLocation);
+                        destBucketMD, destObjMD, sourceLocationConstraintName);
                 });
         },
         function goGetData(storeMetadataParams, dataLocator, destBucketMD,
-            destObjMD, sourceLocation, next) {
+            destObjMD, sourceLocationConstraintName, next) {
             const serverSideEncryption = destBucketMD.getServerSideEncryption();
 
             const backendInfoObj = locationConstraintCheck(request,
@@ -363,7 +363,7 @@ function objectCopy(authInfo, request, sourceBucket,
             // NOTE: using copyObject only if copying object from one external
             // backend to the same external backend
             const locationTypeMatch = request.headers[locationHeader] ?
-            config.locationConstraints[sourceLocation].type ===
+            config.locationConstraints[sourceLocationConstraintName].type ===
             config.locationConstraints[request.headers[locationHeader]].type
             : true;
             if (locationTypeMatch &&
@@ -372,8 +372,9 @@ function objectCopy(authInfo, request, sourceBucket,
                 const location = storeMetadataParams
                 .metaHeaders[locationHeader];
                 const objectGetInfo = dataLocator[0];
+                const externalSourceKey = objectGetInfo.key;
                 return multipleBackendGateway.copyObject(request, location,
-                sourceBucket, sourceObject, sourceLocation, log,
+                externalSourceKey, sourceLocationConstraintName, log,
                 (error, objectRetrievalInfo) => {
                     if (error) {
                         return next(error, destBucketMD);

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -359,26 +359,23 @@ class AwsClient {
             return callback();
         });
     }
-    copyObject(request, sourceBucketName, sourceObjectKey, sourceLocation,
-    log, callback) {
+    copyObject(request, sourceKey, sourceLocationConstraintName, log,
+    callback) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
         const destAwsKey = this._createAwsKey(destBucketName, destObjectKey,
           this._bucketMatch);
 
-        const sourceBucketMatch =
-        config.locationConstraints[sourceLocation].details.bucketMatch;
         const sourceAwsBucketName =
-        config.locationConstraints[sourceLocation].details.bucketName;
-        const sourceAwsKey = this._createAwsKey(sourceBucketName,
-          sourceObjectKey, sourceBucketMatch);
+        config.locationConstraints[sourceLocationConstraintName]
+        .details.bucketName;
 
         const metadataDirective = request.headers['x-amz-metadata-directive'];
         const metaHeaders = trimXMetaPrefix(getMetaHeaders(request.headers));
         this._client.copyObject({
             Bucket: this._awsBucketName,
             Key: destAwsKey,
-            CopySource: `${sourceAwsBucketName}/${sourceAwsKey}`,
+            CopySource: `${sourceAwsBucketName}/${sourceKey}`,
             Metadata: metaHeaders,
             MetadataDirective: metadataDirective,
         }, err => {

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -228,12 +228,12 @@ const multipleBackendGateway = {
 
     // NOTE: using copyObject only if copying object from one external
     // backend to the same external backend
-    copyObject: (request, location, sourceBucket, sourceObject,
-    sourceLocation, log, cb) => {
+    copyObject: (request, location, externalSourceKey,
+    sourceLocationConstraintName, log, cb) => {
         const client = clients[location];
         if (client.copyObject) {
-            return client.copyObject(request, sourceBucket, sourceObject,
-            sourceLocation, log, (err, key) => {
+            return client.copyObject(request, externalSourceKey,
+            sourceLocationConstraintName, log, (err, key) => {
                 const dataRetrievalInfo = {
                     key,
                     dataStoreName: location,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy.js
@@ -11,6 +11,7 @@ const { createEncryptedBucketPromise } =
 
 const awsLocation = 'aws-test';
 const awsLocation2 = 'aws-test-2';
+const awsLocationMismatch = 'aws-test-mismatch';
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -278,6 +279,32 @@ function testSuite() {
                         `"${correctMD5}"`);
                     assertGetObjects(key, bucket, awsLocation, copyKey, bucket,
                         awsLocation, copyKey, 'COPY', false, awsS3,
+                        awsLocation, done);
+                });
+            });
+        });
+
+        it('should copy an object on AWS location with bucketMatch equals ' +
+        'false to a different AWS location with bucketMatch equals true',
+        done => {
+            putSourceObj(awsLocationMismatch, false, key => {
+                const copyKey = `copyKey-${Date.now()}`;
+                const copyParams = {
+                    Bucket: bucket,
+                    Key: copyKey,
+                    CopySource: `/${bucket}/${key}`,
+                    MetadataDirective: 'REPLACE',
+                    Metadata: {
+                        'scal-location-constraint': awsLocation },
+                };
+                process.stdout.write('Copying object\n');
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, awsLocationMismatch, copyKey,
+                        bucket, awsLocation, copyKey, 'REPLACE', false, awsS3,
                         awsLocation, done);
                 });
             });

--- a/tests/locationConfigTests.json
+++ b/tests/locationConfigTests.json
@@ -46,6 +46,16 @@
             "credentialsProfile": "default"
         }
     },
+    "aws-test-mismatch": {
+        "type": "aws_s3",
+        "legacyAwsBehavior": true,
+        "details": {
+            "awsEndpoint": "s3.amazonaws.com",
+            "bucketName": "multitester555",
+            "bucketMatch": false,
+            "credentialsProfile": "default"
+        }
+    },
     "aws-test-2": {
         "type": "aws_s3",
         "legacyAwsBehavior": true,


### PR DESCRIPTION
Do not need to re-create the source key name if we get it directly from metadata.location info :) 