### PR TITLE
FIX: Locations max issue

### DIFF
--- a/lib/api/apiUtils/object/setPartRanges.js
+++ b/lib/api/apiUtils/object/setPartRanges.js
@@ -37,7 +37,7 @@ function setPartRanges(dataLocations, outerRange) {
     const max = end - begin + 1;
     let total = 0;
     for (let i = 0; i < dataLocations.length; i++) {
-        if (total >= max) {
+        if (total >= (max - 1)) {
             break;
         }
         const partStart = parseInt(dataLocations[i].start, 10);


### PR DESCRIPTION
For parts with many locations, setPartRanges was going one location more
than needed, resulting in sending more data than the content-length.