### PR TITLE
RF: Include replicated object versionId in user MD

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -251,7 +251,6 @@ function putObject(request, response, log, callback) {
     const canonicalID = request.headers['x-scal-canonical-id'];
     const contentMD5 = request.headers['content-md5'];
     const metaHeaders = {
-        'x-amz-meta-scal-location-constraint': storageLocation,
         'x-amz-meta-scal-replication-status': 'REPLICA',
         'x-amz-meta-scal-version-id': sourceVersionId,
     };
@@ -314,7 +313,6 @@ function initiateMultipartUpload(request, response, log, callback) {
     const storageLocation = request.headers['x-scal-storage-class'];
     const sourceVersionId = request.headers['x-scal-version-id'];
     const metaHeaders = {
-        'scal-location-constraint': storageLocation,
         'scal-replication-status': 'REPLICA',
         'scal-version-id': sourceVersionId,
     };

--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -1,5 +1,12 @@
 const { getVersionIdResHeader } = require('../api/apiUtils/object/versioning');
 
+/* eslint-disable camelcase */
+const CLOUD_BACKENDS = {
+    aws_s3: 'aws-s3',
+    azure: 'azure',
+};
+/* eslint-enable camelcase */
+
 /**
  * Pulls data from saved object metadata to send in response
  * @param {object} objectMD - object's metadata
@@ -68,6 +75,14 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
     if (objectMD.replicationInfo && objectMD.replicationInfo.status) {
         responseMetaHeaders['x-amz-replication-status'] =
             objectMD.replicationInfo.status;
+    }
+    if (objectMD.replicationInfo &&
+        objectMD.replicationInfo.storageType &&
+        objectMD.replicationInfo.status === 'COMPLETED') {
+        const { storageType, dataStoreVersionId } = objectMD.replicationInfo;
+        const headerStorageType = CLOUD_BACKENDS[storageType];
+        responseMetaHeaders[`x-amz-meta-${headerStorageType}-version-id`] =
+            dataStoreVersionId;
     }
     return responseMetaHeaders;
 }


### PR DESCRIPTION
Include replicated object versionId in user MD.

* When an object is replicated to an external
backend, include the replicated object's version
ID in the source object's user metadata.

* Remove 'scal-location-constraint' from
destination object's user MD as it is uneeded.