### PR TITLE
S3C-1003 FX: COPY External backends encryption

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -766,6 +766,11 @@ class Config extends EventEmitter {
         this.getAzureEndpoint(locationConstraintSrc) ===
         this.getAzureEndpoint(locationConstraintDest) : true;
     }
+
+    isAWSServerSideEncrytion(locationConstraint) {
+        return this.locationConstraints[locationConstraint].details
+        .serverSideEncryption === true;
+    }
 }
 
 module.exports = {

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -312,12 +312,13 @@ function objectCopy(authInfo, request, sourceBucket,
                         }
                     }
                     return next(null, storeMetadataParams, dataLocator,
-                        destBucketMD, destObjMD, sourceLocationConstraintName,
-                        backendInfoDest);
+                        sourceBucketMD, destBucketMD, destObjMD,
+                        sourceLocationConstraintName, backendInfoDest);
                 });
         },
-        function goGetData(storeMetadataParams, dataLocator, destBucketMD,
-            destObjMD, sourceLocationConstraintName, backendInfoDest, next) {
+        function goGetData(storeMetadataParams, dataLocator, sourceBucketMD,
+            destBucketMD, destObjMD, sourceLocationConstraintName,
+            backendInfoDest, next) {
             const serverSideEncryption = destBucketMD.getServerSideEncryption();
             const vcfg = destBucketMD.getVersioningConfiguration();
             const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
@@ -374,7 +375,7 @@ function objectCopy(authInfo, request, sourceBucket,
             }
             return data.copyObject(request, sourceLocationConstraintName,
               storeMetadataParams, dataLocator, dataStoreContext,
-              backendInfoDest, serverSideEncryption, log,
+              backendInfoDest, sourceBucketMD, destBucketMD, log,
             (err, results) => {
                 if (err) {
                     return next(err, destBucketMD);

--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -426,8 +426,8 @@ class AwsClient {
             return callback();
         });
     }
-    copyObject(request, sourceKey, sourceLocationConstraintName, log,
-    callback) {
+    copyObject(request, destLocationConstraintName, sourceKey,
+    sourceLocationConstraintName, log, callback) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
         const destAwsKey = this._createAwsKey(destBucketName, destObjectKey,
@@ -438,13 +438,18 @@ class AwsClient {
 
         const metadataDirective = request.headers['x-amz-metadata-directive'];
         const metaHeaders = trimXMetaPrefix(getMetaHeaders(request.headers));
-        this._client.copyObject({
+        const awsParams = {
             Bucket: this._awsBucketName,
             Key: destAwsKey,
             CopySource: `${sourceAwsBucketName}/${sourceKey}`,
             Metadata: metaHeaders,
             MetadataDirective: metadataDirective,
-        }, (err, copyResult) => {
+        };
+        if (destLocationConstraintName &&
+        config.isAWSServerSideEncrytion(destLocationConstraintName)) {
+            awsParams.ServerSideEncryption = 'AES256';
+        }
+        this._client.copyObject(awsParams, (err, copyResult) => {
             if (err) {
                 if (err.code === 'AccessDenied') {
                     logHelper(log, 'error', 'Unable to access ' +

--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -348,8 +348,8 @@ class AzureClient {
             }], log, callback);
     }
 
-    copyObject(request, sourceKey, sourceLocationConstraintName, log,
-    callback) {
+    copyObject(request, destLocationConstraintName, sourceKey,
+    sourceLocationConstraintName, log, callback) {
         const destContainerName = request.bucketName;
         const destObjectKey = request.objectKey;
 

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -42,23 +42,37 @@ const utils = {
     },
 
     /**
-     * externalBackendCopy - using external copyObject only if copying object
-     * from one externalbackend to the same external backend and for Azure if
-     * it is the same account since Azure copy outside of an account is async
+     * externalBackendCopy - Server side copy should only be allowed:
+     * 1) if source object and destination object are both on aws or both
+     * on azure.
+     * 2) if azure to azure, must be the same storage account since Azure
+     * copy outside of an account is async
+     * 3) if the source bucket is not an encrypted bucket and the
+     * destination bucket is not an encrypted bucket (unless the copy
+     * is all within the same bucket).
      * @param {string} locationConstraintSrc - location constraint of the source
      * @param {string} locationConstraintDest - location constraint of the
      * destination
+     * @param {object} sourceBucketMD - metadata of the source bucket
+     * @param {object} destBucketMD - metadata of the destination bucket
      * @return {boolean} - true if copying object from one
      * externalbackend to the same external backend and for Azure if it is the
      * same account since Azure copy outside of an account is async
      */
-    externalBackendCopy(locationConstraintSrc, locationConstraintDest) {
+    externalBackendCopy(locationConstraintSrc, locationConstraintDest,
+      sourceBucketMD, destBucketMD) {
+        const sourceBucketName = sourceBucketMD.getName();
+        const destBucketName = destBucketMD.getName();
+        const isSameBucket = sourceBucketName === destBucketName;
+        const bucketsNotEncrypted = destBucketMD.getServerSideEncryption()
+        === sourceBucketMD.getServerSideEncryption() &&
+        sourceBucketMD.getServerSideEncryption() === null;
         const sourceLocationConstraintType =
         config.getLocationConstraintType(locationConstraintSrc);
         const locationTypeMatch =
         config.getLocationConstraintType(locationConstraintSrc) ===
         config.getLocationConstraintType(locationConstraintDest);
-        return locationTypeMatch &&
+        return locationTypeMatch && (isSameBucket || bucketsNotEncrypted) &&
               (sourceLocationConstraintType === 'aws_s3' ||
               (sourceLocationConstraintType === 'azure' &&
               config.isSameAzureAccount(locationConstraintSrc,

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -246,9 +246,9 @@ const multipleBackendGateway = {
     sourceLocationConstraintName, log, cb) => {
         const client = clients[destLocationConstraintName];
         if (client.copyObject) {
-            return client.copyObject(request, externalSourceKey,
-            sourceLocationConstraintName, log, (err, key,
-                dataStoreVersionId) => {
+            return client.copyObject(request, destLocationConstraintName,
+            externalSourceKey, sourceLocationConstraintName, log,
+            (err, key, dataStoreVersionId) => {
                 const dataRetrievalInfo = {
                     key,
                     dataStoreName: destLocationConstraintName,

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -245,6 +245,11 @@ const data = {
         if (_shouldSkipDelete(locations, requestMethod, newObjDataStoreName)) {
             return;
         }
+        log.trace('initiating batch delete', {
+            keys: locations,
+            implName,
+            method: 'batchDelete',
+        });
         async.eachLimit(locations, 5, (loc, next) => {
             data.delete(loc, log, next);
         },
@@ -300,6 +305,95 @@ const data = {
         return client.getDiskUsage(log.getSerializedUids(), cb);
     },
 
+
+   /**
+    * _putForCopy - put used for copying object
+    * @param {object} cipherBundle - cipher bundle that encrypt the data
+    * @param {object} stream - stream containing the data
+    * @param {object} part - element of dataLocator array
+    * @param {object} dataStoreContext - information of the
+    * destination object
+    * dataStoreContext.bucketName: destination bucket name,
+    * dataStoreContext.owner: owner,
+    * dataStoreContext.namespace: request namespace,
+    * dataStoreContext.objectKey: destination object key name,
+    * @param {BackendInfo} destBackendInfo - Instance of BackendInfo:
+    * Represents the info necessary to evaluate which data backend to use
+    * on a data put call.
+    * @param {object} log - Werelogs request logger
+    * @param {function} cb - callback
+    * @returns {function} cb - callback
+    */
+    _putForCopy: (cipherBundle, stream, part, dataStoreContext,
+    destBackendInfo, log, cb) => data.put(cipherBundle, stream,
+        part.size, dataStoreContext,
+        destBackendInfo, log,
+        (error, partRetrievalInfo) => {
+            if (error) {
+                return cb(error);
+            }
+            const partResult = {
+                key: partRetrievalInfo.key,
+                dataStoreName: partRetrievalInfo
+                    .dataStoreName,
+                dataStoreType: partRetrievalInfo
+                    .dataStoreType,
+                start: part.start,
+                size: part.size,
+            };
+            if (cipherBundle) {
+                partResult.cryptoScheme = cipherBundle.cryptoScheme;
+                partResult.cipheredDataKey = cipherBundle.cipheredDataKey;
+            }
+            if (part.dataStoreETag) {
+                partResult.dataStoreETag = part.dataStoreETag;
+            }
+            if (partRetrievalInfo.dataStoreVersionId) {
+                partResult.dataStoreVersionId =
+                partRetrievalInfo.dataStoreVersionId;
+            }
+            return cb(null, partResult);
+        }),
+
+    /**
+     * _dataCopyPut - put used for copying object with and without
+     * encryption
+     * @param {string} serverSideEncryption - Server side encryption
+     * @param {object} stream - stream containing the data
+     * @param {object} part - element of dataLocator array
+     * @param {object} dataStoreContext - information of the
+     * destination object
+     * dataStoreContext.bucketName: destination bucket name,
+     * dataStoreContext.owner: owner,
+     * dataStoreContext.namespace: request namespace,
+     * dataStoreContext.objectKey: destination object key name,
+     * @param {BackendInfo} destBackendInfo - Instance of BackendInfo:
+     * Represents the info necessary to evaluate which data backend to use
+     * on a data put call.
+     * @param {object} log - Werelogs request logger
+     * @param {function} cb - callback
+     * @returns {function} cb - callback
+     */
+    _dataCopyPut: (serverSideEncryption, stream, part, dataStoreContext,
+    destBackendInfo, log, cb) => {
+        if (serverSideEncryption) {
+            return kms.createCipherBundle(
+            serverSideEncryption,
+            log, (err, cipherBundle) => {
+                if (err) {
+                    log.debug('error getting cipherBundle');
+                    return cb(errors.InternalError);
+                }
+                return data._putForCopy(cipherBundle, stream, part,
+                  dataStoreContext, destBackendInfo, log, cb);
+            });
+        }
+        // Copied object is not encrypted so just put it
+        // without a cipherBundle
+        return data._putForCopy(null, stream, part, dataStoreContext,
+          destBackendInfo, log, cb);
+    },
+
     /**
      * copyObject - copy object
      * @param {object} request - request object
@@ -318,139 +412,76 @@ const data = {
      * @param {BackendInfo} destBackendInfo - Instance of BackendInfo:
      * Represents the info necessary to evaluate which data backend to use
      * on a data put call.
-     * @param {object} serverSideEncryption - serverSideEncryption
+     * @param {object} sourceBucketMD - metadata of the source bucket
+     * @param {object} destBucketMD - metadata of the destination bucket
      * @param {object} log - Werelogs request logger
      * @param {function} cb - callback
      * @returns {function} cb - callback
      */
     copyObject: (request,
       sourceLocationConstraintName, storeMetadataParams, dataLocator,
-      dataStoreContext, destBackendInfo, serverSideEncryption, log, cb) => {
-        if (config.backends.data === 'multiple') {
+      dataStoreContext, destBackendInfo, sourceBucketMD, destBucketMD, log,
+      cb) => {
+        const serverSideEncryption = destBucketMD.getServerSideEncryption();
+        if (config.backends.data === 'multiple' &&
+        utils.externalBackendCopy(sourceLocationConstraintName,
+        storeMetadataParams.dataStoreName, sourceBucketMD, destBucketMD)) {
             const destLocationConstraintName =
-                storeMetadataParams.dataStoreName;
-            if (utils.externalBackendCopy(sourceLocationConstraintName,
-            destLocationConstraintName)) {
-                const objectGetInfo = dataLocator[0];
-                const externalSourceKey = objectGetInfo.key;
-                return client.copyObject(request, destLocationConstraintName,
-                externalSourceKey, sourceLocationConstraintName, log,
-                (error, objectRetrievalInfo) => {
-                    if (error) {
-                        return cb(error);
-                    }
-                    const putResult = {
-                        key: objectRetrievalInfo.key,
-                        dataStoreName: objectRetrievalInfo.
-                            dataStoreName,
-                        dataStoreType: objectRetrievalInfo.
-                            dataStoreType,
-                        dataStoreVersionId:
-                            objectRetrievalInfo.dataStoreVersionId,
-                        size: storeMetadataParams.size,
-                        dataStoreETag: objectGetInfo.dataStoreETag,
-                        start: objectGetInfo.start,
-                    };
-                    const putResultArr = [putResult];
-                    return cb(null, putResultArr);
-                });
-            }
+              storeMetadataParams.dataStoreName;
+            const objectGetInfo = dataLocator[0];
+            const externalSourceKey = objectGetInfo.key;
+            return client.copyObject(request, destLocationConstraintName,
+            externalSourceKey, sourceLocationConstraintName, log,
+            (error, objectRetrievalInfo) => {
+                if (error) {
+                    return cb(error);
+                }
+                const putResult = {
+                    key: objectRetrievalInfo.key,
+                    dataStoreName: objectRetrievalInfo.
+                        dataStoreName,
+                    dataStoreType: objectRetrievalInfo.
+                        dataStoreType,
+                    dataStoreVersionId:
+                        objectRetrievalInfo.dataStoreVersionId,
+                    size: storeMetadataParams.size,
+                    dataStoreETag: objectGetInfo.dataStoreETag,
+                    start: objectGetInfo.start,
+                };
+                const putResultArr = [putResult];
+                return cb(null, putResultArr);
+            });
         }
+
         // dataLocator is an array.  need to get and put all parts
         // For now, copy 1 part at a time. Could increase the second
         // argument here to increase the number of parts
         // copied at once.
         return async.mapLimit(dataLocator, 1,
             // eslint-disable-next-line prefer-arrow-callback
-            function copyPart(part, cb) {
+            function copyPart(part, copyCb) {
                 if (part.dataStoreType === 'azure') {
                     const passThrough = new PassThrough();
                     return async.parallel([
-                        next => data.get(part, passThrough, log, err =>
-                          next(err)),
-                        next => data.put(null, passThrough, part.size,
-                        dataStoreContext, destBackendInfo,
-                        log, (error, partRetrievalInfo) => {
-                            if (error) {
-                                return next(error);
-                            }
-                            const partResult = {
-                                key: partRetrievalInfo.key,
-                                dataStoreType: partRetrievalInfo
-                                    .dataStoreType,
-                                dataStoreName: partRetrievalInfo.
-                                    dataStoreName,
-                                dataStoreETag: part.dataStoreETag,
-                                start: part.start,
-                                size: part.size,
-                            };
-                            return next(null, partResult);
-                        }),
+                        parallelCb => data.get(part, passThrough, log, err =>
+                          parallelCb(err)),
+                        parallelCb => data._dataCopyPut(serverSideEncryption,
+                            passThrough,
+                            part, dataStoreContext, destBackendInfo, log,
+                            parallelCb),
                     ], (err, res) => {
                         if (err) {
-                            return cb(err);
+                            return copyCb(err);
                         }
-                        return cb(null, res[1]);
+                        return copyCb(null, res[1]);
                     });
                 }
                 return data.get(part, null, log, (err, stream) => {
                     if (err) {
-                        return cb(err);
+                        return copyCb(err);
                     }
-                    if (serverSideEncryption) {
-                        return kms.createCipherBundle(
-                        serverSideEncryption,
-                        log, (err, cipherBundle) => {
-                            if (err) {
-                                log.debug('error getting cipherBundle');
-                                return cb(errors.InternalError);
-                            }
-                            return data.put(cipherBundle, stream,
-                            part.size, dataStoreContext,
-                            destBackendInfo, log,
-                            (error, partRetrievalInfo) => {
-                                if (error) {
-                                    return cb(error);
-                                }
-                                const partResult = {
-                                    key: partRetrievalInfo.key,
-                                    dataStoreName: partRetrievalInfo
-                                        .dataStoreName,
-                                    dataStoreType: partRetrievalInfo
-                                        .dataStoreType,
-                                    start: part.start,
-                                    size: part.size,
-                                    cryptoScheme: cipherBundle
-                                        .cryptoScheme,
-                                    cipheredDataKey: cipherBundle
-                                        .cipheredDataKey,
-                                };
-                                return cb(null, partResult);
-                            });
-                        });
-                    }
-                    // Copied object is not encrypted so just put it
-                    // without a cipherBundle
-                    return data.put(null, stream, part.size,
-                    dataStoreContext, destBackendInfo,
-                    log, (error, partRetrievalInfo) => {
-                        if (error) {
-                            return cb(error);
-                        }
-                        const partResult = {
-                            key: partRetrievalInfo.key,
-                            dataStoreType: partRetrievalInfo
-                                .dataStoreType,
-                            dataStoreName: partRetrievalInfo.
-                                dataStoreName,
-                            dataStoreETag: part.dataStoreETag,
-                            dataStoreVersionId: partRetrievalInfo.
-                                dataStoreVersionId,
-                            start: part.start,
-                            size: part.size,
-                        };
-                        return cb(null, partResult);
-                    });
+                    return data._dataCopyPut(serverSideEncryption, stream,
+                    part, dataStoreContext, destBackendInfo, log, copyCb);
                 });
             }, (err, results) => {
                 if (err) {
@@ -460,6 +491,130 @@ const data = {
                 }
                 return cb(null, results);
             });
+    },
+
+
+    _dataCopyPutPart: (request,
+      serverSideEncryption, stream, part,
+      dataStoreContext, destBackendInfo, locations, log, cb) => {
+        const numberPartSize =
+          Number.parseInt(part.size, 10);
+        const partNumber = Number.parseInt(request.query.partNumber, 10);
+        const uploadId = request.query.uploadId;
+        const destObjectKey = request.objectKey;
+        const destBucketName = request.bucketName;
+        const destLocationConstraintName = destBackendInfo
+        .getControllingLocationConstraint();
+        if (externalBackends[config
+            .locationConstraints[destLocationConstraintName]
+            .type]) {
+            return multipleBackendGateway.uploadPart(null, null,
+            stream, numberPartSize,
+            destLocationConstraintName, destObjectKey, uploadId,
+            partNumber, destBucketName, log,
+            (err, partInfo) => {
+                if (err) {
+                    log.error('error putting ' +
+                    'part to AWS', {
+                        error: err,
+                        method:
+                        'objectPutCopyPart::' +
+                        'multipleBackendGateway.' +
+                        'uploadPart',
+                    });
+                    return cb(errors.InternalError);
+                }
+                // skip to end of waterfall
+                // because don't need to store
+                // part metadata
+                if (partInfo &&
+                    partInfo.dataStoreType === 'aws_s3') {
+                    // if data backend handles MPU, skip to end
+                    // of waterfall
+                    const partResult = {
+                        dataStoreETag: partInfo.dataStoreETag,
+                    };
+                    locations.push(partResult);
+                    return cb(skipError, partInfo.dataStoreETag);
+                } else if (
+                  partInfo &&
+                  partInfo.dataStoreType === 'azure') {
+                    const partResult = {
+                        key: partInfo.key,
+                        dataStoreName: partInfo.dataStoreName,
+                        dataStoreETag: partInfo.dataStoreETag,
+                        size: numberPartSize,
+                        numberSubParts:
+                          partInfo.numberSubParts,
+                    };
+                    locations.push(partResult);
+                    return cb();
+                }
+                return cb(skipError);
+            });
+        }
+        if (serverSideEncryption) {
+            return kms.createCipherBundle(
+                serverSideEncryption,
+                log, (err, cipherBundle) => {
+                    if (err) {
+                        log.debug('error getting cipherBundle',
+                        { error: err });
+                        return cb(errors.InternalError);
+                    }
+                    return data.put(cipherBundle, stream,
+                        numberPartSize, dataStoreContext,
+                        destBackendInfo, log,
+                        (error, partRetrievalInfo,
+                        hashedStream) => {
+                            if (error) {
+                                log.debug('error putting ' +
+                                'encrypted part', { error });
+                                return cb(error);
+                            }
+                            const partResult = {
+                                key: partRetrievalInfo.key,
+                                dataStoreName: partRetrievalInfo
+                                    .dataStoreName,
+                                dataStoreETag: hashedStream
+                                    .completedHash,
+                                // Do not include part start
+                                // here since will change in
+                                // final MPU object
+                                size: numberPartSize,
+                                sseCryptoScheme: cipherBundle
+                                    .cryptoScheme,
+                                sseCipheredDataKey: cipherBundle
+                                    .cipheredDataKey,
+                                sseAlgorithm: cipherBundle
+                                    .algorithm,
+                                sseMasterKeyId: cipherBundle
+                                    .masterKeyId,
+                            };
+                            locations.push(partResult);
+                            return cb();
+                        });
+                });
+        }
+        // Copied object is not encrypted so just put it
+        // without a cipherBundle
+        return data.put(null, stream, numberPartSize,
+        dataStoreContext, destBackendInfo,
+        log, (error, partRetrievalInfo, hashedStream) => {
+            if (error) {
+                log.debug('error putting object part',
+                { error });
+                return cb(error);
+            }
+            const partResult = {
+                key: partRetrievalInfo.key,
+                dataStoreName: partRetrievalInfo.dataStoreName,
+                dataStoreETag: hashedStream.completedHash,
+                size: numberPartSize,
+            };
+            locations.push(partResult);
+            return cb();
+        });
     },
 
     /**
@@ -489,10 +644,6 @@ const data = {
       callback) => {
         const serverSideEncryption = destBucketMD.getServerSideEncryption();
         const lastModified = new Date().toJSON();
-        const partNumber = Number.parseInt(request.query.partNumber, 10);
-        const uploadId = request.query.uploadId;
-        const destObjectKey = request.objectKey;
-        const destBucketName = request.bucketName;
 
         // skip if 0 byte object
         if (dataLocator.length === 0) {
@@ -535,8 +686,6 @@ const data = {
         return async.forEachOfSeries(dataLocator,
             // eslint-disable-next-line prefer-arrow-callback
             function copyPart(part, index, cb) {
-                const numberPartSize =
-                  Number.parseInt(part.size, 10);
                 if (part.dataStoreType === 'azure') {
                     const passThrough = new PassThrough();
                     return async.parallel([
@@ -554,33 +703,9 @@ const data = {
                             }
                             return next();
                         }),
-                        next => multipleBackendGateway.uploadPart(null,
-                        null, passThrough, numberPartSize,
-                        destLocationConstraintName, destObjectKey, uploadId,
-                        partNumber, destBucketName, log,
-                        (err, partInfo) => {
-                            if (err) {
-                                log.error('error putting ' +
-                                'part to Azure', {
-                                    error: err,
-                                    method:
-                                    'objectPutCopyPart::' +
-                                    'multipleBackendGateway.' +
-                                    'uploadPart',
-                                });
-                                return next(errors.InternalError);
-                            }
-                            const partResult = {
-                                key: partInfo.key,
-                                dataStoreName: partInfo.dataStoreName,
-                                dataStoreETag: partInfo.dataStoreETag,
-                                size: part.size,
-                                numberSubParts:
-                                  partInfo.numberSubParts,
-                            };
-                            locations.push(partResult);
-                            return next();
-                        }),
+                        next => data._dataCopyPutPart(request,
+                          serverSideEncryption, passThrough, part,
+                          dataStoreContext, backendInfo, locations, log, next),
                     ], err => {
                         if (err) {
                             return cb(err);
@@ -602,112 +727,9 @@ const data = {
 
                     // destLocationConstraintName is location of the
                     // destination MPU object
-                    if (externalBackends[config
-                        .locationConstraints[destLocationConstraintName]
-                        .type]) {
-                        return multipleBackendGateway.uploadPart(null, null,
-                        hashedStream, numberPartSize,
-                        destLocationConstraintName, destObjectKey, uploadId,
-                        partNumber, destBucketName, log,
-                        (err, partInfo) => {
-                            if (err) {
-                                log.error('error putting ' +
-                                'part to AWS', {
-                                    error: err,
-                                    method:
-                                    'objectPutCopyPart::' +
-                                    'multipleBackendGateway.' +
-                                    'uploadPart',
-                                });
-                                return cb(errors.InternalError);
-                            }
-                            // skip to end of waterfall
-                            // because don't need to store
-                            // part metadata
-                            if (partInfo &&
-                                partInfo.dataStoreType === 'aws_s3') {
-                                // if data backend handles MPU, skip to end
-                                // of waterfall
-                                return cb(skipError);
-                            } else if (
-                              partInfo &&
-                              partInfo.dataStoreType === 'azure') {
-                                const partResult = {
-                                    key: partInfo.key,
-                                    dataStoreName: partInfo.dataStoreName,
-                                    dataStoreETag: partInfo.dataStoreETag,
-                                    size: part.size,
-                                    numberSubParts:
-                                      partInfo.numberSubParts,
-                                };
-                                locations.push(partResult);
-                                return cb();
-                            }
-                            return cb(skipError);
-                        });
-                    }
-                    if (serverSideEncryption) {
-                        return kms.createCipherBundle(
-                            serverSideEncryption,
-                            log, (err, cipherBundle) => {
-                                if (err) {
-                                    log.debug('error getting cipherBundle',
-                                    { error: err });
-                                    return cb(errors.InternalError);
-                                }
-                                return data.put(cipherBundle, hashedStream,
-                                    numberPartSize, dataStoreContext,
-                                    backendInfo, log,
-                                    (error, partRetrievalInfo,
-                                    hashedStream) => {
-                                        if (error) {
-                                            log.debug('error putting ' +
-                                            'encrypted part', { error });
-                                            return cb(error);
-                                        }
-                                        const partResult = {
-                                            key: partRetrievalInfo.key,
-                                            dataStoreName: partRetrievalInfo
-                                                .dataStoreName,
-                                            dataStoreETag: hashedStream
-                                                .completedHash,
-                                            // Do not include part start
-                                            // here since will change in
-                                            // final MPU object
-                                            size: part.size,
-                                            sseCryptoScheme: cipherBundle
-                                                .cryptoScheme,
-                                            sseCipheredDataKey: cipherBundle
-                                                .cipheredDataKey,
-                                            sseAlgorithm: cipherBundle
-                                                .algorithm,
-                                            sseMasterKeyId: cipherBundle
-                                                .masterKeyId,
-                                        };
-                                        locations.push(partResult);
-                                        return cb();
-                                    });
-                            });
-                    }
-                    // Copied object is not encrypted so just put it
-                    // without a cipherBundle
-                    return data.put(null, hashedStream, numberPartSize,
-                    dataStoreContext, backendInfo,
-                    log, (error, partRetrievalInfo, hashedStream) => {
-                        if (error) {
-                            log.debug('error putting object part',
-                            { error });
-                            return cb(error);
-                        }
-                        const partResult = {
-                            key: partRetrievalInfo.key,
-                            dataStoreName: partRetrievalInfo.dataStoreName,
-                            dataStoreETag: hashedStream.completedHash,
-                            size: part.size,
-                        };
-                        locations.push(partResult);
-                        return cb();
-                    });
+                    return data._dataCopyPutPart(request,
+                      serverSideEncryption, hashedStream, part,
+                      dataStoreContext, backendInfo, locations, log, cb);
                 });
             }, err => {
                 // Digest the final combination of all of the part streams

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
@@ -94,7 +94,7 @@ function completeAndAssertMpu(s3, params, cb) {
 
 describeSkipIfNotMultiple('AWS backend complete mpu with versioning',
 function testSuite() {
-    this.timeout(30000);
+    this.timeout(50000);
     withV4(sigCfg => {
         const bucketUtil = new BucketUtility('default', sigCfg);
         const s3 = bucketUtil.s3;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
@@ -13,6 +13,7 @@ const { describeSkipIfNotMultiple, awsS3, memLocation, awsLocation,
     require('../utils');
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const bucketAws = 'bucketawstestmultiplebackendobjectcopy';
+const awsServerSideEncryptionbucket = 'awsserversideencryptionbucketobjectcopy';
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';
@@ -120,6 +121,12 @@ function testSuite() {
                   LocationConstraint: memLocation,
               },
             })
+            .then(() => s3.createBucketAsync({
+                Bucket: awsServerSideEncryptionbucket,
+                CreateBucketConfiguration: {
+                    LocationConstraint: awsLocationEncryption,
+                },
+            }))
             .then(() => s3.createBucketAsync({ Bucket: bucketAws,
               CreateBucketConfiguration: {
                   LocationConstraint: awsLocation,
@@ -135,9 +142,15 @@ function testSuite() {
             process.stdout.write('Emptying bucket\n');
             return bucketUtil.empty(bucket)
             .then(() => bucketUtil.empty(bucketAws))
+            .then(() => bucketUtil.empty(awsServerSideEncryptionbucket))
             .then(() => {
                 process.stdout.write(`Deleting bucket ${bucket}\n`);
                 return bucketUtil.deleteOne(bucket);
+            })
+            .then(() => {
+                process.stdout.write('Deleting bucket ' +
+                `${awsServerSideEncryptionbucket}\n`);
+                return bucketUtil.deleteOne(awsServerSideEncryptionbucket);
             })
             .then(() => {
                 process.stdout.write(`Deleting bucket ${bucketAws}\n`);
@@ -245,7 +258,8 @@ function testSuite() {
             });
         });
 
-        it('should copy an object from mem to AWS with encryption', done => {
+        it('should copy an object from mem to AWS with aws server side ' +
+        'encryption', done => {
             putSourceObj(memLocation, false, bucket, key => {
                 const copyKey = `copyKey-${Date.now()}`;
                 const copyParams = {
@@ -288,6 +302,56 @@ function testSuite() {
                     assertGetObjects(key, bucket, awsLocation, copyKey, bucket,
                         undefined, key, 'REPLACE', false,
                         awsS3, awsLocation, done);
+                });
+            });
+        });
+
+        it('should copy an object on AWS with aws server side encryption',
+        done => {
+            putSourceObj(awsLocation, false, bucket, key => {
+                const copyKey = `copyKey-${Date.now()}`;
+                const copyParams = {
+                    Bucket: bucket,
+                    Key: copyKey,
+                    CopySource: `/${bucket}/${key}`,
+                    MetadataDirective: 'REPLACE',
+                    Metadata: {
+                        'scal-location-constraint': awsLocationEncryption },
+                };
+                process.stdout.write('Copying object\n');
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, awsLocation, copyKey, bucket,
+                        awsLocationEncryption, copyKey, 'REPLACE', false, awsS3,
+                        awsLocation, done);
+                });
+            });
+        });
+
+        it('should copy an object on AWS with aws server side ' +
+        'encrypted bucket', done => {
+            putSourceObj(awsLocation, false, awsServerSideEncryptionbucket,
+            key => {
+                const copyKey = `copyKey-${Date.now()}`;
+                const copyParams = {
+                    Bucket: awsServerSideEncryptionbucket,
+                    Key: copyKey,
+                    CopySource: `/${awsServerSideEncryptionbucket}/${key}`,
+                    MetadataDirective: 'COPY',
+                };
+                process.stdout.write('Copying object\n');
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, awsServerSideEncryptionbucket,
+                        awsLocation, copyKey, awsServerSideEncryptionbucket,
+                        awsLocationEncryption, copyKey, 'COPY',
+                        false, awsS3, awsLocation, done);
                 });
             });
         });

--- a/tests/unit/testConfigs/configTest.js
+++ b/tests/unit/testConfigs/configTest.js
@@ -1,66 +1,145 @@
 const assert = require('assert');
 const utils = require('../../../lib/data/external/utils');
+const BucketInfo = require('arsenal').models.BucketInfo;
+
+const userBucketOwner = 'Bart';
+const creationDate = new Date().toJSON();
+const serverSideEncryption = { cryptoScheme: 123, algorithm: 'algo',
+masterKeyId: 'masterKeyId', mandatory: false };
+const bucketOne = new BucketInfo('bucketone',
+  userBucketOwner, userBucketOwner, creationDate,
+  BucketInfo.currentModelVersion());
+const bucketTwo = new BucketInfo('buckettwo',
+  userBucketOwner, userBucketOwner, creationDate,
+  BucketInfo.currentModelVersion());
+const bucketOnetWithEncryption = new BucketInfo('bucketone',
+    userBucketOwner, userBucketOwner, creationDate,
+    BucketInfo.currentModelVersion(), undefined, undefined, undefined,
+    serverSideEncryption);
+const bucketTwoWithEncryption = new BucketInfo('buckettwo',
+    userBucketOwner, userBucketOwner, creationDate,
+    BucketInfo.currentModelVersion(), undefined, undefined, undefined,
+    serverSideEncryption);
 
 const results = [
   { sourceLocationConstraintName: 'azuretest',
     destLocationConstraintName: 'azuretest',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: true,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'azuretest2',
     destLocationConstraintName: 'azuretest2',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: true,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'aws-test',
     destLocationConstraintName: 'aws-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: true,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'aws-test',
     destLocationConstraintName: 'aws-test-2',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: true,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'aws-test-2',
     destLocationConstraintName: 'aws-test-2',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: true,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'mem-test',
     destLocationConstraintName: 'mem-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'mem-test',
     destLocationConstraintName: 'azuretest',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'azuretest',
     destLocationConstraintName: 'mem-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'aws-test',
     destLocationConstraintName: 'mem-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'mem-test',
     destLocationConstraintName: 'aws-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'azuretest',
     destLocationConstraintName: 'aws-test',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
   },
   { sourceLocationConstraintName: 'azuretest',
     destLocationConstraintName: 'azuretest2',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketOne,
     boolExpected: false,
+    description: 'same bucket metadata',
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'azuretest',
+    sourceBucketMD: bucketOne,
+    destBucketMD: bucketTwo,
+    boolExpected: true,
+    description: 'different non-encrypted bucket metadata',
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'azuretest',
+    sourceBucketMD: bucketOnetWithEncryption,
+    destBucketMD: bucketOnetWithEncryption,
+    boolExpected: true,
+    description: 'same encrypted bucket metadata',
+  },
+  { sourceLocationConstraintName: 'azuretest',
+    destLocationConstraintName: 'azuretest',
+    sourceBucketMD: bucketOnetWithEncryption,
+    destBucketMD: bucketTwoWithEncryption,
+    boolExpected: false,
+    description: 'different encrypted bucket metadata',
   },
 ];
 
 describe('Testing Config.js function: ', () => {
     results.forEach(result => {
         it(`should return ${result.boolExpected} if source location ` +
-        `constriant name equals to ${result.sourceLocationConstraintName} ` +
-        'destination location constraint equals to' +
-        `and ${result.destLocationConstraintName}`, done => {
+        `constraint === ${result.sourceLocationConstraintName} ` +
+        'and destination location constraint ===' +
+        ` ${result.destLocationConstraintName} and ${result.description}`,
+        done => {
             const isCopy = utils.externalBackendCopy(
               result.sourceLocationConstraintName,
-              result.destLocationConstraintName);
+              result.destLocationConstraintName, result.sourceBucketMD,
+              result.destBucketMD);
             assert.strictEqual(isCopy, result.boolExpected);
             done();
         });


### PR DESCRIPTION
We need to exclude certain scenarios from using AWS/Azure server-side copy (for copy object and copy part) due to encryption.
Server side copy should only be allowed:
1) if source object and destination object are both on aws or both on azure.
2) if azure to azure, must be the same storage account
3) if the source bucket is not an encrypted bucket and the destination bucket is not an encrypted bucket (unless the copy is all within the same bucket).
Also, we should make sure we are sending the sse header to aws if the destination location has SSE set to true in the locationConfig.