### PR TITLE
fix: Do not reuse connections in report tests

### DIFF
--- a/tests/functional/report/checkRoutes.js
+++ b/tests/functional/report/checkRoutes.js
@@ -22,6 +22,7 @@ function options(token = 'report-token-1') {
         path: '/_/report',
         port: 8000,
         headers: { 'x-scal-report-token': token },
+        agent: false,
     };
 }
 


### PR DESCRIPTION
Tentative flakiness fix on the report endpoint tests: in some cases this kind of error would pop up:
```
  1) Report route should contain expected attribute dataDiskUsage:
     Error: socket hang up
      at createHangUpError (_http_client.js:254:15)
      at Socket.socketOnEnd (_http_client.js:346:23)
      at endReadableNT (_stream_readable.js:974:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```