### PR TITLE
FT: Add storageType to replicationInfo

### DIFF
--- a/lib/api/apiUtils/object/getReplicationInfo.js
+++ b/lib/api/apiUtils/object/getReplicationInfo.js
@@ -1,3 +1,5 @@
+const s3config = require('../../../Config').config;
+
 /**
  * Get the object replicationInfo to replicate data and metadata, or only
  * metadata if the operation only changes metadata or the object is 0 bytes
@@ -14,12 +16,14 @@ function getReplicationInfo(objKey, bucketMD, isMD, objSize) {
     if (config) {
         const rule = config.rules.find(rule => objKey.startsWith(rule.prefix));
         if (rule) {
+            const location = s3config.locationConstraints[rule.storageClass];
             return {
                 status: 'PENDING',
                 content,
                 destination: config.destination,
                 storageClass: rule.storageClass || '',
                 role: config.role,
+                storageType: location && location.type || '',
             };
         }
     }


### PR DESCRIPTION
Depends on https://github.com/scality/Arsenal/pull/347.

* Add the `storageType` field to the `replicationInfo` field of an object's metadata.
* If the given `storageClass` of a replication configuration rule matches a location in the locationConfig.json, we set the `storageType` to the value of `type` (for example, 'aws_s3') that is included in the given location constraint.
* The definition of a valid `storageClass` is expanded to include values that exist in the locationConfig.json.