### PR TITLE
FIX: replicationEndpoints config with multiplebackend

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -301,7 +301,7 @@ class Config extends EventEmitter {
                 assert.strictEqual(typeof replicationEndpoint, 'object',
                     'bad config: `replicationEndpoints` property must be an ' +
                     'array of objects');
-                const { site, servers } = replicationEndpoint;
+                const { site, servers, type } = replicationEndpoint;
                 assert.notStrictEqual(site, undefined, 'bad config: each ' +
                     'object of `replicationEndpoints` array must have a ' +
                     '`site` property');
@@ -310,17 +310,25 @@ class Config extends EventEmitter {
                     'must be a string');
                 assert.notStrictEqual(site, '', 'bad config: `site` property ' +
                     "of object in `replicationEndpoints` must not be ''");
-                assert.notStrictEqual(servers, undefined, 'bad config: each ' +
-                    'object of `replicationEndpoints` array must have a ' +
-                    '`servers` property');
-                assert(servers instanceof Array, 'bad config: ' +
-                    '`servers` property of object in `replicationEndpoints` ' +
-                    'must be an array');
-                servers.forEach(item => {
-                    assert(typeof item === 'string' && item !== '',
-                    'bad config: each item of `replicationEndpoints:servers` ' +
-                    'must be a non-empty string');
-                });
+                if (type !== undefined) {
+                    assert(externalBackends[type], 'bad config: `type` ' +
+                        'property of `replicationEndpoints` object must be ' +
+                        'a valid external backend (one of: "' +
+                        `${Object.keys(externalBackends).join('", "')}")`);
+                } else {
+                    assert.notStrictEqual(servers, undefined, 'bad config: ' +
+                        'each object of `replicationEndpoints` array that is ' +
+                        'not an external backend must have `servers` property');
+                    assert(servers instanceof Array, 'bad config: ' +
+                        '`servers` property of object in ' +
+                        '`replicationEndpoints` must be an array');
+                    servers.forEach(item => {
+                        assert(typeof item === 'string' && item !== '',
+                        'bad config: each item of ' +
+                        '`replicationEndpoints:servers` must be a non-empty ' +
+                        'string');
+                    });
+                }
             });
             this.replicationEndpoints = replicationEndpoints;
         }


### PR DESCRIPTION
When defining replication endpoints using an external backend during deployment, we want to support an optional list of servers when the `type` is a key in the `externalBackends` constant. As specified here: https://github.com/scality/Federation/blob/master/env/client-template/group_vars/all#L400.