### PR TITLE
fix: add timeout for aws get flakiness

### DIFF
--- a/tests/multipleBackend/objectPutCopyPart.js
+++ b/tests/multipleBackend/objectPutCopyPart.js
@@ -24,8 +24,6 @@ const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
 
 const bucketName = 'superbucket9999999';
-const sourceObjName = 'supersourceobject';
-const destObjName = 'copycatobject';
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
 const body = Buffer.from('I am a body', 'utf8');
 
@@ -35,15 +33,32 @@ const awsBucket = 'multitester555';
 const awsLocation = 'aws-test';
 const awsLocation2 = 'aws-test-2';
 const awsLocationMismatch = 'aws-test-mismatch';
-const awsParams = { Bucket: awsBucket, Key: destObjName };
-const awsParamsBucketMismatch = { Bucket: awsBucket, Key:
-  `${bucketName}/${destObjName}` };
 const partETag = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 
 const describeSkipIfE2E = process.env.S3_END_TO_END ? describe.skip : describe;
 
+function getSourceAndDestKeys() {
+    const timestamp = Date.now();
+    return {
+        sourceObjName: `supersourceobject-${timestamp}`,
+        destObjName: `copycatobject-${timestamp}`,
+    };
+}
+
+function getAwsParams(destObjName, uploadId) {
+    return { Bucket: awsBucket, Key: destObjName, UploadId: uploadId };
+}
+
+function getAwsParamsBucketMismatch(destObjName, uploadId) {
+    const params = getAwsParams(destObjName, uploadId);
+    params.Key = `${bucketName}/${destObjName}`;
+    return params;
+}
+
 function copyPutPart(bucketLoc, mpuLoc, srcObjLoc, requestHost, cb,
 errorPutCopyPart) {
+    const keys = getSourceAndDestKeys();
+    const { sourceObjName, destObjName } = keys;
     const post = bucketLoc ? '<?xml version="1.0" encoding="UTF-8"?>' +
         '<CreateBucketConfiguration ' +
         'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
@@ -142,7 +157,7 @@ errorPutCopyPart) {
                     assert.strictEqual(json.CopyPartResult.ETag[0],
                         `"${partETag}"`);
                     assert(json.CopyPartResult.LastModified);
-                    return cb(testUploadId);
+                    return cb(keys, testUploadId);
                 });
             });
     });
@@ -158,7 +173,7 @@ function assertPartList(partList, uploadId) {
 
 describeSkipIfE2E('ObjectCopyPutPart API with multiple backends',
 function testSuite() {
-    this.timeout(20000);
+    this.timeout(60000);
 
     beforeEach(() => {
         cleanup();
@@ -183,9 +198,10 @@ function testSuite() {
     });
 
     it('should copy part to AWS based on mpu location', done => {
-        copyPutPart(memLocation, awsLocation, null, 'localhost', uploadId => {
+        copyPutPart(memLocation, awsLocation, null, 'localhost',
+        (keys, uploadId) => {
             assert.strictEqual(ds.length, 2);
-            const awsReq = Object.assign({ UploadId: uploadId }, awsParams);
+            const awsReq = getAwsParams(keys.destObjName, uploadId);
             s3.listParts(awsReq, (err, partList) => {
                 assertPartList(partList, uploadId);
                 s3.abortMultipartUpload(awsReq, err => {
@@ -225,9 +241,9 @@ function testSuite() {
     });
 
     it('should copy part to AWS based on bucket location', done => {
-        copyPutPart(awsLocation, null, null, 'localhost', uploadId => {
+        copyPutPart(awsLocation, null, null, 'localhost', (keys, uploadId) => {
             assert.deepStrictEqual(ds, []);
-            const awsReq = Object.assign({ UploadId: uploadId }, awsParams);
+            const awsReq = getAwsParams(keys.destObjName, uploadId);
             s3.listParts(awsReq, (err, partList) => {
                 assertPartList(partList, uploadId);
                 s3.abortMultipartUpload(awsReq, err => {
@@ -242,9 +258,9 @@ function testSuite() {
     it('should copy part an object on AWS location that has bucketMatch ' +
     'equals false to a mpu with a different AWS location', done => {
         copyPutPart(null, awsLocation, awsLocationMismatch, 'localhost',
-        uploadId => {
+        (keys, uploadId) => {
             assert.deepStrictEqual(ds, []);
-            const awsReq = Object.assign({ UploadId: uploadId }, awsParams);
+            const awsReq = getAwsParams(keys.destObjName, uploadId);
             s3.listParts(awsReq, (err, partList) => {
                 assertPartList(partList, uploadId);
                 s3.abortMultipartUpload(awsReq, err => {
@@ -259,10 +275,10 @@ function testSuite() {
     it('should copy part an object on AWS to a mpu with a different ' +
     'AWS location that has bucketMatch equals false', done => {
         copyPutPart(null, awsLocationMismatch, awsLocation, 'localhost',
-        uploadId => {
+        (keys, uploadId) => {
             assert.deepStrictEqual(ds, []);
-            const awsReq = Object.assign({ UploadId: uploadId },
-              awsParamsBucketMismatch);
+            const awsReq = getAwsParamsBucketMismatch(keys.destObjName,
+                uploadId);
             s3.listParts(awsReq, (err, partList) => {
                 assertPartList(partList, uploadId);
                 s3.abortMultipartUpload(awsReq, err => {

--- a/tests/multipleBackend/objectPutPart.js
+++ b/tests/multipleBackend/objectPutPart.js
@@ -29,9 +29,8 @@ const log = new DummyRequestLogger();
 const canonicalID = 'accessKey1';
 const authInfo = makeAuthInfo(canonicalID);
 const namespace = 'default';
-const bucketName = 'bucketname';
+const bucketName = `bucketname-${Date.now}`;
 
-const objectName = 'objectName';
 const body1 = Buffer.from('I am a body', 'utf8');
 const body2 = Buffer.from('I am a body with a different ETag', 'utf8');
 const mpuBucket = `${constants.mpuBucketPrefix}${bucketName}`;
@@ -44,6 +43,7 @@ const describeSkipIfE2E = process.env.S3_END_TO_END ? describe.skip : describe;
 
 function putPart(bucketLoc, mpuLoc, requestHost, cb,
 errorDescription) {
+    const objectName = `objectName-${Date.now()}`;
     const post = bucketLoc ? '<?xml version="1.0" encoding="UTF-8"?>' +
         '<CreateBucketConfiguration ' +
         'xmlns="http://s3.amazonaws.com/doc/2006-03-01/">' +
@@ -134,7 +134,7 @@ errorDescription) {
                 assert.strictEqual(keysInMPUkeyMap.length, 2);
                 assert.strictEqual(partETag, calculatedHash1);
             }
-            cb(testUploadId);
+            cb(objectName, testUploadId);
         });
     });
 }
@@ -187,7 +187,8 @@ function testSuite() {
     });
 
     it('should put a part to AWS based on mpu location', done => {
-        putPart(fileLocation, awsLocation, 'localhost', uploadId => {
+        putPart(fileLocation, awsLocation, 'localhost',
+        (objectName, uploadId) => {
             assert.deepStrictEqual(ds, []);
             listAndAbort(uploadId, null, objectName, done);
         });
@@ -195,7 +196,8 @@ function testSuite() {
 
     it('should replace part if two parts uploaded with same part number to AWS',
     done => {
-        putPart(fileLocation, awsLocation, 'localhost', uploadId => {
+        putPart(fileLocation, awsLocation, 'localhost',
+        (objectName, uploadId) => {
             assert.deepStrictEqual(ds, []);
             const partReqParams = {
                 bucketName,
@@ -240,7 +242,7 @@ function testSuite() {
 
     it('should put a part to AWS based on bucket location', done => {
         putPart(awsLocation, null, 'localhost',
-        uploadId => {
+        (objectName, uploadId) => {
             assert.deepStrictEqual(ds, []);
             listAndAbort(uploadId, null, objectName, done);
         });
@@ -249,7 +251,7 @@ function testSuite() {
     it('should put a part to AWS based on bucket location with bucketMatch ' +
     'set to true', done => {
         putPart(null, awsLocation, 'localhost',
-        uploadId => {
+        (objectName, uploadId) => {
             assert.deepStrictEqual(ds, []);
             listAndAbort(uploadId, null, objectName, done);
         });
@@ -258,7 +260,7 @@ function testSuite() {
     it('should put a part to AWS based on bucket location with bucketMatch ' +
     'set to false', done => {
         putPart(null, awsLocationMismatch, 'localhost',
-        uploadId => {
+        (objectName, uploadId) => {
             assert.deepStrictEqual(ds, []);
             listAndAbort(uploadId, null, `${bucketName}/${objectName}`, done);
         });


### PR DESCRIPTION
Seems some of the delete aws backend tests are flaky when making direct calls to AWS, like we are getting out-of-date data. I added a timeout.