### PR TITLE
fix: undef client in multiplebackend head

### DIFF
--- a/lib/api/apiUtils/object/BackendInfo.js
+++ b/lib/api/apiUtils/object/BackendInfo.js
@@ -114,7 +114,7 @@ class BackendInfo {
      * constraint from bucket metadata
      * @param {string} requestEndpoint - endpoint of request
      * @param {object} log - werelogs logger
-     * @return {object} - location contraint validity
+     * @return {object} - location constraint validity
      */
     static controllingBackendParam(objectLocationConstraint,
         bucketLocationConstraint, requestEndpoint, log) {
@@ -148,7 +148,10 @@ class BackendInfo {
             `endpoint "${escapeForXml(requestEndpoint)}" does not ` +
             'match any config locationConstraint - Please update.' };
         }
-        return { isValid: true };
+        if (BackendInfo.isRequestEndpointPresent(requestEndpoint, log)) {
+            return { isValid: true };
+        }
+        return { isValid: true, defaultedToDataBackend: true };
     }
 
     /**

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -126,7 +126,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
 
     const backendInfo = backendInfoObj.backendInfo;
     const location = backendInfo.getControllingLocationConstraint();
-    const locationType = config.getLocationConstraintType(location);
+    const locationType = backendInfoObj.defaultedToDataBackend ? location :
+        config.getLocationConstraintType(location);
     metadataStoreParams.dataStoreName = location;
 
     if (versioningNotImplBackends[locationType]) {

--- a/lib/api/apiUtils/object/locationConstraintCheck.js
+++ b/lib/api/apiUtils/object/locationConstraintCheck.js
@@ -44,6 +44,7 @@ function locationConstraintCheck(request, metaHeaders, bucket, log) {
     backendInfoObj = {
         err: null,
         controllingLC: backendInfo.getControllingLocationConstraint(),
+        defaultedToDataBackend: controllingBackend.defaultedToDataBackend,
         backendInfo,
     };
     return backendInfoObj;

--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -1,7 +1,7 @@
 const { errors, s3middleware } = require('arsenal');
 const { parseRange } = require('arsenal/lib/network/http/utils');
 
-const multipleBackendGateway = require('../data/multipleBackendGateway');
+const data = require('../data/wrapper');
 
 const { decodeVersionId } = require('./apiUtils/object/versioning');
 const collectCorsHeaders = require('../utilities/collectCorsHeaders');
@@ -188,8 +188,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 dataLocator = setPartRanges(dataLocator, byteRange);
             }
         }
-        return multipleBackendGateway.head(dataLocator, log.getSerializedUids(),
-        err => {
+        return data.head(dataLocator, log, err => {
             if (err) {
                 log.error('error from external backend checking for ' +
                 'object existence', { error: err });

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -142,6 +142,15 @@ const data = {
              });
     },
 
+    head: (objectGetInfo, log, cb) => {
+        if (implName !== 'multipleBackends') {
+            // no-op if not multipleBackend implementation;
+            // head is used during get just to check external backend data state
+            return process.nextTick(cb);
+        }
+        return client.head(objectGetInfo, log.getSerializedUids(), cb);
+    },
+
     get: (objectGetInfo, response, log, cb) => {
         // If objectGetInfo.key exists the md-model-version is 2 or greater.
         // Otherwise, the objectGetInfo is just the key string.

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/delete.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/delete.js
@@ -3,6 +3,8 @@ const assert = require('assert');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { config } = require('../../../../../../lib/Config');
+const { memLocation, fileLocation, awsLocation, awsLocationMismatch }
+    = require('../utils');
 
 const bucket = 'buckettestmultiplebackenddelete';
 const memObject = `memObject-${Date.now()}`;
@@ -13,8 +15,6 @@ const bigObject = `bigObject-${Date.now()}`;
 const mismatchObject = `mismatchOjbect-${Date.now()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
-const awsLocation = 'aws-test';
-const awsLocationMismatch = 'aws-test-mismatch';
 
 const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
     || process.env.S3_END_TO_END) ? describe.skip : describe;
@@ -36,13 +36,13 @@ describeSkipIfNotMultiple('Multiple backend delete', () => {
             .then(() => {
                 process.stdout.write('Putting object to mem\n');
                 const params = { Bucket: bucket, Key: memObject, Body: body,
-                    Metadata: { 'scal-location-constraint': 'mem' } };
+                    Metadata: { 'scal-location-constraint': memLocation } };
                 return s3.putObject(params);
             })
             .then(() => {
                 process.stdout.write('Putting object to file\n');
                 const params = { Bucket: bucket, Key: fileObject, Body: body,
-                    Metadata: { 'scal-location-constraint': 'file' } };
+                    Metadata: { 'scal-location-constraint': fileLocation } };
                 return s3.putObject(params);
             })
             .then(() => {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAzure.js
@@ -4,12 +4,11 @@ const async = require('async');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const withV4 = require('../../support/withV4');
 const { config } = require('../../../../../../lib/Config');
-const { uniqName, getAzureClient, getAzureContainerName, getAzureKeys } =
+const { uniqName, getAzureClient, getAzureContainerName, getAzureKeys,
+    azureLocation, azureLocationMismatch } =
   require('../utils');
 
 const keyObject = 'deleteazure';
-const azureLocationMismatch = 'azuretestmismatch';
-const azureLocation = 'azuretest';
 const azureContainerName = getAzureContainerName();
 const keys = getAzureKeys();
 const azureClient = getAzureClient();

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
@@ -3,9 +3,9 @@ const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { config } = require('../../../../../../lib/Config');
+const { memLocation, fileLocation, awsLocation, awsLocationMismatch }
+    = require('../utils');
 
-const awsLocation = 'aws-test';
-const awsLocationMismatch = 'aws-test-mismatch';
 const bucket = 'buckettestmultiplebackendget';
 const memObject = `memobject-${Date.now()}`;
 const fileObject = `fileobject-${Date.now()}`;
@@ -181,12 +181,14 @@ describe('Multiple backend get object', function testSuite() {
                 process.stdout.write('Putting object to mem\n');
                 return s3.putObjectAsync({ Bucket: bucket, Key: memObject,
                     Body: body,
-                    Metadata: { 'scal-location-constraint': 'mem' } })
+                    Metadata: { 'scal-location-constraint': memLocation } })
                 .then(() => {
                     process.stdout.write('Putting object to file\n');
                     return s3.putObjectAsync({ Bucket: bucket, Key: fileObject,
                         Body: body,
-                        Metadata: { 'scal-location-constraint': 'file' } });
+                        Metadata:
+                        { 'scal-location-constraint': fileLocation },
+                    });
                 })
                 .then(() => {
                     process.stdout.write('Putting object to AWS\n');
@@ -198,7 +200,9 @@ describe('Multiple backend get object', function testSuite() {
                 .then(() => {
                     process.stdout.write('Putting 0-byte object to mem\n');
                     return s3.putObjectAsync({ Bucket: bucket, Key: emptyObject,
-                        Metadata: { 'scal-location-constraint': 'mem' } });
+                        Metadata:
+                        { 'scal-location-constraint': memLocation },
+                    });
                 })
                 .then(() => {
                     process.stdout.write('Putting 0-byte object to AWS\n');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAwsVersioning.js
@@ -6,6 +6,7 @@ const BucketUtility = require('../../../lib/utility/bucket-util');
 const { config } = require('../../../../../../lib/Config');
 const { getRealAwsConfig } = require('../../support/awsConfig');
 const {
+    awsLocation,
     enableVersioning,
     suspendVersioning,
     mapToAwsPuts,
@@ -14,7 +15,6 @@ const {
     expectedETag,
 } = require('../utils');
 
-const awsLocation = 'aws-test';
 const someBody = 'testbody';
 const bucket = 'buckettestmultiplebackendgetawsversioning';
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
@@ -4,9 +4,8 @@ const BucketUtility = require('../../../lib/utility/bucket-util');
 const withV4 = require('../../support/withV4');
 
 const { uniqName, getAzureClient, getAzureContainerName,
-  getAzureKeys } = require('../utils');
+  getAzureKeys, azureLocation } = require('../utils');
 
-const azureLocation = 'azuretest';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();
 const keys = getAzureKeys();

--- a/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
@@ -4,11 +4,11 @@ const assert = require('assert');
 const { config } = require('../../../../../../lib/Config');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
+const { azureLocation } = require('../utils');
 
 const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
     || process.env.S3_END_TO_END) ? describe.skip : describe;
 
-const azureLocation = 'azuretest';
 let azureContainerName;
 
 if (config.locationConstraints[azureLocation] &&

--- a/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
@@ -3,11 +3,11 @@ const assert = require('assert');
 const { config } = require('../../../../../../lib/Config');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
+const { azureLocation } = require('../utils');
 
 const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
     || process.env.S3_END_TO_END) ? describe.skip : describe;
 
-const azureLocation = 'azuretest';
 let azureContainerName;
 const bodyFirstPart = Buffer.alloc(10);
 const bodySecondPart = Buffer.alloc(104857610);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/azureAbortMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/azureAbortMPU.js
@@ -4,13 +4,12 @@ const async = require('async');
 const { s3middleware } = require('arsenal');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { uniqName, getAzureClient, getAzureContainerName, convertMD5 }
-    = require('../utils');
+const { uniqName, getAzureClient, getAzureContainerName, convertMD5,
+    azureLocation } = require('../utils');
 const { config } = require('../../../../../../lib/Config');
 const azureMpuUtils = s3middleware.azureHelper.mpuUtils;
 const maxSubPartSize = azureMpuUtils.maxSubPartSize;
 
-const azureLocation = 'azuretest';
 const keyObject = 'abortazure';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
@@ -6,8 +6,8 @@ const { s3middleware } = require('arsenal');
 const { config } = require('../../../../../../lib/Config');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { getAzureClient, getAzureContainerName } =
-    require('../utils');
+const { fileLocation, awsLocation, azureLocation, azureLocationMismatch,
+    getAzureClient, getAzureContainerName } = require('../utils');
 const { getRealAwsConfig } =
     require('../../support/awsConfig');
 
@@ -15,10 +15,7 @@ const azureMpuUtils = s3middleware.azureHelper.mpuUtils;
 const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
     || process.env.S3_END_TO_END) ? describe.skip : describe;
 
-const awsLocation = 'aws-test';
 const awsBucket = 'multitester555';
-const azureLocation = 'azuretest';
-const azureLocationMismatch = 'azuretestmismatch';
 const azureContainerName = getAzureContainerName();
 const azureClient = getAzureClient();
 const azureTimeout = 20000;
@@ -172,7 +169,7 @@ function testSuite() {
                 Bucket: azureContainerName,
                 Key: this.test.key,
                 Body: body,
-                Metadata: { 'scal-location-constraint': 'file' } },
+                Metadata: { 'scal-location-constraint': fileLocation } },
             err => {
                 assert.equal(err, null, `Err putting object to file: ${err}`);
                 mpuSetup(this.test.key, azureLocation,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/azurePutPart.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/azurePutPart.js
@@ -5,13 +5,12 @@ const { s3middleware } = require('arsenal');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { expectedETag, uniqName, getAzureClient, getAzureContainerName,
-    convertMD5 } = require('../utils');
+    convertMD5, azureLocation } = require('../utils');
 const { config } = require('../../../../../../lib/Config');
 const azureMpuUtils = s3middleware.azureHelper.mpuUtils;
 const maxSubPartSize = azureMpuUtils.maxSubPartSize;
 const getBlockId = azureMpuUtils.getBlockId;
 
-const azureLocation = 'azuretest';
 const keyObject = 'putazure';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
@@ -5,17 +5,14 @@ const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const constants = require('../../../../../../constants');
 const { config } = require('../../../../../../lib/Config');
-const { getAzureClient, getAzureContainerName, convertMD5 } =
+const { getAzureClient, getAzureContainerName, convertMD5, memLocation,
+    awsLocation, azureLocation, azureLocation2, azureLocationMismatch } =
     require('../utils');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
 
-const azureLocation = 'azuretest';
-const azureLocation2 = 'azuretest2';
-const azureLocationMismatch = 'azuretestmismatch';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();
-const awsLocation = 'aws-test';
 
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const body = Buffer.from('I am a body', 'utf8');
@@ -138,7 +135,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
         });
 
         it('should copy an object from mem to Azure', function itFn(done) {
-            putSourceObj(this.test.key, 'mem', null, () => {
+            putSourceObj(this.test.key, memLocation, null, () => {
                 const copyParams = {
                     Bucket: bucket,
                     Key: this.test.copyKey,
@@ -151,7 +148,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${normalMD5}"`);
-                    assertGetObjects(this.test.key, bucket, 'mem',
+                    assertGetObjects(this.test.key, bucket, memLocation,
                         this.test.copyKey, bucket, azureLocation,
                         this.test.copyKey, 'REPLACE', null, done);
                 });
@@ -165,7 +162,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     Key: this.test.copyKey,
                     CopySource: `/${bucket}/${this.test.key}`,
                     MetadataDirective: 'REPLACE',
-                    Metadata: { 'scal-location-constraint': 'mem' },
+                    Metadata: { 'scal-location-constraint': memLocation },
                 };
                 s3.copyObject(copyParams, (err, result) => {
                     assert.equal(err, null, 'Expected success but got ' +
@@ -173,7 +170,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${normalMD5}"`);
                     assertGetObjects(this.test.key, bucket, azureLocation,
-                        this.test.copyKey, bucket, 'mem', this.test.key,
+                        this.test.copyKey, bucket, memLocation, this.test.key,
                         'REPLACE', null, done);
                 });
             });
@@ -223,7 +220,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
 
         it('should copy an object from mem to Azure and retain metadata',
         function itFn(done) {
-            putSourceObj(this.test.key, 'mem', null, () => {
+            putSourceObj(this.test.key, memLocation, null, () => {
                 const copyParams = {
                     Bucket: bucket,
                     Key: this.test.copyKey,
@@ -236,7 +233,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${normalMD5}"`);
-                    assertGetObjects(this.test.key, bucket, 'mem',
+                    assertGetObjects(this.test.key, bucket, memLocation,
                         this.test.copyKey, bucket, azureLocation,
                         this.test.copyKey, 'COPY', null, done);
                 });
@@ -384,7 +381,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
 
         it('should copy a 0-byte object from mem to Azure',
         function itFn(done) {
-            putSourceObj(this.test.key, 'mem', { empty: true }, () => {
+            putSourceObj(this.test.key, memLocation, { empty: true }, () => {
                 const copyParams = {
                     Bucket: bucket,
                     Key: this.test.copyKey,
@@ -397,7 +394,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${emptyMD5}"`);
-                    assertGetObjects(this.test.key, bucket, 'mem',
+                    assertGetObjects(this.test.key, bucket, memLocation,
                         this.test.copyKey, bucket, azureLocation,
                         this.test.copyKey, 'REPLACE', { empty: true }, done);
                 });
@@ -425,7 +422,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
         });
 
         it('should copy a 5MB object from mem to Azure', function itFn(done) {
-            putSourceObj(this.test.key, 'mem', { big: true }, () => {
+            putSourceObj(this.test.key, memLocation, { big: true }, () => {
                 const copyParams = {
                     Bucket: bucket,
                     Key: this.test.copyKey,
@@ -438,7 +435,7 @@ describeSkipIfNotMultiple('MultipleBackend object copy', function testSuite() {
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${bigMD5}"`);
                     setTimeout(() => {
-                        assertGetObjects(this.test.key, bucket, 'mem',
+                        assertGetObjects(this.test.key, bucket, memLocation,
                             this.test.copyKey, bucket, azureLocation,
                             this.test.copyKey, 'REPLACE', { big: true }, done);
                     }, azureTimeout);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
@@ -8,10 +8,9 @@ const { config } = require('../../../../../../lib/Config');
 const { getRealAwsConfig } = require('../../support/awsConfig');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
+const { memLocation, awsLocation, awsLocation2, awsLocationMismatch } =
+    require('../utils');
 
-const awsLocation = 'aws-test';
-const awsLocation2 = 'aws-test-2';
-const awsLocationMismatch = 'aws-test-mismatch';
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -140,7 +139,7 @@ function testSuite() {
         });
 
         it('should copy an object from mem to AWS', done => {
-            putSourceObj('mem', false, key => {
+            putSourceObj(memLocation, false, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
                     Bucket: bucket,
@@ -156,7 +155,7 @@ function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${correctMD5}"`);
-                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                    assertGetObjects(key, bucket, memLocation, copyKey, bucket,
                         awsLocation, copyKey, 'REPLACE', false, awsS3,
                         awsLocation, done);
                 });
@@ -164,7 +163,7 @@ function testSuite() {
         });
 
         it('should copy an object from mem to AWS with encryption', done => {
-            putSourceObj('mem', false, key => {
+            putSourceObj(memLocation, false, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
                     Bucket: bucket,
@@ -180,7 +179,7 @@ function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${correctMD5}"`);
-                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                    assertGetObjects(key, bucket, memLocation, copyKey, bucket,
                         awsLocationEncryption, copyKey, 'REPLACE', false,
                         awsS3, awsLocation, done);
                 });
@@ -189,7 +188,7 @@ function testSuite() {
 
         it('should return NotImplemented copying an object from mem to a ' +
         'versioning enable AWS bucket', done => {
-            putSourceObj('mem', false, key => {
+            putSourceObj(memLocation, false, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
                     Bucket: bucket,
@@ -223,7 +222,7 @@ function testSuite() {
                     CopySource: `/${bucket}/${key}`,
                     MetadataDirective: 'REPLACE',
                     Metadata: {
-                        'scal-location-constraint': 'mem' },
+                        'scal-location-constraint': memLocation },
                 };
                 process.stdout.write('Copying object\n');
                 s3.copyObject(copyParams, (err, result) => {
@@ -232,14 +231,15 @@ function testSuite() {
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${correctMD5}"`);
                     assertGetObjects(key, bucket, awsLocation, copyKey, bucket,
-                        'mem', key, 'REPLACE', false, awsS3, awsLocation, done);
+                        memLocation, key, 'REPLACE', false, awsS3,
+                        awsLocation, done);
                 });
             });
         });
 
         it('should copy an object from mem to AWS and retain metadata',
         done => {
-            putSourceObj('mem', false, key => {
+            putSourceObj(memLocation, false, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
                     Bucket: bucket,
@@ -255,7 +255,7 @@ function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${correctMD5}"`);
-                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                    assertGetObjects(key, bucket, memLocation, copyKey, bucket,
                         awsLocation, copyKey, 'COPY', false, awsS3,
                         awsLocation, done);
                 });
@@ -396,7 +396,7 @@ function testSuite() {
         });
 
         it('should copy a 0-byte object from mem to AWS', done => {
-            putSourceObj('mem', true, key => {
+            putSourceObj(memLocation, true, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
                     Bucket: bucket,
@@ -412,7 +412,7 @@ function testSuite() {
                     `error: ${err}`);
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${emptyMD5}"`);
-                    assertGetObjects(key, bucket, 'mem', copyKey, bucket,
+                    assertGetObjects(key, bucket, memLocation, copyKey, bucket,
                         awsLocation, copyKey, 'REPLACE', true, awsS3,
                         awsLocation, done);
                 });

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging.js
@@ -5,10 +5,10 @@ const withV4 = require('../support/withV4');
 const BucketUtility = require('../../lib/utility/bucket-util');
 const { config } = require('../../../../../lib/Config');
 const { getRealAwsConfig } = require('../support/awsConfig');
-const { getAzureClient, getAzureContainerName, convertMD5 } =
+const { getAzureClient, getAzureContainerName, convertMD5,
+    memLocation, fileLocation, awsLocation, azureLocation } =
     require('./utils');
 
-const awsLocation = 'aws-test';
 const awsBucket = 'multitester555';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();
@@ -27,7 +27,7 @@ const describeSkipIfNotMultiple = (config.backends.data !== 'multiple'
     || process.env.S3_END_TO_END) ? describe.skip : describe;
 
 const putParams = { Bucket: bucket, Body: body };
-const testBackends = ['mem', 'file', 'aws-test', 'azuretest'];
+const testBackends = [memLocation, fileLocation, awsLocation, azureLocation];
 const tagString = 'key1=value1&key2=value2';
 const putTags = {
     TagSet: [

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
@@ -10,7 +10,7 @@ const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
 const { versioningEnabled } = require('../../../lib/utility/versioning-util');
 
-const awsLocation = 'aws-test';
+const { awsLocation, memLocation, fileLocation } = require('../utils');
 const awsLocationEncryption = 'aws-test-encryption';
 const bucket = 'buckettestmultiplebackendput';
 const body = Buffer.from('I am a body', 'utf8');
@@ -138,7 +138,7 @@ describe('MultipleBackend put object', function testSuite() {
                 const key = `somekey-${Date.now()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
-                    Metadata: { 'scal-location-constraint': 'mem' },
+                    Metadata: { 'scal-location-constraint': memLocation },
                 };
                 s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
@@ -155,7 +155,7 @@ describe('MultipleBackend put object', function testSuite() {
             it('should put a 0-byte object to mem', done => {
                 const key = `somekey-${Date.now()}`;
                 const params = { Bucket: bucket, Key: key,
-                    Metadata: { 'scal-location-constraint': 'mem' },
+                    Metadata: { 'scal-location-constraint': memLocation },
                 };
                 s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
@@ -189,7 +189,7 @@ describe('MultipleBackend put object', function testSuite() {
                 const key = `somekey-${Date.now()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
-                    Metadata: { 'scal-location-constraint': 'file' },
+                    Metadata: { 'scal-location-constraint': fileLocation },
                 };
                 s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
@@ -314,7 +314,8 @@ describe('MultipleBackend put object', function testSuite() {
                 s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
                         `got error ${err}`);
-                    params.Metadata = { 'scal-location-constraint': 'file' };
+                    params.Metadata =
+                        { 'scal-location-constraint': fileLocation };
                     s3.putObject(params, err => {
                         assert.equal(err, null, 'Expected success, ' +
                             `got error ${err}`);
@@ -325,7 +326,7 @@ describe('MultipleBackend put object', function testSuite() {
                                     `got error ${err}`);
                                 assert.strictEqual(
                                     res.Metadata['scal-location-constraint'],
-                                    'file');
+                                    fileLocation);
                                 awsS3.getObject({ Bucket: awsBucket,
                                     Key: key }, err => {
                                     assert.strictEqual(err.code, 'NoSuchKey');
@@ -342,7 +343,7 @@ describe('MultipleBackend put object', function testSuite() {
                 const key = `somekey-${Date.now()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
-                    Metadata: { 'scal-location-constraint': 'file' } };
+                    Metadata: { 'scal-location-constraint': fileLocation } };
                 s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
                         `got error ${err}`);
@@ -415,7 +416,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             process.stdout.write('Creating bucket\n');
             return s3.createBucket({ Bucket: bucket,
                 CreateBucketConfiguration: {
-                    LocationConstraint: 'mem',
+                    LocationConstraint: memLocation,
                 },
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);
@@ -439,7 +440,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             process.stdout.write('Creating bucket\n');
             return s3.createBucket({ Bucket: bucket,
                 CreateBucketConfiguration: {
-                    LocationConstraint: 'file',
+                    LocationConstraint: fileLocation,
                 },
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -4,12 +4,10 @@ const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { uniqName, getAzureClient, getAzureContainerName, getAzureKeys,
-    convertMD5 }
-  = require('../utils');
+    convertMD5, fileLocation, azureLocation, azureLocationMismatch }
+    = require('../utils');
 const { config } = require('../../../../../../lib/Config');
 
-const azureLocation = 'azuretest';
-const azureLocationMismatch = 'azuretestmismatch';
 const keyObject = 'putazure';
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName();
@@ -197,7 +195,7 @@ describeF() {
                     next => s3.putObject(params, err => next(err)),
                     next => {
                         params.Metadata = { 'scal-location-constraint':
-                        'file' };
+                        fileLocation };
                         s3.putObject(params, err => setTimeout(() =>
                           next(err), azureTimeout));
                     },
@@ -209,7 +207,7 @@ describeF() {
                             `got error ${err}`);
                         assert.strictEqual(
                             res.Metadata['scal-location-constraint'],
-                            'file');
+                            fileLocation);
                         next();
                     }),
                     next => azureClient.getBlobProperties(azureContainerName,
@@ -226,7 +224,7 @@ describeF() {
                 const params = { Bucket: azureContainerName, Key:
                     this.test.keyName,
                     Body: normalBody,
-                    Metadata: { 'scal-location-constraint': 'file' } };
+                    Metadata: { 'scal-location-constraint': fileLocation } };
                 async.waterfall([
                     next => s3.putObject(params, err => next(err)),
                     next => {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -6,12 +6,27 @@ const azure = require('azure-storage');
 
 const { config } = require('../../../../../lib/Config');
 
-const azureLocation = 'azuretest';
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
 const awsLocation = 'aws-test';
+const awsLocation2 = 'aws-test-2';
+const awsLocationMismatch = 'aws-test-mismatch';
+const azureLocation = 'azuretest';
+const azureLocation2 = 'azuretest2';
+const azureLocationMismatch = 'azuretestmismatch';
 const versioningEnabled = { Status: 'Enabled' };
 const versioningSuspended = { Status: 'Suspended' };
 
-const utils = {};
+const utils = {
+    fileLocation,
+    memLocation,
+    awsLocation,
+    awsLocation2,
+    awsLocationMismatch,
+    azureLocation,
+    azureLocation2,
+    azureLocationMismatch,
+};
 
 utils.uniqName = name => `${name}${new Date().getTime()}`;
 

--- a/tests/locationConfigTests.json
+++ b/tests/locationConfigTests.json
@@ -5,7 +5,7 @@
         "legacyAwsBehavior": true,
         "details": {}
     },
-    "file": {
+    "file-test": {
         "type": "file",
         "legacyAwsBehavior": false,
         "details": {}
@@ -15,7 +15,7 @@
         "legacyAwsBehavior": false,
         "details": {}
     },
-    "mem": {
+    "mem-test": {
         "type": "mem",
         "legacyAwsBehavior": false,
         "details": {}

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -25,6 +25,8 @@ const completeMultipartUpload =
 const listParts = require('../../lib/api/listParts');
 const listMultipartUploads = require('../../lib/api/listMultipartUploads');
 
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
 const awsLocation = 'aws-test';
 const awsLocationMismatch = 'aws-test-mismatch';
 const awsConfig = getRealAwsConfig(awsLocation);
@@ -515,7 +517,7 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
 
     it('should complete MPU on AWS with same key as object put to file',
     done => {
-        putObject('file', () => {
+        putObject(fileLocation, () => {
             mpuSetup(awsLocation, objectKey, uploadId => {
                 const compParams = Object.assign({
                     url: `/${objectKey}?uploadId=${uploadId}`,
@@ -534,7 +536,7 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
     it('should complete MPU on file with same key as object put to AWS',
     done => {
         putObject(awsLocation, () => {
-            mpuSetup('file', objectKey, uploadId => {
+            mpuSetup(fileLocation, objectKey, uploadId => {
                 const compParams = Object.assign({
                     url: `/${fileKey}?uploadId=${uploadId}`,
                     query: { uploadId } }, completeParams);
@@ -543,7 +545,7 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                     assert.equal(err, null, 'Error completing mpu on file ' +
                     `${err}`);
                     assertMpuCompleteResults(result);
-                    assertObjOnBackend('file', objectKey, done);
+                    assertObjOnBackend(fileLocation, objectKey, done);
                 });
             });
         });
@@ -654,9 +656,9 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
 
     it('should list all multipart uploads on all backends', done => {
         async.series([
-            cb => mpuSetup('file', fileKey,
+            cb => mpuSetup(fileLocation, fileKey,
                 fileUploadId => cb(null, fileUploadId)),
-            cb => mpuSetup('mem', memKey, memUploadId =>
+            cb => mpuSetup(memLocation, memKey, memUploadId =>
                 cb(null, memUploadId)),
             cb => mpuSetup(awsLocation, objectKey, awsUploadId =>
                 cb(null, awsUploadId)),
@@ -681,9 +683,10 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
                     assert.strictEqual(objectKey, mpuListing[2].Key[0]);
                     assert.strictEqual(uploadIds[2], mpuListing[2].UploadId[0]);
                     const backendsInfo = [
-                        { backend: 'file', key: fileKey,
+                        { backend: fileLocation, key: fileKey,
                             uploadId: uploadIds[0] },
-                        { backend: 'mem', key: memKey, uploadId: uploadIds[1] },
+                        { backend: memLocation, key: memKey,
+                            uploadId: uploadIds[1] },
                         { backend: 'aws', key: objectKey,
                             uploadId: uploadIds[2] },
                     ];

--- a/tests/multipleBackend/objectPut.js
+++ b/tests/multipleBackend/objectPut.js
@@ -15,6 +15,8 @@ const bucketName = 'bucketname';
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const objectName = 'objectName';
+const fileLocation = 'file-test';
+const memLocation = 'mem-test';
 
 const describeSkipIfE2E = process.env.S3_END_TO_END ? describe.skip : describe;
 
@@ -75,35 +77,35 @@ describeSkipIfE2E('objectPutAPI with multiple backends', function testSuite() {
     });
 
     it('should put an object to mem', done => {
-        put('file', 'mem', 'localhost', () => {
+        put(fileLocation, memLocation, 'localhost', () => {
             assert.deepStrictEqual(ds[1].value, body);
             done();
         });
     });
 
     it('should put an object to file', done => {
-        put('mem', 'file', 'localhost', () => {
+        put(memLocation, fileLocation, 'localhost', () => {
             assert.deepStrictEqual(ds, []);
             done();
         });
     });
 
     it('should put an object to AWS', done => {
-        put('mem', 'aws-test', 'localhost', () => {
+        put(memLocation, 'aws-test', 'localhost', () => {
             assert.deepStrictEqual(ds, []);
             done();
         });
     });
 
     it('should put an object to mem based on bucket location', done => {
-        put('mem', null, 'localhost', () => {
+        put(memLocation, null, 'localhost', () => {
             assert.deepStrictEqual(ds[1].value, body);
             done();
         });
     });
 
     it('should put an object to file based on bucket location', done => {
-        put('file', null, 'localhost', () => {
+        put(fileLocation, null, 'localhost', () => {
             assert.deepStrictEqual(ds, []);
             done();
         });
@@ -124,7 +126,7 @@ describeSkipIfE2E('objectPutAPI with multiple backends', function testSuite() {
     });
 
     it('should put an object to Azure based on object location', done => {
-        put('mem', 'azuretest', 'localhost', () => {
+        put(memLocation, 'azuretest', 'localhost', () => {
             assert.deepStrictEqual(ds, []);
             done();
         });

--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -29,6 +29,8 @@ const destObjName = 'copycatobject';
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
 const body = Buffer.from('I am a body', 'utf8');
 
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
 const awsBucket = 'multitester555';
 const awsLocation = 'aws-test';
 const awsLocation2 = 'aws-test-2';
@@ -163,7 +165,7 @@ function testSuite() {
     });
 
     it('should copy part to mem based on mpu location', done => {
-        copyPutPart('file', 'mem', null, 'localhost', () => {
+        copyPutPart(fileLocation, memLocation, null, 'localhost', () => {
             // object info is stored in ds beginning at index one,
             // so an array length of two means only one object
             // was stored in mem
@@ -174,14 +176,14 @@ function testSuite() {
     });
 
     it('should copy part to file based on mpu location', done => {
-        copyPutPart('mem', 'file', null, 'localhost', () => {
+        copyPutPart(memLocation, fileLocation, null, 'localhost', () => {
             assert.strictEqual(ds.length, 2);
             done();
         });
     });
 
     it('should copy part to AWS based on mpu location', done => {
-        copyPutPart('mem', awsLocation, null, 'localhost', uploadId => {
+        copyPutPart(memLocation, awsLocation, null, 'localhost', uploadId => {
             assert.strictEqual(ds.length, 2);
             const awsReq = Object.assign({ UploadId: uploadId }, awsParams);
             s3.listParts(awsReq, (err, partList) => {
@@ -196,7 +198,7 @@ function testSuite() {
     });
 
     it('should copy part to mem from AWS based on mpu location', done => {
-        copyPutPart(awsLocation, 'mem', null, 'localhost', () => {
+        copyPutPart(awsLocation, memLocation, null, 'localhost', () => {
             assert.strictEqual(ds.length, 2);
             assert.deepStrictEqual(ds[1].value, body);
             done();
@@ -204,7 +206,7 @@ function testSuite() {
     });
 
     it('should copy part to mem based on bucket location', done => {
-        copyPutPart('mem', null, null, 'localhost', () => {
+        copyPutPart(memLocation, null, null, 'localhost', () => {
             // ds length should be three because both source
             // and copied objects should be in mem
             assert.strictEqual(ds.length, 3);
@@ -214,7 +216,7 @@ function testSuite() {
     });
 
     it('should copy part to file based on bucket location', done => {
-        copyPutPart('file', null, null, 'localhost', () => {
+        copyPutPart(fileLocation, null, null, 'localhost', () => {
             // ds should be empty because both source and
             // coped objects should be in file
             assert.deepStrictEqual(ds, []);
@@ -282,7 +284,7 @@ function testSuite() {
 
 
     it('should copy part to file based on request endpoint', done => {
-        copyPutPart(null, null, 'mem', 'localhost', () => {
+        copyPutPart(null, null, memLocation, 'localhost', () => {
             assert.strictEqual(ds.length, 2);
             done();
         });

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -17,6 +17,8 @@ const constants = require('../../constants');
 const { getRealAwsConfig } =
     require('../functional/aws-node-sdk/test/support/awsConfig');
 
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
 const awsLocation = 'aws-test';
 const awsLocationMismatch = 'aws-test-mismatch';
 const awsConfig = getRealAwsConfig(awsLocation);
@@ -168,7 +170,7 @@ function testSuite() {
     });
 
     it('should upload a part to file based on mpu location', done => {
-        putPart('mem', 'file', 'localhost', () => {
+        putPart(memLocation, fileLocation, 'localhost', () => {
             // if ds is empty, the object is not in mem, which means it
             // must be in file because those are the only possibilities
             // for unit tests
@@ -178,14 +180,14 @@ function testSuite() {
     });
 
     it('should put a part to mem based on mpu location', done => {
-        putPart('file', 'mem', 'localhost', () => {
+        putPart(fileLocation, memLocation, 'localhost', () => {
             assert.deepStrictEqual(ds[1].value, body1);
             done();
         });
     });
 
     it('should put a part to AWS based on mpu location', done => {
-        putPart('file', awsLocation, 'localhost', uploadId => {
+        putPart(fileLocation, awsLocation, 'localhost', uploadId => {
             assert.deepStrictEqual(ds, []);
             listAndAbort(uploadId, null, objectName, done);
         });
@@ -193,7 +195,7 @@ function testSuite() {
 
     it('should replace part if two parts uploaded with same part number to AWS',
     done => {
-        putPart('file', awsLocation, 'localhost', uploadId => {
+        putPart(fileLocation, awsLocation, 'localhost', uploadId => {
             assert.deepStrictEqual(ds, []);
             const partReqParams = {
                 bucketName,
@@ -216,21 +218,21 @@ function testSuite() {
 
     it('should upload part based on mpu location even if part ' +
         'location constraint is specified ', done => {
-        putPart('file', 'mem', 'localhost', () => {
+        putPart(fileLocation, memLocation, 'localhost', () => {
             assert.deepStrictEqual(ds[1].value, body1);
             done();
         });
     });
 
     it('should put a part to file based on bucket location', done => {
-        putPart('file', null, 'localhost', () => {
+        putPart(fileLocation, null, 'localhost', () => {
             assert.deepStrictEqual(ds, []);
             done();
         });
     });
 
     it('should put a part to mem based on bucket location', done => {
-        putPart('mem', null, 'localhost', () => {
+        putPart(memLocation, null, 'localhost', () => {
             assert.deepStrictEqual(ds[1].value, body1);
             done();
         });

--- a/tests/unit/api/bucketPut.js
+++ b/tests/unit/api/bucketPut.js
@@ -26,28 +26,28 @@ const testRequest = {
 
 const testChecks = [
     {
-        data: 'file',
-        locationSent: 'file',
+        data: 'file-test',
+        locationSent: 'file-test',
         parsedHost: '127.1.2.3',
-        locationReturn: 'file',
+        locationReturn: 'file-test',
         isError: false,
     },
     {
-        data: 'file',
+        data: 'file-test',
         locationSent: 'wronglocation',
         parsedHost: '127.1.0.0',
         locationReturn: undefined,
         isError: true,
     },
     {
-        data: 'file',
+        data: 'file-test',
         locationSent: '',
         parsedHost: '127.0.0.1',
         locationReturn: config.restEndpoints['127.0.0.1'],
         isError: false,
     },
     {
-        data: 'file',
+        data: 'file-test',
         locationSent: '',
         parsedHost: '127.3.2.1',
         locationReturn: 'us-east-1',

--- a/tests/unit/api/multipartDelete.js
+++ b/tests/unit/api/multipartDelete.js
@@ -34,7 +34,7 @@ const initiateRequest = {
     url: `/${objectKey}?uploads`,
 };
 const eastLocation = 'us-east-1';
-const westLocation = 'file';
+const westLocation = 'file-test';
 
 function _createAndAbortMpu(usEastSetting, fakeUploadID, locationConstraint,
     callback) {

--- a/tests/unit/api/multipartUpload.js
+++ b/tests/unit/api/multipartUpload.js
@@ -38,7 +38,7 @@ const bucketPutRequest = {
     url: '/',
     post: '<CreateBucketConfiguration ' +
     'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
-    '<LocationConstraint>mem</LocationConstraint>' +
+    '<LocationConstraint>mem-test</LocationConstraint>' +
     '</CreateBucketConfiguration >',
 };
 const objectKey = 'testObject';
@@ -101,7 +101,8 @@ describe('Multipart Upload API', () => {
     });
 
     it('should initiate a multipart upload', done => {
-        bucketPut(authInfo, bucketPutRequest, log, () => {
+        bucketPut(authInfo, bucketPutRequest, log, err => {
+            assert.strictEqual(err, null, `err putting bucket: ${err}`);
             initiateMultipartUpload(authInfo, initiateRequest,
                 log, (err, result) => {
                     assert.strictEqual(err, null);

--- a/tests/unit/api/objectReplicationMD.js
+++ b/tests/unit/api/objectReplicationMD.js
@@ -157,7 +157,7 @@ function putMPU(key, body, cb) {
     const obj = {
         partLocations: [{
             key: 1,
-            dataStoreName: 'mem',
+            dataStoreName: 'mem-test',
             dataStoreETag: `1:${calculatedHash}`,
         }],
         key: partKey,

--- a/tests/unit/multipleBackend/BackendInfo.js
+++ b/tests/unit/multipleBackend/BackendInfo.js
@@ -6,7 +6,10 @@ const { config } = require('../../../lib/Config');
 const log = new DummyRequestLogger();
 const data = config.backends.data;
 
-const dummyBackendInfo = new BackendInfo('mem', 'file', '127.0.0.1');
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
+const dummyBackendInfo = new BackendInfo(memLocation, fileLocation,
+    '127.0.0.1');
 
 describe('BackendInfo class', () => {
     describe('controllingBackendParam', () => {
@@ -16,7 +19,7 @@ describe('BackendInfo class', () => {
         it('should return object with applicable error if ' +
         'objectLocationConstraint is invalid', () => {
             const res = BackendInfo.controllingBackendParam(
-                'notValid', 'file', '127.0.0.1', log);
+                'notValid', fileLocation, '127.0.0.1', log);
             assert.equal(res.isValid, false);
             assert((res.description).indexOf('Object Location Error')
             > -1);
@@ -55,14 +58,14 @@ describe('BackendInfo class', () => {
         'is invalid and data backend is set to "file"', () => {
             config.backends.data = 'file';
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'file', 'notValid', log);
+                memLocation, fileLocation, 'notValid', log);
             assert.equal(res.isValid, true);
         });
         it('should return isValid if requestEndpoint ' +
         'is invalid and data backend is set to "mem"', () => {
             config.backends.data = 'mem';
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'file', 'notValid', log);
+                memLocation, fileLocation, 'notValid', log);
             assert.equal(res.isValid, true);
         });
         it('should return isValid if requestEndpoint ' +
@@ -70,7 +73,7 @@ describe('BackendInfo class', () => {
         'was provided', () => {
             config.backends.data = 'multiple';
             const res = BackendInfo.controllingBackendParam(
-                'mem', undefined, 'notValid', log);
+                memLocation, undefined, 'notValid', log);
             assert.equal(res.isValid, true);
         });
         it('should return isValid if requestEndpoint ' +
@@ -78,13 +81,13 @@ describe('BackendInfo class', () => {
         'was provided', () => {
             config.backends.data = 'multiple';
             const res = BackendInfo.controllingBackendParam(
-                undefined, 'mem', 'notValid', log);
+                undefined, memLocation, 'notValid', log);
             assert.equal(res.isValid, true);
         });
         it('should return isValid if all backend ' +
         'parameters are valid', () => {
             const res = BackendInfo.controllingBackendParam(
-                'mem', 'file', '127.0.0.1', log);
+                memLocation, fileLocation, '127.0.0.1', log);
             assert.equal(res.isValid, true);
         });
     });
@@ -92,19 +95,19 @@ describe('BackendInfo class', () => {
         it('should return object location constraint', () => {
             const controllingLC =
                 dummyBackendInfo.getControllingLocationConstraint();
-            assert.strictEqual(controllingLC, 'mem');
+            assert.strictEqual(controllingLC, memLocation);
         });
     });
     describe('getters', () => {
         it('should return object location constraint', () => {
             const objectLC =
                 dummyBackendInfo.getObjectLocationConstraint();
-            assert.strictEqual(objectLC, 'mem');
+            assert.strictEqual(objectLC, memLocation);
         });
         it('should return bucket location constraint', () => {
             const bucketLC =
                 dummyBackendInfo.getBucketLocationConstraint();
-            assert.strictEqual(bucketLC, 'file');
+            assert.strictEqual(bucketLC, fileLocation);
         });
         it('should return request endpoint', () => {
             const reqEndpoint =

--- a/tests/unit/multipleBackend/locConstraintParse.js
+++ b/tests/unit/multipleBackend/locConstraintParse.js
@@ -3,20 +3,23 @@ const parseLC = require('../../../lib/data/locationConstraintParser');
 const inMemory = require('../../../lib/data/in_memory/backend').backend;
 const DataFileInterface = require('../../../lib/data/file/backend');
 
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
+const awsLocation = 'aws-test';
 const clients = parseLC();
 
 describe('locationConstraintParser', () => {
     it('should return object containing mem object', () => {
-        assert.notEqual(Object.keys(clients).indexOf('mem'), -1);
-        assert.strictEqual(typeof clients.mem, 'object');
-        assert.deepEqual(clients.mem, inMemory);
+        assert.notEqual(Object.keys(clients).indexOf(memLocation), -1);
+        assert.strictEqual(typeof clients[memLocation], 'object');
+        assert.deepEqual(clients[memLocation], inMemory);
     });
     it('should return object containing file object', () => {
-        assert.notEqual(Object.keys(clients).indexOf('file'), -1);
-        assert(clients.file instanceof DataFileInterface);
+        assert.notEqual(Object.keys(clients).indexOf(fileLocation), -1);
+        assert(clients[fileLocation] instanceof DataFileInterface);
     });
     it('should return object containing AWS object', () => {
-        assert.notEqual(Object.keys(clients).indexOf('aws-test'), -1);
-        assert.strictEqual(typeof clients.file, 'object');
+        assert.notEqual(Object.keys(clients).indexOf(awsLocation), -1);
+        assert.strictEqual(typeof clients[awsLocation], 'object');
     });
 });

--- a/tests/unit/multipleBackend/locationConstraintCheck.js
+++ b/tests/unit/multipleBackend/locationConstraintCheck.js
@@ -6,11 +6,13 @@ const { DummyRequestLogger } = require('../helpers');
 const locationConstraintCheck
     = require('../../../lib/api/apiUtils/object/locationConstraintCheck');
 
+const memLocation = 'mem-test';
+const fileLocation = 'file-test';
 const bucketName = 'nameOfBucket';
 const owner = 'canonicalID';
 const ownerDisplayName = 'bucketOwner';
 const testDate = new Date().toJSON();
-const locationConstraint = 'file';
+const locationConstraint = fileLocation;
 const namespace = 'default';
 const objectKey = 'someobject';
 const postBody = Buffer.from('I am a body', 'utf8');
@@ -46,16 +48,16 @@ describe('Location Constraint Check', () => {
     it('should return instance of BackendInfo with correct ' +
     'locationConstraints', done => {
         const backendInfoObj = locationConstraintCheck(
-            createTestRequest('mem'), null, testBucket, log);
+            createTestRequest(memLocation), null, testBucket, log);
         assert.strictEqual(backendInfoObj.err, null, 'Expected success ' +
             `but got error ${backendInfoObj.err}`);
         assert.strictEqual(typeof backendInfoObj.controllingLC, 'string');
         assert.equal(backendInfoObj.backendInfo instanceof BackendInfo,
             true);
         assert.strictEqual(backendInfoObj.
-            backendInfo.getObjectLocationConstraint(), 'mem');
+            backendInfo.getObjectLocationConstraint(), memLocation);
         assert.strictEqual(backendInfoObj.
-            backendInfo.getBucketLocationConstraint(), 'file');
+            backendInfo.getBucketLocationConstraint(), fileLocation);
         assert.strictEqual(backendInfoObj.backendInfo.getRequestEndpoint(),
             'localhost');
         done();


### PR DESCRIPTION
Thanks to @bennettbuchanan for reporting a bug introduced by 7a02f4c58e6af3d4b36461a5303a01534925ca59 which crashes the service when using object GET without multiple backends (`S3DATA=multiple`).

The following error was thrown at the line https://github.com/scality/S3/blob/master/lib/data/multipleBackendGateway.js#L71:
```
{"name":"S3","time":1507317236361,"error":"Cannot read property 'head' of undefined","stack":"TypeError: Cannot read property 'head' of undefined\n    at Object.head (/Users/bennettbuchanan/repos/scality/S3/lib/data/multipleBackendGateway.js:72:19)\n    at metadataValidateBucketAndObj (/Users/bennettbuchanan/repos/scality/S3/lib/api/objectGet.js:191:39)\n    at async.waterfall (/Users/bennettbuchanan/repos/scality/S3/lib/metadata/metadataUtils.js:210:16)\n    at /Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:421:16\n    at next (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5302:29)\n    at /Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:906:16\n    at checkObjectAuth (/Users/bennettbuchanan/repos/scality/S3/lib/metadata/metadataUtils.js:203:20)\n    at nextTask (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5297:14)\n    at next (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5304:9)\n    at /Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:906:16\n    at handleNullVersionGet (/Users/bennettbuchanan/repos/scality/S3/lib/metadata/metadataUtils.js:193:20)\n    at nextTask (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5297:14)\n    at next (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5304:9)\n    at /Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:906:16\n    at checkBucketAuth (/Users/bennettbuchanan/repos/scality/S3/lib/metadata/metadataUtils.js:186:20)\n    at nextTask (/Users/bennettbuchanan/repos/scality/S3/node_modules/async/dist/async.js:5297:14)","workerId":11,"workerPid":3244,"level":"fatal","message":"caught error","hostname":"Bennetts-MacBook-Pro-2.local","pid":3244}
```

The client was undefined in multipleBackendGateway because we were expecting the `dataStoreName` saved in `objectGetInfo` to be the name of  the location constraint (e.g. "us-east-1"), but it is `implName`(e.g. "file" or "mem") when not using `S3DATA=multiple` (see: https://github.com/scality/S3/blob/master/lib/data/wrapper.js#L118).

The error was not caught by our CI tests because we test with a locationConfig file that has location constraints named "file" and "mem" (coincidentally same as the `implNames`). The default locationConfig, which Bennett was testing with, does not have these location constraints.

Testing locally with the default locationConfig file, the changes in this PR fix the bug, but creating tests for the CI will involve additional work since we either have to create an additional location config file to test with or modify the existing one (and related tests).