### PR TITLE
ft: add tests for bucketMatch false

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
@@ -15,6 +15,7 @@ const awsObject = `awsobject-${Date.now()}`;
 const emptyObject = `emptyObject-${Date.now()}`;
 const emptyAwsObject = `emptyObject-${Date.now()}`;
 const bigObject = `bigObject-${Date.now()}`;
+const mismatchObject = `mismatch-${Date.now()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -290,6 +291,26 @@ describe('Multiple backend get object', function testSuite() {
                         assert.strictEqual(err.code, 'NetworkingError');
                         done();
                     });
+                });
+            });
+        });
+
+        describeSkipIfNotMultiple('with bucketMatch set to false', () => {
+            beforeEach(done => {
+                s3.putObject({ Bucket: bucket, Key: mismatchObject, Body: body,
+                Metadata: { 'scal-location-constraint': awsLocationMismatch } },
+                err => {
+                    assert.equal(err, null, `Err putting object: ${err}`);
+                    done();
+                });
+            });
+
+            it('should get an object from AWS', done => {
+                s3.getObject({ Bucket: bucket, Key: mismatchObject },
+                (err, res) => {
+                    assert.equal(err, null, `Error getting object: ${err}`);
+                    assert.strictEqual(res.ETag, `"${correctMD5}"`);
+                    done();
                 });
             });
         });


### PR DESCRIPTION
Adds tests for the get and delete APIs when bucketMatch = false, which was handled but not tested.