### PR TITLE
FX: Sending utapi client string for content-length instead of int

### DIFF
--- a/lib/api/objectGet.js
+++ b/lib/api/objectGet.js
@@ -198,7 +198,7 @@ function objectGet(authInfo, request, returnTagCount, log, callback) {
                 authInfo,
                 bucket: bucketName,
                 newByteLength:
-                responseMetaHeaders['Content-Length'],
+                Number.parseInt(responseMetaHeaders['Content-Length'], 10),
             });
             return callback(null, dataLocator, responseMetaHeaders,
                 byteRange);


### PR DESCRIPTION
We're crashing because we're sending utapi client a string for content-length instead of an integer when we get the content-length from an external backend.  We should be parseInt'ing the content-length before we send to utapi --

```{"name":"S3","clientIP":"::ffff:172.17.0.3","clientPort":34537,"httpMethod":"GET","httpURL":"/buckettestmultiplebackendmpuawsversioning/somekey-1509312283466","time":1509312286523,"req_id":"088c852e6e4e8c7e1570","level":"info","message":"received request","hostname":"box27","pid":360}
responseMetaHeaders in objectGet!! { 'x-amz-website-redirect-location': '',
  'x-amz-meta-scal-location-constraint': 'awsbackend',
  'x-amz-version-id': undefined,
  'Content-Length': '10485760',
  ETag: '"f65590340fd7a9f7c0643548071050c7-2"',
  'Last-Modified': 'Sun, 29 Oct 2017 21:24:46 GMT',
  'Content-Type': 'application/octet-stream' }
Content-Length there???
{"name":"S3","time":1509312286856,"error":"newByteLength property must be an integer","stack":"AssertionError: newByteLength property must be an integer\n    at properties.forEach.prop (/home/scality/S3/node_modules/utapi/lib/UtapiClient.js:194:17)\n    at Array.forEach (native)\n    at UtapiClient._checkProperties (/home/scality/S3/node_modules/utapi/lib/UtapiClient.js:186:20)\n    at UtapiClient._pushMetricGetObject (/home/scality/S3/node_modules/utapi/lib/UtapiClient.js:759:14)\n    at UtapiClient.pushMetric (/home/scality/S3/node_modules/utapi/lib/UtapiClient.js:339:48)\n    at pushMetric (/home/scality/S3/lib/utapi/utilities.js:213:18)\n    at data.head.err (/home/scality/S3/lib/api/objectGet.js:199:13)\n    at Response._client.headObject.err (/home/scality/S3/lib/data/external/AwsClient.js:106:20)\n    at Request.<anonymous> (/home/scality/S3/node_modules/aws-sdk/lib/request.js:360:18)\n    at Request.callListeners (/home/scality/S3/node_modules/aws-sdk/lib/sequential_executor.js:105:20)\n    at Request.emit (/home/scality/S3/node_modules/aws-sdk/lib/sequential_executor.js:77:10)\n    at Request.emit (/home/scality/S3/node_modules/aws-sdk/lib/request.js:673:14)\n    at Request.transition (/home/scality/S3/node_modules/aws-sdk/lib/request.js:22:10)\n    at AcceptorStateMachine.runTo (/home/scality/S3/node_modules/aws-sdk/lib/state_machine.js:14:12)\n    at /home/scality/S3/node_modules/aws-sdk/lib/state_machine.js:26:10\n    at Request.<anonymous> (/home/scality/S3/node_modules/aws-sdk/lib/request.js:38:9)","workerId":11,"workerPid":360,"level":"fatal","message":"caught error","hostname":"box27","pid":360}```
