### PR TITLE
FT: Make REST endpoint mapping dynamic

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -40,6 +40,17 @@ function sproxydAssert(configSproxyd) {
     return sproxydFields;
 }
 
+function restEndpointsAssert(restEndpoints, locationConstraints) {
+    assert(typeof restEndpoints === 'object',
+        'bad config: restEndpoints must be an object of endpoints');
+    assert(Object.keys(restEndpoints).every(
+        r => typeof restEndpoints[r] === 'string'),
+        'bad config: each endpoint must be a string');
+    assert(Object.keys(restEndpoints).every(
+        r => typeof locationConstraints[restEndpoints[r]] === 'object'),
+        'bad config: rest endpoint target not in locationConstraints');
+}
+
 function locationConstraintAssert(locationConstraints) {
     const supportedBackends =
       ['mem', 'file', 'scality'].concat(Object.keys(externalBackends));
@@ -131,8 +142,8 @@ class Config extends EventEmitter {
         }
 
         // Read config automatically
-        this._getConfig();
         this._getLocationConfig();
+        this._getConfig();
         this._configureBackends();
     }
 
@@ -277,11 +288,7 @@ class Config extends EventEmitter {
 
         if (config.restEndpoints !== undefined) {
             this.restEndpoints = {};
-            assert(typeof config.restEndpoints === 'object',
-                'bad config: restEndpoints must be an object of endpoints');
-            assert(Object.keys(config.restEndpoints).every(
-                r => typeof config.restEndpoints[r] === 'string'),
-                'bad config: each endpoint must be a string');
+            restEndpointsAssert(config.restEndpoints, this.locationConstraints);
             this.restEndpoints = config.restEndpoints;
         }
 
@@ -739,6 +746,7 @@ class Config extends EventEmitter {
     }
 
     setRestEndpoints(restEndpoints) {
+        restEndpointsAssert(restEndpoints, this.locationConstraints);
         this.restEndpoints = restEndpoints;
         this.emit('rest-endpoints-update');
     }

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -737,6 +737,11 @@ class Config extends EventEmitter {
     getLocationConstraintType(locationConstraint) {
         return this.locationConstraints[locationConstraint].type;
     }
+
+    setRestEndpoints(restEndpoints) {
+        this.restEndpoints = restEndpoints;
+        this.emit('rest-endpoints-update');
+    }
 }
 
 module.exports = {

--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -9,8 +9,11 @@ const { config } = require('../Config');
 const aclUtils = require('../utilities/aclUtils');
 const { pushMetric } = require('../utapi/utilities');
 
-const { locationConstraints, restEndpoints } = config;
-
+const { locationConstraints } = config;
+let { restEndpoints } = config;
+config.on('rest-endpoints-update', () => {
+    restEndpoints = config.restEndpoints;
+});
 
 /**
  * checkLocationConstraint - check that a location constraint is explicitly

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,8 +14,14 @@ const RedisClient = require('./RedisClient');
 const StatsClient = require('./StatsClient');
 
 const routes = arsenal.s3routes.routes;
-const allEndpoints = Object.keys(_config.restEndpoints);
 const websiteEndpoints = _config.websiteEndpoints;
+
+let allEndpoints;
+function updateAllEndpoints() {
+    allEndpoints = Object.keys(_config.restEndpoints);
+}
+_config.on('rest-endpoints-update', updateAllEndpoints);
+updateAllEndpoints();
 
 // redis client
 let localCacheClient;

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -269,4 +269,29 @@ describe('bucketPut API', () => {
         });
         done();
     });
+
+    it('should pick up updated rest endpoint config', done => {
+        const bucketName = 'new-loc-bucket-name';
+        const newRestEndpoint = 'newly.defined.rest.endpoint';
+        const newLocation = 'scality-us-west-1';
+
+        const req = Object.assign({}, testRequest, {
+            parsedHost: newRestEndpoint,
+            bucketName,
+        });
+
+        const newRestEndpoints = Object.assign({}, config.restEndpoints);
+        newRestEndpoints[newRestEndpoint] = newLocation;
+        config.setRestEndpoints(newRestEndpoints);
+
+        bucketPut(authInfo, req, log, err => {
+            assert.deepStrictEqual(err, null);
+            metadata.getBucket(bucketName, log, (err, bucketInfo) => {
+                assert.deepStrictEqual(err, null);
+                assert.deepStrictEqual(newLocation,
+                    bucketInfo.getLocationConstraint());
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
This allows changing REST endpoint to location constraint mappings on the fly, without restarting processes, by calling `Config.setRestEndpoints()`.