### PR TITLE
fix: use credentials for getRealAwsConfig if fit

### DIFF
--- a/tests/functional/aws-node-sdk/test/support/awsConfig.js
+++ b/tests/functional/aws-node-sdk/test/support/awsConfig.js
@@ -17,13 +17,18 @@ function getAwsCredentials(profile, credFile) {
 }
 
 function getRealAwsConfig(awsLocation) {
-    const cp =
-        config.locationConstraints[awsLocation].details.credentialsProfile
-        || 'default';
-    const credentials = getAwsCredentials(cp, '/.aws/credentials');
-    const realAwsConfig = { credentials, signatureVersion: 'v4' };
-
-    return realAwsConfig;
+    const { credentialsProfile, credentials: locCredentials } =
+        config.locationConstraints[awsLocation].details;
+    if (credentialsProfile) {
+        const credentials = getAwsCredentials(credentialsProfile,
+            '/.aws/credentials');
+        return { credentials, signatureVersion: 'v4' };
+    }
+    return {
+        accessKeyId: locCredentials.accessKey,
+        secretAccessKey: locCredentials.secretKey,
+        signatureVersion: 'v4',
+    };
 }
 
 module.exports = {

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -391,7 +391,8 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
     });
 
     it('should only return number of parts equal to specified maxParts',
-    done => {
+    function itF(done) {
+        this.timeout(90000);
         const objectKey = `key-${Date.now()}`;
         mpuSetup(awsLocation, objectKey, uploadId => {
             const listParams = getListParams(objectKey, uploadId);


### PR DESCRIPTION
We relied on having a `credentialsProfile` for multiple backend tests but ended up using the `credentials` config option in the Integration set-up. We may as well support both options to get the right AWS credentials for our aws multiple backend tests.