### PR TITLE
chore: increase timeouts for flaky aws versioning tests

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
@@ -94,7 +94,7 @@ function completeAndAssertMpu(s3, params, cb) {
 
 describeSkipIfNotMultiple('AWS backend complete mpu with versioning',
 function testSuite() {
-    this.timeout(50000);
+    this.timeout(120000);
     withV4(sigCfg => {
         const bucketUtil = new BucketUtility('default', sigCfg);
         const s3 = bucketUtil.s3;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-delete.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-delete.js
@@ -22,7 +22,7 @@ const someBody = 'teststring';
 
 describeSkipIfNotMultiple('AWS backend object delete tagging with versioning ',
 function testSuite() {
-    this.timeout(30000);
+    this.timeout(120000);
     const tags = { key1: 'value1', key2: 'value2' };
 
     withV4(sigCfg => {

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-putget.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-putget.js
@@ -23,7 +23,7 @@ const someBody = 'teststring';
 
 describeSkipIfNotMultiple('AWS backend object put/get tagging with versioning',
 function testSuite() {
-    this.timeout(30000);
+    this.timeout(120000);
     const tags = { key1: 'value1', key2: 'value2' };
 
     withV4(sigCfg => {


### PR DESCRIPTION
Increasing the wait and mocha timeouts for some tests that seem like they are still flaky on ci runs.