### PR TITLE
S3C-1003 FX: COPY External backends encryption

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -766,6 +766,11 @@ class Config extends EventEmitter {
         this.getAzureEndpoint(locationConstraintSrc) ===
         this.getAzureEndpoint(locationConstraintDest) : true;
     }
+
+    isAWSServerSideEncrytion(locationConstraint) {
+        return this.locationConstraints[locationConstraint].details
+        .serverSideEncryption;
+    }
 }
 
 module.exports = {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -769,7 +769,7 @@ class Config extends EventEmitter {
 
     isAWSServerSideEncrytion(locationConstraint) {
         return this.locationConstraints[locationConstraint].details
-        .serverSideEncryption;
+        .serverSideEncryption === true;
     }
 }
 

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -93,6 +93,7 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
     }
     // If metadataDirective is 'COPY' and location constraint header is
     // specified, new location constraint should override source object's
+    console.log('headers[locationHeader]!!!!', headers[locationHeader]);
     if (whichMetadata === 'COPY' && headers[locationHeader]) {
         userMetadata[locationHeader] = headers[locationHeader];
     }

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -291,11 +291,12 @@ function objectCopy(authInfo, request, sourceBucket,
                         }
                     }
                     return next(null, storeMetadataParams, dataLocator,
-                        destBucketMD, destObjMD, sourceLocationConstraintName);
+                    sourceBucketMD, destBucketMD, destObjMD,
+                    sourceLocationConstraintName);
                 });
         },
-        function goGetData(storeMetadataParams, dataLocator, destBucketMD,
-            destObjMD, sourceLocationConstraintName, next) {
+        function goGetData(storeMetadataParams, dataLocator, sourceBucketMD,
+            destBucketMD, destObjMD, sourceLocationConstraintName, next) {
             const serverSideEncryption = destBucketMD.getServerSideEncryption();
 
             const backendInfoObj = locationConstraintCheck(request,
@@ -362,7 +363,7 @@ function objectCopy(authInfo, request, sourceBucket,
 
             return data.copyObject(request, sourceLocationConstraintType,
               sourceLocationConstraintName, storeMetadataParams, dataLocator,
-              dataStoreContext, backendInfo, serverSideEncryption, log,
+              dataStoreContext, backendInfo, sourceBucketMD, destBucketMD, log,
             (err, results) => {
                 if (err) {
                     return next(err, destBucketMD);

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -6,6 +6,8 @@ const createLogger = require('../multipleBackendLogger');
 const { prepareStream } = require('../../api/apiUtils/object/prepareStream');
 const { logHelper, removeQuotes, trimXMetaPrefix } = require('./utils');
 const { config } = require('../../Config');
+const constants = require('../../../constants');
+const locationHeader = constants.objectLocationConstraintHeader;
 
 class AwsClient {
     constructor(config) {
@@ -403,21 +405,28 @@ class AwsClient {
     callback) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
+        const headers = request.headers;
         const destAwsKey = this._createAwsKey(destBucketName, destObjectKey,
           this._bucketMatch);
 
         const sourceAwsBucketName =
           config.getAwsBucketName(sourceLocationConstraintName);
 
-        const metadataDirective = request.headers['x-amz-metadata-directive'];
-        const metaHeaders = trimXMetaPrefix(getMetaHeaders(request.headers));
-        this._client.copyObject({
+        const metadataDirective = headers['x-amz-metadata-directive'];
+        const metaHeaders = trimXMetaPrefix(getMetaHeaders(headers));
+        const s3Params = {
             Bucket: this._awsBucketName,
             Key: destAwsKey,
             CopySource: `${sourceAwsBucketName}/${sourceKey}`,
             Metadata: metaHeaders,
             MetadataDirective: metadataDirective,
-        }, err => {
+        };
+        const isAWSServerSideEncrytion = headers[locationHeader] ?
+        config.isAWSServerSideEncrytion(headers[locationHeader]) : false;
+        if (isAWSServerSideEncrytion) {
+            s3Params.ServerSideEncryption = 'AES256';
+        }
+        this._client.copyObject(s3Params, err => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -401,8 +401,8 @@ class AwsClient {
             return callback();
         });
     }
-    copyObject(request, sourceKey, sourceLocationConstraintName, log,
-    callback) {
+    copyObject(request, sourceKey, sourceLocationConstraintName, destBucketMD,
+    log, callback) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
         const headers = request.headers;
@@ -421,9 +421,17 @@ class AwsClient {
             Metadata: metaHeaders,
             MetadataDirective: metadataDirective,
         };
-        const isAWSServerSideEncrytion = headers[locationHeader] ?
-        config.isAWSServerSideEncrytion(headers[locationHeader]) : false;
-        if (isAWSServerSideEncrytion) {
+        // NOTE: - if server side encrytion OR
+        // - if the destination bucket is an AWS serviceSideEncryption
+        // location
+        console.log('destBucketMD.getLocationConstraint()!!!', destBucketMD.getLocationConstraint());
+        if ((headers[locationHeader] &&
+          config.isAWSServerSideEncrytion(headers[locationHeader])) ||
+          (destBucketMD.getLocationConstraint() &&
+            config.isAWSServerSideEncrytion(
+              destBucketMD.getLocationConstraint()))
+        ) {
+            console.log('HERE!!!!');
             s3Params.ServerSideEncryption = 'AES256';
         }
         this._client.copyObject(s3Params, err => {

--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -322,7 +322,7 @@ class AzureClient {
     }
 
     copyObject(request, sourceKey, sourceLocationConstraintName, log,
-    callback) {
+    destBucketMD, callback) {
         const destContainerName = request.bucketName;
         const destObjectKey = request.objectKey;
 

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -243,11 +243,11 @@ const multipleBackendGateway = {
     // NOTE: using copyObject only if copying object from one external
     // backend to the same external backend
     copyObject: (request, location, externalSourceKey,
-    sourceLocationConstraintName, log, cb) => {
+    sourceLocationConstraintName, destBucketMD, log, cb) => {
         const client = clients[location];
         if (client.copyObject) {
             return client.copyObject(request, externalSourceKey,
-            sourceLocationConstraintName, log, (err, key) => {
+            sourceLocationConstraintName, destBucketMD, log, (err, key) => {
                 const dataRetrievalInfo = {
                     key,
                     dataStoreName: location,

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -388,6 +388,7 @@ const data = {
         const sourceBucketName = sourceBucketMD.getName();
         const destBucketName = request.bucketName;
         const isSameBucket = sourceBucketName === destBucketName;
+        console.log('destBucketMD!!!', destBucketMD);
         const serverSideEncryption = destBucketMD.getServerSideEncryption();
         const bucketNotEncrypted = serverSideEncryption
         === sourceBucketMD.getServerSideEncryption() === null;
@@ -400,7 +401,7 @@ const data = {
             const objectGetInfo = dataLocator[0];
             const externalSourceKey = objectGetInfo.key;
             return client.copyObject(request, location,
-            externalSourceKey, sourceLocationConstraintName, log,
+            externalSourceKey, sourceLocationConstraintName, destBucketMD, log,
             (error, objectRetrievalInfo) => {
                 if (error) {
                     return cb(error);

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -299,7 +299,7 @@ const data = {
                     log.debug('error getting cipherBundle');
                     return cb(errors.InternalError);
                 }
-                return data.put(null, stream,
+                return data.put(cipherBundle, stream,
                 part.size,
                 dataStoreContext, destBackendInfo,
                 log, (error, partRetrievalInfo) => {

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -289,6 +289,60 @@ const data = {
         return client.getDiskUsage(log.getSerializedUids(), cb);
     },
 
+    _dataCopyPut: (serverSideEncryption, stream, part,
+      dataStoreContext, destBackendInfo, log, cb) => {
+        if (serverSideEncryption) {
+            return kms.createCipherBundle(
+            serverSideEncryption,
+            log, (err, cipherBundle) => {
+                if (err) {
+                    log.debug('error getting cipherBundle');
+                    return cb(errors.InternalError);
+                }
+                return data.put(null, stream,
+                part.size,
+                dataStoreContext, destBackendInfo,
+                log, (error, partRetrievalInfo) => {
+                    if (error) {
+                        return cb(error);
+                    }
+                    const partResult = {
+                        key: partRetrievalInfo.key,
+                        dataStoreName: partRetrievalInfo
+                            .dataStoreName,
+                        dataStoreType: partRetrievalInfo
+                            .dataStoreType,
+                        start: part.start,
+                        size: part.size,
+                        cryptoScheme: cipherBundle
+                            .cryptoScheme,
+                        cipheredDataKey: cipherBundle
+                            .cipheredDataKey,
+                    };
+                    return cb(null, partResult);
+                });
+            });
+        }
+        return data.put(null, stream, part.size,
+        dataStoreContext, destBackendInfo,
+        log, (error, partRetrievalInfo) => {
+            if (error) {
+                return cb(error);
+            }
+            const partResult = {
+                key: partRetrievalInfo.key,
+                dataStoreType: partRetrievalInfo
+                    .dataStoreType,
+                dataStoreName: partRetrievalInfo.
+                    dataStoreName,
+                dataStoreETag: part.dataStoreETag,
+                start: part.start,
+                size: part.size,
+            };
+            return cb(null, partResult);
+        });
+    },
+
     /**
      * copyObject - copy object
      * @param {object} request - request object
@@ -309,23 +363,35 @@ const data = {
      * @param {BackendInfo} destBackendInfo - Instance of BackendInfo:
      * Represents the info necessary to evaluate which data backend to use
      * on a data put call.
-     * @param {object} serverSideEncryption - serverSideEncryption
+     * @param {object} sourceBucketMD - bucket metadata of the source
+     * @param {object} destBucketMD - bucket metadata of the destination
      * @param {object} log - Werelogs request logger
      * @param {function} cb - callback
      * @returns {function} cb - callback
      */
     copyObject: (request, sourceLocationConstraintType,
       sourceLocationConstraintName, storeMetadataParams, dataLocator,
-      dataStoreContext, destBackendInfo, serverSideEncryption, log, cb) => {
-        // NOTE: using copyObject only if copying object from one external
-        // backend to the same external backend
-        // and for Azure if it is the same account since Azure copy outside
-        // of an account is async
+      dataStoreContext, destBackendInfo, sourceBucketMD, destBucketMD, log,
+      cb) => {
+        // NOTE: Server side copy should only be allowed:
+        // 1) if source object and destination object are both on aws or both
+        // on azure.
+        // 2) if azure to azure, must be the same storage account since Azure
+        // copy outside of an account is async
+        // 3) if the source bucket is not an encrypted bucket and the
+        // destination bucket is not an encrypted bucket (unless the copy
+        // is all within the same bucket).
         const locationTypeMatch = request.headers[locationHeader] ?
         config.getLocationConstraintType(sourceLocationConstraintName) ===
         config.getLocationConstraintType(request.headers[locationHeader])
         : true;
-        if (locationTypeMatch &&
+        const sourceBucketName = sourceBucketMD.getName();
+        const destBucketName = request.bucketName;
+        const isSameBucket = sourceBucketName === destBucketName;
+        const serverSideEncryption = destBucketMD.getServerSideEncryption();
+        const bucketNotEncrypted = serverSideEncryption
+        === sourceBucketMD.getServerSideEncryption() === null;
+        if (locationTypeMatch && (isSameBucket || bucketNotEncrypted) &&
         (sourceLocationConstraintType === 'aws_s3' ||
         (sourceLocationConstraintType === 'azure' && config.isSameAzureAccount(
         sourceLocationConstraintName, request.headers[locationHeader])))) {
@@ -360,93 +426,30 @@ const data = {
         // copied at once.
         return async.mapLimit(dataLocator, 1,
             // eslint-disable-next-line prefer-arrow-callback
-            function copyPart(part, cb) {
+            function copyPart(part, copyCb) {
                 if (part.dataStoreType === 'azure') {
                     const passThrough = new PassThrough();
                     return async.parallel([
-                        next => data.get(part, passThrough, log, err =>
-                          next(err)),
-                        next => data.put(null, passThrough, part.size,
-                        dataStoreContext, destBackendInfo,
-                        log, (error, partRetrievalInfo) => {
-                            if (error) {
-                                return next(error);
-                            }
-                            const partResult = {
-                                key: partRetrievalInfo.key,
-                                dataStoreType: partRetrievalInfo
-                                    .dataStoreType,
-                                dataStoreName: partRetrievalInfo.
-                                    dataStoreName,
-                                dataStoreETag: part.dataStoreETag,
-                                start: part.start,
-                                size: part.size,
-                            };
-                            return next(null, partResult);
-                        }),
+                        parallelCb => data.get(part, passThrough, log, err =>
+                          parallelCb(err)),
+                        parallelCb => {
+                            data._dataCopyPut(serverSideEncryption, passThrough,
+                            part, dataStoreContext, destBackendInfo, log,
+                            parallelCb);
+                        },
                     ], (err, res) => {
                         if (err) {
-                            return cb(err);
+                            return copyCb(err);
                         }
-                        return cb(null, res[1]);
+                        return copyCb(null, res[1]);
                     });
                 }
                 return data.get(part, null, log, (err, stream) => {
                     if (err) {
-                        return cb(err);
+                        return copyCb(err);
                     }
-                    if (serverSideEncryption) {
-                        return kms.createCipherBundle(
-                        serverSideEncryption,
-                        log, (err, cipherBundle) => {
-                            if (err) {
-                                log.debug('error getting cipherBundle');
-                                return cb(errors.InternalError);
-                            }
-                            return data.put(cipherBundle, stream,
-                            part.size, dataStoreContext,
-                            destBackendInfo, log,
-                            (error, partRetrievalInfo) => {
-                                if (error) {
-                                    return cb(error);
-                                }
-                                const partResult = {
-                                    key: partRetrievalInfo.key,
-                                    dataStoreName: partRetrievalInfo
-                                        .dataStoreName,
-                                    dataStoreType: partRetrievalInfo
-                                        .dataStoreType,
-                                    start: part.start,
-                                    size: part.size,
-                                    cryptoScheme: cipherBundle
-                                        .cryptoScheme,
-                                    cipheredDataKey: cipherBundle
-                                        .cipheredDataKey,
-                                };
-                                return cb(null, partResult);
-                            });
-                        });
-                    }
-                    // Copied object is not encrypted so just put it
-                    // without a cipherBundle
-                    return data.put(null, stream, part.size,
-                    dataStoreContext, destBackendInfo,
-                    log, (error, partRetrievalInfo) => {
-                        if (error) {
-                            return cb(error);
-                        }
-                        const partResult = {
-                            key: partRetrievalInfo.key,
-                            dataStoreType: partRetrievalInfo
-                                .dataStoreType,
-                            dataStoreName: partRetrievalInfo.
-                                dataStoreName,
-                            dataStoreETag: part.dataStoreETag,
-                            start: part.start,
-                            size: part.size,
-                        };
-                        return cb(null, partResult);
-                    });
+                    return data._dataCopyPut(serverSideEncryption, stream,
+                    part, dataStoreContext, destBackendInfo, log, copyCb);
                 });
             }, (err, results) => {
                 if (err) {


### PR DESCRIPTION
We need to exclude certain scenarios from using AWS/Azure server-side copy (for copy object and copy part) due to encryption.
Server side copy should only be allowed:
1) if source object and destination object are both on aws or both on azure.
2) if azure to azure, must be the same storage acocunt
3) if the source bucket is not an encrypted bucket and the destination bucket is not an encrypted bucket (unless the copy is all within the same bucket).
Also, we should make sure we are sending the sse header to aws if the destination location has SSE set to true in the locationConfig.