### PR TITLE
rf: update auth config example file

### DIFF
--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -2,49 +2,22 @@
     "accounts": [{
         "name": "Bart",
         "email": "sampleaccount1@sampling.com",
-        "arn": "aws::iam:123456789012:root",
+        "arn": "arn:aws:iam::123456789012:root",
         "canonicalID": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be",
         "shortid": "123456789012",
         "keys": [{
             "access": "accessKey1",
             "secret": "verySecretKey1"
-        }],
-        "users": [{
-            "name": "Bart Jr",
-            "email": "user1.sampleaccount2@sampling.com",
-            "arn": "aws::iam:123456789013:bart",
-            "keys": [{
-                "access": "USERBARTFUNACCESSKEY",
-                "secret": "verySecretKey1"
-            }]
-         }, {
-            "name": "backbeat",
-            "email": "backbeat@scality.com",
-            "arn": "aws::iam:123456789012:user/backbeat",
-            "keys": [{
-                "access": "accessKeyBackbeat",
-                "secret": "verySecretKeyBackbeat"
-            }]
         }]
     }, {
         "name": "Lisa",
         "email": "sampleaccount2@sampling.com",
-        "arn": "aws::iam:accessKey2:user/Lisa",
+        "arn": "arn:aws:iam::123456789013:root",
         "canonicalID": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf",
-        "shortid": "123456789012",
+        "shortid": "123456789013",
         "keys": [{
             "access": "accessKey2",
             "secret": "verySecretKey2"
-        }]
-    }, {
-        "name": "Docker",
-        "email": "sampleaccount3@sampling.com",
-        "arn": "aws::iam:accessKeyDocker:user/Docker",
-        "canonicalID": "sd359df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47eh3hd",
-        "shortid": "123456789012",
-        "keys": [{
-            "access": "accessKeyDocker",
-            "secret": "verySecretKeyDocker"
         }]
     }]
 }

--- a/lib/auth/in_memory/builder.js
+++ b/lib/auth/in_memory/builder.js
@@ -8,7 +8,7 @@ function buildAuthDataAccount(accessKey, secretKey) {
         accounts: [{
             name: 'CustomAccount',
             email: 'customaccount1@setbyenv.com',
-            arn: 'aws::iam:123456789012:root',
+            arn: 'arn:aws:iam::123456789012:root',
             canonicalID: '12349df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d52' +
             '18e7cd47qwer',
             shortid: '123456789012',

--- a/tests/functional/aws-node-sdk/lib/json/mem_credentials.json
+++ b/tests/functional/aws-node-sdk/lib/json/mem_credentials.json
@@ -6,9 +6,5 @@
   "lisa": {
     "accessKey": "accessKey2",
     "secretKey": "verySecretKey2"
-},
-  "userBart": {
-      "accessKey": "USERBARTFUNACCESSKEY",
-      "secretKey": "verySecretKey1"
   }
 }

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -39,19 +39,9 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
 
     withV4(sigCfg => {
         let bucketUtil;
-        let userBucketUtil;
 
         before(() => {
             bucketUtil = new BucketUtility('default', sigCfg);
-            userBucketUtil = new BucketUtility('userBart', sigCfg);
-        });
-
-        describe('user creates a bucket', () => {
-            afterEach(done => bucketUtil.s3.deleteBucket({ Bucket: bucketName },
-              done));
-            it('user should be able to create a bucket', done => {
-                userBucketUtil.s3.createBucket({ Bucket: bucketName }, done);
-            });
         });
 
         describe('create bucket twice', () => {

--- a/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
+++ b/tests/functional/aws-node-sdk/test/object/multiObjectDelete.js
@@ -1,15 +1,11 @@
 const assert = require('assert');
 const Promise = require('bluebird');
 
-const { config } = require('../../../../../lib/Config');
 const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 
 const otherAccountBucketUtility = new BucketUtility('lisa', {});
 const otherAccountS3 = otherAccountBucketUtility.s3;
-
-const userBucketUtility = new BucketUtility('userBart', {});
-const userS3 = userBucketUtility.s3;
 
 const bucketName = 'multi-object-delete-234-634';
 const key = 'key';
@@ -244,14 +240,8 @@ describe('Multi-Object Delete Access', function access() {
 
 
     it('should batch delete objects where requester has permission', () => {
-        // if test run with file or mem backend, test user access for
-        // in memory implementation (which should grant user access).
-        // if using distributed backend, test with account since need
-        // policy authorizaing user for user to have access.
-        // tests of user with a distributed backend are in integration.
-        const requester = config.backends.auth === 'mem' ? userS3 : s3;
         const objects = createObjectsList(500);
-        return requester.deleteObjectsAsync({
+        return s3.deleteObjectsAsync({
             Bucket: bucketName,
             Delete: {
                 Objects: objects,

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -9,8 +9,8 @@ const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
 const describeSkipIfAWS = process.env.AWS_ON_AIR ? describe.skip : describe;
 
 const backbeatAuthCredentials = {
-    accessKey: 'accessKeyBackbeat',
-    secretKey: 'verySecretKeyBackbeat',
+    accessKey: 'accessKey1',
+    secretKey: 'verySecretKey1',
 };
 
 const TEST_BUCKET = 'backbeatbucket';


### PR DESCRIPTION
Use proper ARNs for accounts, remove account users which is now unsupported.

This change will be necessary for the example file to be parsed correctly when https://github.com/scality/Arsenal/pull/346 is merged, but can be merged before since it will still be parsed correctly by the existing code in arsenal.