### PR TITLE
bf: fix possible timeout in unit tests

### DIFF
--- a/lib/metadata/bucketfile/backend.js
+++ b/lib/metadata/bucketfile/backend.js
@@ -13,10 +13,20 @@ const versionSep = arsenal.versioning.VersioningConstants.VersionId.Separator;
 const METASTORE = '__metastore';
 
 class BucketFileInterface {
-    constructor() {
+
+    /**
+     * @constructor
+     * @param {object} [params] - constructor params
+     * @param {boolean} [params.noDbOpen=false] - true to skip DB open
+     *   (for unit tests only)
+     */
+    constructor(params) {
         this.logger = logger;
         const { host, port } = config.metadataClient;
         this.mdClient = new MetadataFileClient({ host, port });
+        if (params && params.noDbOpen) {
+            return;
+        }
         this.mdDB = this.mdClient.openDB(err => {
             if (err) {
                 throw err;

--- a/tests/unit/metadata/bucketfile/backend.js
+++ b/tests/unit/metadata/bucketfile/backend.js
@@ -48,7 +48,7 @@ class Reader extends EventEmitter {
 }
 
 describe('BucketFileInterface::internalListObject', alldone => {
-    const bucketfile = new BucketFileInterface();
+    const bucketfile = new BucketFileInterface({ noDbOpen: true });
 
     // stub db to inspect the extensions
     const db = {


### PR DESCRIPTION
Prevent S3 unit tests from trying to access a local dmd which is not
running, by adding an option to BucketFileInterface constructor not to
attempt to open the database.

This is only for unit tests that use mocking with BucketFileInterface
and should be limited to this use.
