### PR TITLE
multiple auth sources

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -5,9 +5,9 @@ const path = require('path');
 
 const uuid = require('node-uuid');
 
-const validateAuthConfig = require('arsenal').auth.inMemory.validateAuthConfig;
 const { buildAuthDataAccount } = require('./auth/in_memory/builder');
-const externalBackends = require('../constants').externalBackends;
+const AuthLoader = require('arsenal').auth.inMemory.AuthLoader;
+const constants = require('../constants');
 
 // whitelist IP, CIDR for health checks
 const defaultHealthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
@@ -53,7 +53,8 @@ function restEndpointsAssert(restEndpoints, locationConstraints) {
 
 function locationConstraintAssert(locationConstraints) {
     const supportedBackends =
-      ['mem', 'file', 'scality'].concat(Object.keys(externalBackends));
+      ['mem', 'file', 'scality'].concat(
+          Object.keys(constants.externalBackends));
     assert(typeof locationConstraints === 'object',
         'bad config: locationConstraints must be an object');
     Object.keys(locationConstraints).forEach(l => {
@@ -680,23 +681,26 @@ class Config extends EventEmitter {
         if (auth === 'file' || auth === 'mem' || auth === 'cdmi') {
             // Auth only checks for 'mem' since mem === file
             auth = 'mem';
-            let authfile = `${__dirname}/../conf/authdata.json`;
-            if (process.env.S3AUTH_CONFIG) {
-                authfile = process.env.S3AUTH_CONFIG;
-            }
-            let authData;
+            const authLoader = new AuthLoader();
             if (process.env.SCALITY_ACCESS_KEY_ID &&
-            process.env.SCALITY_SECRET_ACCESS_KEY) {
-                authData = buildAuthDataAccount(
-                  process.env.SCALITY_ACCESS_KEY_ID,
-                  process.env.SCALITY_SECRET_ACCESS_KEY);
+                process.env.SCALITY_SECRET_ACCESS_KEY) {
+                authLoader.addAccounts(buildAuthDataAccount(
+                    process.env.SCALITY_ACCESS_KEY_ID,
+                    process.env.SCALITY_SECRET_ACCESS_KEY));
             } else {
-                authData = require(authfile);
+                const authGlob = (process.env.S3AUTH_CONFIG ||
+                                  `${__dirname}/../conf/authdata.json`);
+                // The env var may contain multiple file globs (or
+                // names) separated by spaces, so split at space
+                // character. It will not work if file names contain
+                // spaces, but best practice admin should avoid this
+                // anyway.
+                authLoader.addFilesByGlob(authGlob.split(' '));
             }
-            if (validateAuthConfig(authData)) {
+            this.authData = authLoader.getData();
+            if (!this.authData) {
                 throw new Error('bad config: invalid auth config file.');
             }
-            this.authData = authData;
         }
         if (process.env.S3DATA) {
             const validData = ['mem', 'file', 'scality', 'multiple'];


### PR DESCRIPTION
ft: use the AuthLoader class

Use the AuthLoader class to load authentication info from multiple
file sources, to prepare for docker stack deployment with docker
secrets used for service authentication.

Built on top of https://github.com/scality/S3/pull/919 so that the example file can be parsed correctly.