### PR TITLE
CRR service account

### DIFF
--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -19,5 +19,15 @@
             "access": "accessKey2",
             "secret": "verySecretKey2"
         }]
+    }, {
+        "name": "CRRService",
+        "email": "crr@zenko.io",
+        "arn": "arn:aws:iam::000000001000:root",
+        "canonicalID": "http://acs.zenko.io/accounts/service/crr",
+        "shortid": "000000001000",
+        "keys": [{
+            "access": "accessKeyCRR",
+            "secret": "verySecretKeyCRR"
+        }]
     }]
 }

--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -6,7 +6,11 @@ function isBucketAuthorized(bucket, requestType, canonicalID) {
     // TODO: Add IAM checks and bucket policy checks.
     if (bucket.getOwner() === canonicalID) {
         return true;
-    } else if (requestType === 'bucketOwnerAction') {
+    }
+    if (requestType === 'bucketGetReplication') {
+        return canonicalID === 'http://acs.zenko.io/accounts/service/crr';
+    }
+    if (requestType === 'bucketOwnerAction') {
         // only bucket owner can modify or retrieve this property of a bucket
         return false;
     }
@@ -67,6 +71,10 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
         return false;
     }
     if (objectMD['owner-id'] === canonicalID) {
+        return true;
+    }
+    if (canonicalID === 'http://acs.zenko.io/accounts/service/crr' &&
+        requestType === 'objectGet') {
         return true;
     }
     // account is authorized if:

--- a/lib/api/bucketGetReplication.js
+++ b/lib/api/bucketGetReplication.js
@@ -20,7 +20,7 @@ function bucketGetReplication(authInfo, request, log, callback) {
     const metadataValParams = {
         authInfo,
         bucketName,
-        requestType: 'bucketOwnerAction',
+        requestType: 'bucketGetReplication',
     };
     return metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(headers.origin, method, bucket);

--- a/lib/metadata/metadataUtils.js
+++ b/lib/metadata/metadataUtils.js
@@ -265,6 +265,7 @@ function metadataValidateBucket(params, log, callback) {
 
 module.exports = {
     parseListEntries,
+    metadataGetBucketAndObject,
     metadataGetObject,
     metadataValidateBucketAndObj,
     metadataValidateBucket,

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -10,7 +10,7 @@ const locationConstraintCheck = require(
 const { dataStore } = require('../api/apiUtils/object/storeObject');
 const prepareRequestContexts = require(
 '../api/apiUtils/authorization/prepareRequestContexts');
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { metadataGetBucketAndObject } = require('../metadata/metadataUtils');
 
 auth.setHandler(vault);
 
@@ -154,7 +154,7 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
 
 const backbeatRoutes = {
     PUT: { data: putData,
-        metadata: putMetadata },
+           metadata: putMetadata },
 };
 
 function routeBackbeat(clientIP, request, response, log) {
@@ -185,11 +185,14 @@ function routeBackbeat(clientIP, request, response, log) {
             return next(err, userInfo);
         }, 's3', requestContexts),
         (userInfo, next) => {
-            const mdValParams = { bucketName: request.bucketName,
-                objectKey: request.objectKey,
-                authInfo: userInfo,
-                requestType: 'ReplicateObject' };
-            return metadataValidateBucketAndObj(mdValParams, log, next);
+            // only allow CRR service account to proceed
+            if (!userInfo.isRequesterThisServiceAccount('crr')) {
+                return next(errors.AccessDenied);
+            }
+            return metadataGetBucketAndObject('ReplicateObject',
+                                              request.bucketName,
+                                              request.objectKey, undefined,
+                                              log, next);
         },
         (bucketInfo, objMd, next) => {
             if (backbeatRoutes[request.method] === undefined ||

--- a/tests/functional/raw-node/test/routes/routeBackbeat.js
+++ b/tests/functional/raw-node/test/routes/routeBackbeat.js
@@ -8,7 +8,11 @@ const BucketUtility = require('../../../aws-node-sdk/lib/utility/bucket-util');
 const ipAddress = process.env.IP ? process.env.IP : '127.0.0.1';
 const describeSkipIfAWS = process.env.AWS_ON_AIR ? describe.skip : describe;
 
-const backbeatAuthCredentials = {
+const crrAuthCredentials = {
+    accessKey: 'accessKeyCRR',
+    secretKey: 'verySecretKeyCRR',
+};
+const otherValidAuthCredentials = {
     accessKey: 'accessKey1',
     secretKey: 'verySecretKey1',
 };
@@ -169,7 +173,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                                 'content-md5': testDataMd5,
                                 'x-scal-canonical-id': testArn,
                             },
-                            authCredentials: backbeatAuthCredentials,
+                            authCredentials: crrAuthCredentials,
                             requestBody: testData }, next);
                     }, (response, next) => {
                         assert.strictEqual(response.statusCode, 200);
@@ -179,7 +183,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                             method: 'PUT', bucket: TEST_BUCKET,
                             objectKey: testCase.encodedKey,
                             resourceType: 'metadata',
-                            authCredentials: backbeatAuthCredentials,
+                            authCredentials: crrAuthCredentials,
                             requestBody: JSON.stringify(newMd),
                         }, next);
                     }, (response, next) => {
@@ -205,7 +209,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                         'content-md5': testDataMd5,
                         'x-scal-canonical-id': testArn,
                     },
-                    authCredentials: backbeatAuthCredentials,
+                    authCredentials: crrAuthCredentials,
                     requestBody: testData,
                 }, next);
             }, (response, next) => {
@@ -216,7 +220,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                     method: 'PUT', bucket: TEST_BUCKET,
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
-                    authCredentials: backbeatAuthCredentials,
+                    authCredentials: crrAuthCredentials,
                     requestBody: JSON.stringify(newMd),
                 }, next);
             }, (response, next) => {
@@ -227,7 +231,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                     objectKey: 'test-updatemd-key',
                     resourceType: 'metadata',
                     headers: { 'x-scal-replication-content': 'METADATA' },
-                    authCredentials: backbeatAuthCredentials,
+                    authCredentials: crrAuthCredentials,
                     requestBody: JSON.stringify(newMd),
                 }, next);
             }, (response, next) => {
@@ -248,7 +252,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                 'content-md5': testDataMd5,
                 'x-scal-canonical-id': testArn,
             },
-            authCredentials: backbeatAuthCredentials,
+            authCredentials: crrAuthCredentials,
             requestBody: testData,
         },
         err => {
@@ -260,7 +264,7 @@ describeSkipIfAWS('backbeat routes:', () => {
         done => makeBackbeatRequest({
             method: 'PUT', bucket: NONVERSIONED_BUCKET,
             objectKey: testKey, resourceType: 'metadata',
-            authCredentials: backbeatAuthCredentials,
+            authCredentials: crrAuthCredentials,
             requestBody: JSON.stringify(testMd),
         },
         err => {
@@ -276,7 +280,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                    'content-length': testData.length,
                    'content-md5': testDataMd5,
                },
-               authCredentials: backbeatAuthCredentials,
+               authCredentials: crrAuthCredentials,
                requestBody: testData,
            },
            err => {
@@ -292,7 +296,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                 'content-length': testData.length,
                 'x-scal-canonical-id': testArn,
             },
-            authCredentials: backbeatAuthCredentials,
+            authCredentials: crrAuthCredentials,
             requestBody: testData,
         },
         err => {
@@ -309,7 +313,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                     objectKey: 'does-not-exist',
                     resourceType: 'metadata',
                     headers: { 'x-scal-replication-content': 'METADATA' },
-                    authCredentials: backbeatAuthCredentials,
+                    authCredentials: crrAuthCredentials,
                     requestBody: JSON.stringify(newMd),
                 }, next);
             }], err => {
@@ -355,15 +359,12 @@ describeSkipIfAWS('backbeat routes:', () => {
                 });
              it(`${test.method} ${test.resourceType} should respond with ` +
                 '403 Forbidden if the account does not match the ' +
-                'backbeat user',
+                'CRR service account',
                 done => {
                     makeBackbeatRequest({
                         method: test.method, bucket: TEST_BUCKET,
                         objectKey: TEST_KEY, resourceType: test.resourceType,
-                        authCredentials: {
-                            accessKey: 'accessKey2',
-                            secretKey: 'verySecretKey2',
-                        },
+                        authCredentials: otherValidAuthCredentials,
                     },
                     err => {
                         assert(err);
@@ -379,7 +380,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                         method: test.method, bucket: TEST_BUCKET,
                         objectKey: TEST_KEY, resourceType: test.resourceType,
                         authCredentials: {
-                            accessKey: backbeatAuthCredentials.accessKey,
+                            accessKey: crrAuthCredentials.accessKey,
                             secretKey: 'hastalavista',
                         },
                     },
@@ -399,7 +400,7 @@ describeSkipIfAWS('backbeat routes:', () => {
                makeBackbeatRequest({
                    method: 'GET', bucket: TEST_BUCKET,
                    objectKey: TEST_KEY, resourceType: 'metadata',
-                   authCredentials: backbeatAuthCredentials,
+                   authCredentials: crrAuthCredentials,
                },
                err => {
                    assert(err);


### PR DESCRIPTION
backbeat routes (actually CRR routes) are no longer available to normal
bucket owner accounts, only special CRR account may use those routes.
    
CRR account is defined by its canonical ID as a special URL. Add
this account in authdata.json with a dummy access key for tests.

Made on top of https://github.com/scality/S3/pull/919