### PR TITLE
S3C-1018 FIX: copy with locationConstraint

### DIFF
--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -28,12 +28,14 @@ const externalVersioningErrorMessage = 'We do not currently support putting ' +
 
 /**
  * Preps metadata to be saved (based on copy or replace request header)
+ * @param {object} request - request
  * @param {object} sourceObjMD - object md of source object
  * @param {object} headers - request headers
  * @param {boolean} sourceIsDestination - whether or not source is same as
  * destination
  * @param {AuthInfo} authInfo - authInfo from Vault
  * @param {string} objectKey - destination key name
+ * @param {object} sourceBucketMD - bucket metadata of source bucket
  * @param {object} destBucketMD - bucket metadata of bucket being copied to
  * @param {object} log - logger object
  * @return {object}
@@ -41,8 +43,8 @@ const externalVersioningErrorMessage = 'We do not currently support putting ' +
  * - sourceLocationConstraintName {string} - location type of the source
  * - OR error
  */
-function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
-    objectKey, destBucketMD, log) {
+function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
+    authInfo, objectKey, sourceBucketMD, destBucketMD, log) {
     let whichMetadata = headers['x-amz-metadata-directive'];
     // Default is COPY
     whichMetadata = whichMetadata === undefined ? 'COPY' : whichMetadata;
@@ -91,15 +93,31 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
         });
         return { error: userMetadata };
     }
-    // If metadataDirective is 'COPY' and location constraint header is
-    // specified, new location constraint should override source object's
-    if (whichMetadata === 'COPY' && headers[locationHeader]) {
-        userMetadata[locationHeader] = headers[locationHeader];
+    // If metadataDirective is:
+    // - 'COPY' and source object has a location constraint in its metadata
+    // we use the bucket destination location constraint
+    if (whichMetadata === 'COPY'
+        && userMetadata[locationHeader]
+        && destBucketMD.getLocationConstraint()) {
+        userMetadata[locationHeader] = destBucketMD.getLocationConstraint();
     }
-    const sourceLocationConstraintName = sourceObjMD[locationHeader];
+    const backendInfoObjSource = locationConstraintCheck(request,
+        sourceObjMD, sourceBucketMD, log);
+    if (backendInfoObjSource.err) {
+        return { error: backendInfoObjSource.err };
+    }
+    const sourceLocationConstraintName = backendInfoObjSource.controllingLC;
+
+    const backendInfoObjDest = locationConstraintCheck(request,
+        userMetadata, destBucketMD, log);
+    if (backendInfoObjDest.err) {
+        return { error: backendInfoObjSource.err };
+    }
+    const destLocationConstraintName = backendInfoObjDest.controllingLC;
+
     // If location constraint header is not included, locations match
-    const locationMatch = headers[locationHeader] ?
-        sourceLocationConstraintName === headers[locationHeader] : true;
+    const locationMatch =
+    sourceLocationConstraintName === destLocationConstraintName;
 
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will
@@ -147,7 +165,8 @@ function _prepMetadata(sourceObjMD, headers, sourceIsDestination, authInfo,
     if (!storeMetadataParams.contentType) {
         storeMetadataParams.contentType = sourceObjMD['content-type'];
     }
-    return { storeMetadataParams, sourceLocationConstraintName };
+    return { storeMetadataParams, sourceLocationConstraintName,
+      backendInfoObjDest };
 }
 
 /**
@@ -259,10 +278,10 @@ function objectCopy(authInfo, request, sourceBucket,
                         return next(errors.PreconditionFailed, destBucketMD);
                     }
                     const { storeMetadataParams, error: metadataError,
-                    sourceLocationConstraintName } =
-                        _prepMetadata(sourceObjMD, request.headers,
+                    sourceLocationConstraintName, backendInfoObjDest } =
+                        _prepMetadata(request, sourceObjMD, request.headers,
                             sourceIsDestination, authInfo, destObjectKey,
-                            destBucketMD, log);
+                            sourceBucketMD, destBucketMD, log);
                     if (metadataError) {
                         return next(metadataError, destBucketMD);
                     }
@@ -291,19 +310,16 @@ function objectCopy(authInfo, request, sourceBucket,
                         }
                     }
                     return next(null, storeMetadataParams, dataLocator,
-                        destBucketMD, destObjMD, sourceLocationConstraintName);
+                        destBucketMD, destObjMD, sourceLocationConstraintName,
+                        backendInfoObjDest);
                 });
         },
         function goGetData(storeMetadataParams, dataLocator, destBucketMD,
-            destObjMD, sourceLocationConstraintName, next) {
+            destObjMD, sourceLocationConstraintName, backendInfoObjDest, next) {
             const serverSideEncryption = destBucketMD.getServerSideEncryption();
 
-            const backendInfoObj = locationConstraintCheck(request,
-                storeMetadataParams.metaHeaders, destBucketMD, log);
-            if (backendInfoObj.err) {
-                return next(backendInfoObj.err);
-            }
-            const backendInfo = backendInfoObj.backendInfo;
+            const backendInfoDest = backendInfoObjDest.backendInfo;
+            const destLocationConstraintName = backendInfoObjDest.controllingLC;
 
             // skip if source and dest and location constraint the same
             // still send along serverSideEncryption info so algo
@@ -316,14 +332,11 @@ function objectCopy(authInfo, request, sourceBucket,
             // also skip if 0 byte object, unless location constraint is an
             // external backend and differs from source, in which case put
             // metadata to backend
-            let sourceLocationConstraintType;
-            if (storeMetadataParams.metaHeaders[locationHeader]) {
-                sourceLocationConstraintType = config.getLocationConstraintType(
-                  storeMetadataParams.metaHeaders[locationHeader]);
-            }
+            const destLocationConstraintType =
+            config.getLocationConstraintType(destLocationConstraintName);
             // NOTE: remove the following when we will support putting a
             // versioned object to a location-constraint of type AWS or Azure.
-            if (constants.externalBackends[sourceLocationConstraintType]) {
+            if (constants.externalBackends[destLocationConstraintType]) {
                 const vcfg = destBucketMD.getVersioningConfiguration();
                 const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
                 if (isVersionedObj) {
@@ -336,9 +349,9 @@ function objectCopy(authInfo, request, sourceBucket,
             }
             if (dataLocator.length === 0) {
                 if (!storeMetadataParams.locationMatch &&
-                constants.externalBackends[sourceLocationConstraintType]) {
+                constants.externalBackends[destLocationConstraintType]) {
                     return data.put(null, null, storeMetadataParams.size,
-                        dataStoreContext, backendInfo,
+                        dataStoreContext, backendInfoDest,
                         log, (error, objectRetrievalInfo) => {
                             if (error) {
                                 return next(error, destBucketMD);
@@ -360,9 +373,9 @@ function objectCopy(authInfo, request, sourceBucket,
                     serverSideEncryption, destBucketMD);
             }
 
-            return data.copyObject(request, sourceLocationConstraintType,
-              sourceLocationConstraintName, storeMetadataParams, dataLocator,
-              dataStoreContext, backendInfo, serverSideEncryption, log,
+            return data.copyObject(request, sourceLocationConstraintName,
+              storeMetadataParams, dataLocator, dataStoreContext,
+              backendInfoDest, serverSideEncryption, log,
             (err, results) => {
                 if (err) {
                     return next(err, destBucketMD);

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -1,4 +1,5 @@
 const constants = require('../../../constants');
+const { config } = require('../../../lib/Config');
 
 const utils = {
     logHelper(log, level, description, error, dataStoreName) {
@@ -37,6 +38,30 @@ const utils = {
             return true;
         }
         return false;
+    },
+
+    /**
+     * externalBackendCopy - using external copyObject only if copying object
+     * from one externalbackend to the same external backend and for Azure if
+     * it is the same account since Azure copy outside of an account is async
+     * @param {string} locationConstraintSrc - location constraint of the source
+     * @param {string} locationConstraintDest - location constraint of the
+     * destination
+     * @return {boolean} - true if copying object from one
+     * externalbackend to the same external backend and for Azure if it is the
+     * same account since Azure copy outside of an account is async
+     */
+    externalBackendCopy(locationConstraintSrc, locationConstraintDest) {
+        const sourceLocationConstraintType =
+        config.getLocationConstraintType(locationConstraintSrc);
+        const locationTypeMatch =
+        config.getLocationConstraintType(locationConstraintSrc) ===
+        config.getLocationConstraintType(locationConstraintDest);
+        return locationTypeMatch &&
+              (sourceLocationConstraintType === 'aws_s3' ||
+              (sourceLocationConstraintType === 'azure' &&
+              config.isSameAzureAccount(locationConstraintSrc,
+              locationConstraintDest)));
     },
 };
 

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -242,15 +242,15 @@ const multipleBackendGateway = {
     },
     // NOTE: using copyObject only if copying object from one external
     // backend to the same external backend
-    copyObject: (request, location, externalSourceKey,
+    copyObject: (request, destLocationConstraintName, externalSourceKey,
     sourceLocationConstraintName, log, cb) => {
-        const client = clients[location];
+        const client = clients[destLocationConstraintName];
         if (client.copyObject) {
             return client.copyObject(request, externalSourceKey,
             sourceLocationConstraintName, log, (err, key) => {
                 const dataRetrievalInfo = {
                     key,
-                    dataStoreName: location,
+                    dataStoreName: destLocationConstraintName,
                     dataStoreType: client.clientType,
                 };
                 cb(err, dataRetrievalInfo);

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -5,13 +5,13 @@ const PassThrough = require('stream').PassThrough;
 const DataFileInterface = require('./file/backend');
 const inMemory = require('./in_memory/backend').backend;
 const multipleBackendGateway = require('./multipleBackendGateway');
+const utils = require('./external/utils');
 const { config } = require('../Config');
 const MD5Sum = s3middleware.MD5Sum;
 const assert = require('assert');
 const kms = require('../kms/wrapper');
 const externalBackends = require('../../constants').externalBackends;
 const constants = require('../../constants');
-const locationHeader = constants.objectLocationConstraintHeader;
 const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
 const RelayMD5Sum = require('../utilities/RelayMD5Sum');
 const skipError = new Error('skip');
@@ -304,8 +304,6 @@ const data = {
     /**
      * copyObject - copy object
      * @param {object} request - request object
-     * @param {string} sourceLocationConstraintType -
-     * source locationContraint type (azure, aws_s3, ...)
      * @param {string} sourceLocationConstraintName -
      * source locationContraint name (aws-test, azuretest, ...)
      * @param {object} storeMetadataParams - metadata information of the
@@ -326,44 +324,36 @@ const data = {
      * @param {function} cb - callback
      * @returns {function} cb - callback
      */
-    copyObject: (request, sourceLocationConstraintType,
+    copyObject: (request,
       sourceLocationConstraintName, storeMetadataParams, dataLocator,
       dataStoreContext, destBackendInfo, serverSideEncryption, log, cb) => {
-        // NOTE: using copyObject only if copying object from one external
-        // backend to the same external backend
-        // and for Azure if it is the same account since Azure copy outside
-        // of an account is async
-        const locationTypeMatch = request.headers[locationHeader] ?
-        config.getLocationConstraintType(sourceLocationConstraintName) ===
-        config.getLocationConstraintType(request.headers[locationHeader])
-        : true;
-        if (locationTypeMatch &&
-        (sourceLocationConstraintType === 'aws_s3' ||
-        (sourceLocationConstraintType === 'azure' && config.isSameAzureAccount(
-        sourceLocationConstraintName, request.headers[locationHeader])))) {
-            const location = storeMetadataParams
-            .metaHeaders[locationHeader];
-            const objectGetInfo = dataLocator[0];
-            const externalSourceKey = objectGetInfo.key;
-            return client.copyObject(request, location,
-            externalSourceKey, sourceLocationConstraintName, log,
-            (error, objectRetrievalInfo) => {
-                if (error) {
-                    return cb(error);
-                }
-                const putResult = {
-                    key: objectRetrievalInfo.key,
-                    dataStoreName: objectRetrievalInfo.
-                        dataStoreName,
-                    dataStoreType: objectRetrievalInfo.
-                        dataStoreType,
-                    size: storeMetadataParams.size,
-                    dataStoreETag: objectGetInfo.dataStoreETag,
-                    start: objectGetInfo.start,
-                };
-                const putResultArr = [putResult];
-                return cb(null, putResultArr);
-            });
+        if (config.backends.data === 'multiple') {
+            const destLocationConstraintName =
+                destBackendInfo.getControllingLocationConstraint();
+            if (utils.externalBackendCopy(sourceLocationConstraintName,
+            destLocationConstraintName)) {
+                const objectGetInfo = dataLocator[0];
+                const externalSourceKey = objectGetInfo.key;
+                return client.copyObject(request, destLocationConstraintName,
+                externalSourceKey, sourceLocationConstraintName, log,
+                (error, objectRetrievalInfo) => {
+                    if (error) {
+                        return cb(error);
+                    }
+                    const putResult = {
+                        key: objectRetrievalInfo.key,
+                        dataStoreName: objectRetrievalInfo.
+                            dataStoreName,
+                        dataStoreType: objectRetrievalInfo.
+                            dataStoreType,
+                        size: storeMetadataParams.size,
+                        dataStoreETag: objectGetInfo.dataStoreETag,
+                        start: objectGetInfo.start,
+                    };
+                    const putResultArr = [putResult];
+                    return cb(null, putResultArr);
+                });
+            }
         }
 
         // dataLocator is an array.  need to get and put all parts

--- a/lib/kms/utilities.js
+++ b/lib/kms/utilities.js
@@ -10,14 +10,14 @@ function _createEncryptedBucket(host,
                                 bucketName,
                                 accessKey,
                                 secretKey,
-                                verbose, ssl) {
+                                verbose, ssl,
+                                locationConstraint) {
     const options = {
         host,
         port,
         method: 'PUT',
         path: `/${bucketName}/`,
         headers: {
-            'Content-Length': 0,
             'x-amz-scal-server-side-encryption': 'AES256',
         },
         rejectUnauthorized: false,
@@ -36,6 +36,7 @@ function _createEncryptedBucket(host,
         response.on('end', () => {
             if (response.statusCode >= 200 && response.statusCode < 300) {
                 logger.info('Success', {
+                    statusCode: response.statusCode,
                     body: verbose ? body.join('') : undefined,
                 });
                 process.exit(0);
@@ -52,6 +53,13 @@ function _createEncryptedBucket(host,
     auth.client.generateV4Headers(request, '', accessKey, secretKey, 's3');
     if (verbose) {
         logger.info('request headers', { headers: request._headers });
+    }
+    if (locationConstraint) {
+        const createBucketConfiguration = '<CreateBucketConfiguration ' +
+        'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
+        `<LocationConstraint>${locationConstraint}</LocationConstraint>` +
+        '</CreateBucketConfiguration >';
+        request.write(createBucketConfiguration);
     }
     request.end();
 }
@@ -73,19 +81,20 @@ function createEncryptedBucket() {
         .option('-p, --port <port>', 'Port of the server')
         .option('-s', '--ssl', 'Enable ssl')
         .option('-v, --verbose')
+        .option('-l, --location-constraint <locationConstraint>',
+        'location Constraint')
         .parse(process.argv);
 
-    const { host, port, accessKey, secretKey, bucket, verbose, ssl } =
-        commander;
+    const { host, port, accessKey, secretKey, bucket, verbose, ssl,
+    locationConstraint } = commander;
 
     if (!host || !port || !accessKey || !secretKey || !bucket) {
         logger.error('missing parameter');
         commander.outputHelp();
         process.exit(1);
     }
-
     _createEncryptedBucket(host, port, bucket, accessKey, secretKey, verbose,
-        ssl);
+        ssl, locationConstraint);
 }
 
 module.exports = {

--- a/tests/functional/aws-node-sdk/lib/utility/createEncryptedBucket.js
+++ b/tests/functional/aws-node-sdk/lib/utility/createEncryptedBucket.js
@@ -19,6 +19,12 @@ function createEncryptedBucket(bucketParams, cb) {
     const endpointWithoutHttp = config.endpoint.split('//')[1];
     const host = endpointWithoutHttp.split(':')[0];
     const port = endpointWithoutHttp.split(':')[1];
+    let locationConstraint;
+    if (bucketParams.CreateBucketConfiguration &&
+        bucketParams.CreateBucketConfiguration.LocationConstraint) {
+        locationConstraint = bucketParams.CreateBucketConfiguration
+        .LocationConstraint;
+    }
 
     const prog = `${__dirname}/../../../../../bin/create_encrypted_bucket.js`;
     let args = [
@@ -30,6 +36,9 @@ function createEncryptedBucket(bucketParams, cb) {
         '-p', port,
         '-v',
     ];
+    if (locationConstraint) {
+        args = args.concat(['-l', locationConstraint]);
+    }
     if (config.sslEnabled) {
         args = args.concat('-s');
     }

--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -14,10 +14,10 @@ const fileLocation = 'file-test';
 const awsLocation = 'aws-test';
 const awsLocation2 = 'aws-test-2';
 const awsLocationMismatch = 'aws-test-mismatch';
+const awsLocationEncryption = 'aws-test-encryption';
 const azureLocation = 'azuretest';
 const azureLocation2 = 'azuretest2';
 const azureLocationMismatch = 'azuretestmismatch';
-const awsLocationEncryption = 'aws-test-encryption';
 const versioningEnabled = { Status: 'Enabled' };
 const versioningSuspended = { Status: 'Suspended' };
 const awsTimeout = 10000;
@@ -42,10 +42,10 @@ const utils = {
     awsLocation,
     awsLocation2,
     awsLocationMismatch,
+    awsLocationEncryption,
     azureLocation,
     azureLocation2,
     azureLocationMismatch,
-    awsLocationEncryption,
 };
 
 utils.uniqName = name => `${name}${new Date().getTime()}`;

--- a/tests/locationConfigTests.json
+++ b/tests/locationConfigTests.json
@@ -15,6 +15,11 @@
         "legacyAwsBehavior": false,
         "details": {}
     },
+    "mem": {
+        "type": "mem",
+        "legacyAwsBehavior": false,
+        "details": {}
+    },
     "mem-test": {
         "type": "mem",
         "legacyAwsBehavior": false,
@@ -80,7 +85,7 @@
         "type": "azure",
         "legacyAwsBehavior": true,
         "details": {
-          "azureBlobEndpoint": "https://mystique.blob.core.fake.net",
+          "azureBlobEndpoint": "https://mystique2.blob.core.fake.net",
           "bucketMatch": true,
           "azureBlobSAS": "sv=2015-04-05&sr=b&si=tutorial-policy-635959936345100803&sig=9aCzs76n0E7y5BpEi2GvsSv433BZa22leDOZXX%2BXXIU%3D",
           "azureContainerName": "s3test2"

--- a/tests/unit/testConfigs/configTest.js
+++ b/tests/unit/testConfigs/configTest.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const utils = require('../../../lib/data/external/utils');
+
+const results = [
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'azuretest',
+    boolExpected: true,
+  },
+  { sourceLocationConstraintName: 'azuretest2',
+    destLocationConstraintName: 'azuretest2',
+    boolExpected: true,
+  },
+  { sourceLocationConstraintName: 'aws-test',
+    destLocationConstraintName: 'aws-test',
+    boolExpected: true,
+  },
+  { sourceLocationConstraintName: 'aws-test',
+    destLocationConstraintName: 'aws-test-2',
+    boolExpected: true,
+  },
+  { sourceLocationConstraintName: 'aws-test-2',
+    destLocationConstraintName: 'aws-test-2',
+    boolExpected: true,
+  },
+  { sourceLocationConstraintName: 'mem-test',
+    destLocationConstraintName: 'mem-test',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'mem-test',
+    destLocationConstraintName: 'azuretest',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'mem-test',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'aws-test',
+    destLocationConstraintName: 'mem-test',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'mem-test',
+    destLocationConstraintName: 'aws-test',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'aws-test',
+    boolExpected: false,
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'azuretest2',
+    boolExpected: false,
+  },
+];
+
+describe('Testing Config.js function: ', () => {
+    results.forEach(result => {
+        it(`should return ${result.boolExpected} if source location ` +
+        `constriant name equals to ${result.sourceLocationConstraintName} ` +
+        'destination location constraint equals to' +
+        `and ${result.destLocationConstraintName}`, done => {
+            const isCopy = utils.externalBackendCopy(
+              result.sourceLocationConstraintName,
+              result.destLocationConstraintName);
+            assert.strictEqual(isCopy, result.boolExpected);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
On object copy/copy part we should be copying to the data location of the destination bucket unless the user specifies REPLACE and uses the `x-amz-meta-scal-location-constraint` header.