### PR TITLE
FT: Add replication to AWS backbeat route

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -11,6 +11,8 @@ const { dataStore } = require('../api/apiUtils/object/storeObject');
 const prepareRequestContexts = require(
 '../api/apiUtils/authorization/prepareRequestContexts');
 const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
+const { locationConstraints } = require('../Config').config;
 
 auth.setHandler(vault);
 
@@ -57,21 +59,34 @@ function _getRequestPayload(req, cb) {
     .on('end', () => cb(null, Buffer.concat(payload, payloadLen).toString()));
 }
 
+function _isValidLocation(request) {
+    const { bucketName, headers } = request;
+    const storageType = headers['x-scal-storage-type'];
+    const storageLocation = headers['x-scal-storage-class'];
+    return locationConstraints[storageLocation] &&
+        locationConstraints[storageLocation].type === storageType &&
+        locationConstraints[storageLocation].details.bucketName === bucketName;
+}
+
 /*
 PUT /_/backbeat/metadata/<bucket name>/<object key>
 PUT /_/backbeat/data/<bucket name>/<object key>
+PUT /_/backbeat/multiplebackendputobject/<bucket name>/<object key>
 */
 
 function putData(request, response, bucketInfo, objMd, log, callback) {
+    let errMessage;
     const canonicalID = request.headers['x-scal-canonical-id'];
     if (canonicalID === undefined) {
-        log.error('bad request: missing x-scal-canonical-id header');
-        return callback(errors.BadRequest);
+        errMessage = 'bad request: missing x-scal-canonical-id header';
+        log.error(errMessage);
+        return callback(errors.BadRequest.customizeDescription(errMessage));
     }
     const contentMD5 = request.headers['content-md5'];
     if (contentMD5 === undefined) {
-        log.error('bad request: missing content-md5 header');
-        return callback(errors.BadRequest);
+        errMessage = 'bad request: missing content-md5 header';
+        log.error(errMessage);
+        return callback(errors.BadRequest.customizeDescription(errMessage));
     }
     const context = {
         bucketName: request.bucketName,
@@ -94,6 +109,10 @@ function putData(request, response, bucketInfo, objMd, log, callback) {
         context, CIPHER, request, payloadLen, {},
         backendInfo, log, (err, retrievalInfo, md5) => {
             if (err) {
+                log.error('error putting data', {
+                    error: err,
+                    method: 'putData',
+                });
                 return callback(err);
             }
             if (contentMD5 !== md5) {
@@ -144,6 +163,10 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
         return metadata.putObjectMD(bucketName, objectKey, omVal, options, log,
             (err, md) => {
                 if (err) {
+                    log.error('error putting object metadata', {
+                        error: err,
+                        method: 'putMetadata',
+                    });
                     return callback(err);
                 }
                 return _respond(response, md, log, callback);
@@ -151,10 +174,67 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
     });
 }
 
+function multipleBackendPutObject(request, response, bucketInfo, objMd, log,
+    callback) {
+    const storageLocation = request.headers['x-scal-storage-class'];
+    let errMessage;
+    const canonicalID = request.headers['x-scal-canonical-id'];
+    if (canonicalID === undefined) {
+        errMessage = 'bad request: missing x-scal-canonical-id header';
+        log.error(errMessage);
+        return callback(errors.BadRequest.customizeDescription(errMessage));
+    }
+    const contentMD5 = request.headers['content-md5'];
+    if (contentMD5 === undefined) {
+        errMessage = 'bad request: missing content-md5 header';
+        log.error(errMessage);
+        return callback(errors.BadRequest.customizeDescription(errMessage));
+    }
+    const sourceVersionId = request.headers['x-scal-version-id'];
+    if (sourceVersionId === undefined) {
+        errMessage = 'bad request: missing x-scal-version-id header';
+        log.error(errMessage);
+        return callback(errors.BadRequest.customizeDescription(errMessage));
+    }
+    const metaHeaders = {
+        'x-amz-meta-scal-location-constraint': storageLocation,
+        'x-amz-meta-scal-replication-status': 'REPLICA',
+        'x-amz-meta-scal-version-id': sourceVersionId,
+    };
+    const context = {
+        bucketName: request.bucketName,
+        owner: canonicalID,
+        namespace: NAMESPACE,
+        objectKey: request.objectKey,
+        metaHeaders,
+    };
+    const payloadLen = parseInt(request.headers['content-length'], 10);
+    const backendInfo = new BackendInfo(storageLocation);
+    return dataStore(context, CIPHER, request, payloadLen, {}, backendInfo, log,
+        (err, retrievalInfo, md5) => {
+            if (err) {
+                log.error('error putting data', {
+                    error: err,
+                    method: 'multipleBackendPutObject',
+                });
+                return callback(err);
+            }
+            if (contentMD5 !== md5) {
+                return callback(errors.BadDigest);
+            }
+            const dataRetrievalInfo = {
+                versionId: retrievalInfo.dataStoreVersionId,
+            };
+            return _respond(response, dataRetrievalInfo, log, callback);
+        });
+}
 
 const backbeatRoutes = {
-    PUT: { data: putData,
-        metadata: putMetadata },
+    PUT: {
+        data: putData,
+        metadata: putMetadata,
+        multiplebackendputobject: multipleBackendPutObject,
+    },
 };
 
 function routeBackbeat(clientIP, request, response, log) {
@@ -170,8 +250,9 @@ function routeBackbeat(clientIP, request, response, log) {
         });
         return responseJSONBody(errors.MethodNotAllowed, null, response, log);
     }
-    const requestContexts = prepareRequestContexts('objectReplicate',
-                                                   request);
+    const requestContexts = prepareRequestContexts('objectReplicate', request);
+    const usingMultipleBackend = request.resourceType
+        .startsWith('multiplebackend');
     return async.waterfall([next => auth.server.doAuth(
         request, log, (err, userInfo) => {
             if (err) {
@@ -185,6 +266,10 @@ function routeBackbeat(clientIP, request, response, log) {
             return next(err, userInfo);
         }, 's3', requestContexts),
         (userInfo, next) => {
+            if (usingMultipleBackend) {
+                // Bucket and object do not exist in metadata.
+                return next(null, null, null);
+            }
             const mdValParams = { bucketName: request.bucketName,
                 objectKey: request.objectKey,
                 authInfo: userInfo,
@@ -198,17 +283,31 @@ function routeBackbeat(clientIP, request, response, log) {
                 log.debug('no such route', { method: request.method,
                     bucketName: request.bucketName,
                     objectKey: request.objectKey,
-                    resourceType:
-                                             request.resourceType });
+                    resourceType: request.resourceType,
+                });
                 return next(errors.MethodNotAllowed);
+            }
+            if (usingMultipleBackend) {
+                if (!_isValidLocation(request)) {
+                    log.debug('invalid location constraint in request', {
+                        method: request.method,
+                        bucketName: request.bucketName,
+                        objectKey: request.objectKey,
+                        resourceType: request.resourceType,
+                    });
+                    return next(errors.InvalidRequest);
+                }
+                return backbeatRoutes[request.method][request.resourceType](
+                    request, response, bucketInfo, objMd, log, next);
             }
             const versioningConfig = bucketInfo.getVersioningConfiguration();
             if (!versioningConfig || versioningConfig.Status !== 'Enabled') {
-                log.debug('bucket versioning is not enabled',
-                    { method: request.method,
-                        bucketName: request.bucketName,
-                        objectKey: request.objectKey,
-                        resourceType: request.resourceType });
+                log.debug('bucket versioning is not enabled', {
+                    method: request.method,
+                    bucketName: request.bucketName,
+                    objectKey: request.objectKey,
+                    resourceType: request.resourceType,
+                });
                 return next(errors.InvalidBucketState);
             }
             return backbeatRoutes[request.method][request.resourceType](


### PR DESCRIPTION
Adds route for replication of single-part objects to AWS.

Forthcoming replication operation support:
* MPU objects
* Metadata-only operations (zero-byte objects, putting object ACLs, etc.)
* Object deletion