### PR TITLE
 rf: create azure container if flightCheckOnStartUp

### DIFF
--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -218,11 +218,12 @@ class AzureClient {
             }], log, callback);
     }
 
-    healthcheck(location, callback) {
+    healthcheck(location, callback, flightCheckOnStartUp) {
         const azureResp = {};
-        this._errorWrapper('checkAzureHealth', 'doesContainerExist',
-            [this._azureContainerName,
-            err => {
+        const healthCheckAction = flightCheckOnStartUp ?
+            'createContainerIfNotExists' : 'doesContainerExist';
+        this._errorWrapper('checkAzureHealth', healthCheckAction,
+            [this._azureContainerName, err => {
                 /* eslint-disable no-param-reassign */
                 if (err) {
                     azureResp[location] = { error: err.message,

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -1,3 +1,4 @@
+const async = require('async');
 const constants = require('../../../constants');
 const { config } = require('../../../lib/Config');
 
@@ -88,29 +89,39 @@ const utils = {
               locationConstraintDest)));
     },
 
-    checkExternalBackend(clients, locations, type,
+    checkExternalBackend(clients, locations, type, flightCheckOnStartUp,
       externalBackendHealthCheckInterval, cb) {
         const checkStatus = type === 'aws_s3' ? awsHealth : azureHealth;
-        if (locations.length > 0) {
-            if (checkStatus.response
-                && Date.now() - checkStatus.time
-                < externalBackendHealthCheckInterval) {
-                return cb(null, checkStatus.response);
-            }
+        if (locations.length === 0) {
+            return process.nextTick(cb, null, []);
+        }
+        if (!flightCheckOnStartUp && checkStatus.response &&
+            Date.now() - checkStatus.time
+            < externalBackendHealthCheckInterval) {
+            return process.nextTick(cb, null, checkStatus.response);
+        }
+        let locationsToCheck;
+        if (flightCheckOnStartUp) {
+            // check all locations if flight check on start up
+            locationsToCheck = locations;
+        } else {
             const randomLocation = locations[Math.floor(Math.random() *
                 locations.length)];
-            const checkThisOne = clients[randomLocation];
-            return checkThisOne.healthcheck(randomLocation,
-                (err, result) => {
-                    if (err) {
-                        return cb(err);
-                    }
-                    checkStatus.response = result;
-                    checkStatus.time = Date.now();
-                    return cb(null, result);
-                });
+            locationsToCheck = [randomLocation];
         }
-        return cb();
+        return async.mapLimit(locationsToCheck, 5, (location, next) => {
+            const client = clients[location];
+            client.healthcheck(location, next, flightCheckOnStartUp);
+        }, (err, results) => {
+            if (err) {
+                return cb(err);
+            }
+            if (!flightCheckOnStartUp) {
+                checkStatus.response = results;
+                checkStatus.time = Date.now();
+            }
+            return cb(null, results);
+        });
     },
 };
 

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -114,7 +114,7 @@ const multipleBackendGateway = {
         return client.delete(objectGetInfo, reqUids, callback);
     },
 
-    healthcheck: (log, callback) => {
+    healthcheck: (flightCheckOnStartUp, log, callback) => {
         const multBackendResp = {};
         const awsArray = [];
         const azureArray = [];
@@ -141,19 +141,22 @@ const multipleBackendGateway = {
             //  'mem' or 'file', for which the default response is 200 OK
             multBackendResp[location] = { code: 200, message: 'OK' };
             return cb();
-        }, () =>
+        }, () => {
             async.parallel([
                 next => checkExternalBackend(
-                  clients, awsArray, 'aws_s3',
+                  clients, awsArray, 'aws_s3', flightCheckOnStartUp,
                   externalBackendHealthCheckInterval, next),
                 next => checkExternalBackend(
-                  clients, azureArray, 'azure',
+                  clients, azureArray, 'azure', flightCheckOnStartUp,
                   externalBackendHealthCheckInterval, next),
             ], (errNull, externalResp) => {
-                externalResp.forEach(resp =>
-                  Object.assign(multBackendResp, resp));
+                const externalLocResults = [];
+                externalResp.forEach(resp => externalLocResults.push(...resp));
+                externalLocResults.forEach(locationResult =>
+                  Object.assign(multBackendResp, locationResult));
                 callback(null, multBackendResp);
-            }));
+            });
+        });
     },
 
     createMPU: (key, metaHeaders, bucketName, websiteRedirectHeader,

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -268,13 +268,13 @@ const data = {
         return client;
     },
 
-    checkHealth: (log, cb) => {
+    checkHealth: (log, cb, flightCheckOnStartUp) => {
         if (!client.healthcheck) {
             const defResp = {};
             defResp[implName] = { code: 200, message: 'OK' };
             return cb(null, defResp);
         }
-        return client.healthcheck(log, (err, result) => {
+        return client.healthcheck(flightCheckOnStartUp, log, (err, result) => {
             let respBody = {};
             if (err) {
                 log.error(`error from ${implName}`, { error: err });

--- a/lib/utilities/healthcheckHandler.js
+++ b/lib/utilities/healthcheckHandler.js
@@ -30,13 +30,16 @@ function writeResponse(res, error, log, results, cb) {
 /**
  * Calls each client's healthcheck and translates responses to
  * InternalError message if appropriate
- * @param {boolean} errorOnExternalBackend - whether to return a 500
- * due to a healthcheck fail on an external backend
+ * @param {boolean} flightCheckOnStartUp - whether client check is a flight
+ * check on startup. If performing a flight check, behavior is:
+ *  - return an error to halt start-up if there is any error in the client check
+ *  - check all external backend locations
+ *  - create a container for Azure location if one is missing
  * @param {object} log - werelogs logger instance
  * @param {function} cb - callback
  * @return {undefined}
  */
-function clientCheck(errorOnExternalBackend, log, cb) {
+function clientCheck(flightCheckOnStartUp, log, cb) {
     const clients = [
         data,
         metadata,
@@ -46,7 +49,7 @@ function clientCheck(errorOnExternalBackend, log, cb) {
     clients.forEach(client => {
         if (typeof client.checkHealth === 'function') {
             clientTasks.push(done => {
-                client.checkHealth(log, done);
+                client.checkHealth(log, done, flightCheckOnStartUp);
             });
         }
     });
@@ -61,8 +64,8 @@ function clientCheck(errorOnExternalBackend, log, cb) {
         fail = Object.keys(obj).some(k =>
             // if there is an error from an external backend,
             // only return a 500 if it is on startup
-            // (errorOnExternalBackend set to true)
-            obj[k].error && (errorOnExternalBackend || !obj[k].external)
+            // (flightCheckOnStartUp set to true)
+            obj[k].error && (flightCheckOnStartUp || !obj[k].external)
         );
         if (fail) {
             return cb(errors.InternalError, obj);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAzure.js
@@ -14,7 +14,7 @@ const {
 } = require('../utils');
 
 const keyObject = 'deleteazure';
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const keys = getAzureKeys();
 const azureClient = getAzureClient();
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAzure.js
@@ -13,7 +13,7 @@ const {
 } = require('../utils');
 
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const keys = getAzureKeys();
 const keyObject = 'getazure';
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
@@ -8,7 +8,7 @@ const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName }
 
 const keyName = `somekey-${Date.now()}`;
 
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 let s3;
 let bucketUtil;
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
@@ -5,7 +5,7 @@ const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName }
     = require('../utils');
 
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const bodyFirstPart = Buffer.alloc(10);
 const bodySecondPart = Buffer.alloc(104857610);
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/azureAbortMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/azureAbortMPU.js
@@ -11,7 +11,7 @@ const maxSubPartSize = azureMpuUtils.maxSubPartSize;
 
 const keyObject = 'abortazure';
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const expectedMD5 = 'a63c90cc3684ad8b0a2176a6a8fe9005';
 
 let bucketUtil;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
@@ -18,7 +18,7 @@ const {
 
 const azureMpuUtils = s3middleware.azureHelper.mpuUtils;
 
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const azureClient = getAzureClient();
 const azureTimeout = 20000;
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/azurePutPart.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/azurePutPart.js
@@ -13,7 +13,7 @@ const getBlockId = azureMpuUtils.getBlockId;
 
 const keyObject = 'putazure';
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const expectedMD5 = 'a63c90cc3684ad8b0a2176a6a8fe9005';
 
 let bucketUtil;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
@@ -19,7 +19,7 @@ const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
 
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const bucketAzure = 'bucketazuretestmultiplebackendobjectcopy';

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
@@ -7,7 +7,7 @@ const { describeSkipIfNotMultiple, awsS3, awsBucket, getAzureClient,
     azureLocation } = require('../utils');
 
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const bucket = 'testmultbackendtagging';
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -17,7 +17,7 @@ const {
 
 const keyObject = 'putazure';
 const azureClient = getAzureClient();
-const azureContainerName = getAzureContainerName();
+const azureContainerName = getAzureContainerName(azureLocation);
 const { versioningEnabled } = require('../../../lib/utility/versioning-util');
 
 const normalBody = Buffer.from('I am a body', 'utf8');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -15,10 +15,11 @@ const fileLocation = 'scality-internal-file';
 const awsLocation = 'awsbackend';
 const awsLocation2 = 'awsbackend2';
 const awsLocationMismatch = 'awsbackendmismatch';
+const awsLocationEncryption = 'awsbackendencryption';
 const azureLocation = 'azurebackend';
 const azureLocation2 = 'azurebackend2';
 const azureLocationMismatch = 'azurebackendmismatch';
-const awsLocationEncryption = 'awsbackendencryption';
+const azureLocationNonExistContainer = 'azurenonexistcontainer';
 const versioningEnabled = { Status: 'Enabled' };
 const versioningSuspended = { Status: 'Suspended' };
 const awsFirstTimeout = 10000;
@@ -57,6 +58,7 @@ const utils = {
     azureLocation,
     azureLocation2,
     azureLocationMismatch,
+    azureLocationNonExistContainer,
 };
 
 utils.getOwnerInfo = account => {
@@ -116,7 +118,7 @@ utils.getAzureClient = () => {
         params.azureStorageAccessKey, params.azureStorageEndpoint);
 };
 
-utils.getAzureContainerName = () => {
+utils.getAzureContainerName = azureLocation => {
     let azureContainerName;
     if (config.locationConstraints[azureLocation] &&
     config.locationConstraints[azureLocation].details &&

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -98,5 +98,16 @@
             "bucketMatch": false,
             "azureContainerName": "s3test"
         }
+    },
+    "azurenonexistcontainer": {
+        "type": "azure",
+        "legacyAwsBehavior": true,
+        "details": {
+            "azureStorageEndpoint": "https://fakeaccountname.blob.core.fake.net/",
+            "azureStorageAccountName": "fakeaccountname",
+            "azureStorageAccessKey": "Fake00Key123",
+            "bucketMatch": true,
+            "azureContainerName": "s3createbucketonfly"
+        }
     }
 }

--- a/tests/multipleBackend/backendHealthcheckResponse.js
+++ b/tests/multipleBackend/backendHealthcheckResponse.js
@@ -1,39 +1,33 @@
 'use strict'; // eslint-disable-line strict
 const assert = require('assert');
+const { errors } = require('arsenal');
 const DummyRequestLogger = require('../unit/helpers').DummyRequestLogger;
 const clientCheck
     = require('../../lib/utilities/healthcheckHandler').clientCheck;
 const { config } = require('../../lib/Config');
+const {
+    getAzureClient,
+    azureLocationNonExistContainer,
+    getAzureContainerName,
+} = require('../functional/aws-node-sdk/test/multipleBackend/utils');
 
 const log = new DummyRequestLogger();
 const locConstraints = Object.keys(config.locationConstraints);
+const azureClient = getAzureClient();
 
 describe('Healthcheck response', () => {
-    it('should return no error with errorOnExternalBackend set to false',
-    done => {
-        clientCheck(true, log, err => {
-            assert.strictEqual(err, null,
-                `Expected success but got error ${err}`);
-            done();
-        });
-    });
     it('should return result for every location constraint in ' +
-    'locationConfig and at least one of every external locations with ' +
-    'errorOnExternalBackend set to true', done => {
+    'locationConfig and every external locations with flightCheckOnStartUp ' +
+    'set to true', done => {
         clientCheck(true, log, (err, results) => {
+            const resultKeys = Object.keys(results);
             locConstraints.forEach(constraint => {
-                if (Object.keys(results).indexOf(constraint) === -1) {
-                    const locationType = config
-                        .locationConstraints[constraint].type;
-                    assert(Object.keys(results).some(result =>
-                      config.locationConstraints[result].type
-                        === locationType));
-                }
+                assert(resultKeys.includes(constraint));
             });
             done();
         });
     });
-    it('should return no error with errorOnExternalBackend set to false',
+    it('should return no error with flightCheckOnStartUp set to false',
     done => {
         clientCheck(false, log, err => {
             assert.strictEqual(err, null,
@@ -43,8 +37,9 @@ describe('Healthcheck response', () => {
     });
     it('should return result for every location constraint in ' +
     'locationConfig and at least one of every external locations with ' +
-    'errorOnExternalBackend set to false', done => {
+    'flightCheckOnStartUp set to false', done => {
         clientCheck(false, log, (err, results) => {
+            assert.notStrictEqual(results.length, locConstraints.length);
             locConstraints.forEach(constraint => {
                 if (Object.keys(results).indexOf(constraint) === -1) {
                     const locationType = config
@@ -55,6 +50,55 @@ describe('Healthcheck response', () => {
                 }
             });
             done();
+        });
+    });
+
+    describe('Azure container creation', () => {
+        const containerName =
+            getAzureContainerName(azureLocationNonExistContainer);
+
+        beforeEach(done => {
+            azureClient.deleteContainerIfExists(containerName, done);
+        });
+
+        afterEach(done => {
+            azureClient.deleteContainerIfExists(containerName, done);
+        });
+
+        it('should create an azure location\'s container if it is missing ' +
+        'and the check is a flightCheckOnStartUp', done => {
+            clientCheck(true, log, (err, results) => {
+                const azureLocationNonExistContainerError =
+                    results[azureLocationNonExistContainer].error;
+                if (err) {
+                    assert.strictEqual(err, errors.InternalError,
+                        `got unexpected err in clientCheck: ${err}`);
+                    assert(azureLocationNonExistContainerError.startsWith(
+                        'The specified container is being deleted.'));
+                    return done();
+                }
+                return azureClient.getContainerMetadata(containerName,
+                    (err, azureResult) => {
+                        assert.strictEqual(err, null, 'got unexpected err ' +
+                            `heading azure container: ${err}`);
+                        assert.strictEqual(azureResult.name, containerName);
+                        return done();
+                    });
+            });
+        });
+
+        it('should not create an azure location\'s container even if it is ' +
+        'missing if the check is not a flightCheckOnStartUp', done => {
+            clientCheck(false, log, err => {
+                assert.strictEqual(err, null,
+                    `got unexpected err in clientCheck: ${err}`);
+                return azureClient.getContainerMetadata(containerName, err => {
+                    assert(err, 'Expected err but did not find one');
+                    assert.strictEqual(err.code, 'NotFound',
+                        `got unexpected err code in clientCheck: ${err.code}`);
+                    return done();
+                });
+            });
         });
     });
 });

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -406,6 +406,7 @@ describe('Multipart Upload API with AWS Backend', function mpuTestSuite() {
     });
 
     it('should only list parts after PartNumberMarker', done => {
+        this.timeout(90000);
         const objectKey = `key-${Date.now()}`;
         mpuSetup(awsLocation, objectKey, uploadId => {
             const listParams = getListParams(objectKey, uploadId);

--- a/tests/unit/utils/multipleBackendGateway.js
+++ b/tests/unit/utils/multipleBackendGateway.js
@@ -30,18 +30,18 @@ describe('Testing _checkExternalBackend', function describeF() {
     this.timeout(50000);
     beforeEach(done => {
         const clients = getClients(true);
-        return checkExternalBackend(clients, awsLocations, 'aws_s3',
+        return checkExternalBackend(clients, awsLocations, 'aws_s3', false,
         externalBackendHealthCheckInterval, done);
     });
     it('should not refresh response before externalBackendHealthCheckInterval',
     done => {
         const clients = getClients(false);
         return checkExternalBackend(clients, awsLocations, 'aws_s3',
-        externalBackendHealthCheckInterval, (err, res) => {
+        false, externalBackendHealthCheckInterval, (err, res) => {
             if (err) {
                 return done(err);
             }
-            assert.strictEqual(res.awsbackend, statusSuccess);
+            assert.strictEqual(res[0].awsbackend, statusSuccess);
             return done();
         });
     });
@@ -51,11 +51,11 @@ describe('Testing _checkExternalBackend', function describeF() {
         const clients = getClients(false);
         setTimeout(() => {
             checkExternalBackend(clients, awsLocations, 'aws_s3',
-            externalBackendHealthCheckInterval, (err, res) => {
+            false, externalBackendHealthCheckInterval, (err, res) => {
                 if (err) {
                     return done(err);
                 }
-                assert.strictEqual(res.awsbackend, statusFailure);
+                assert.strictEqual(res[0].awsbackend, statusFailure);
                 return done();
             });
         }, externalBackendHealthCheckInterval + 1);


### PR DESCRIPTION
Add flight check during start-up option to client check. If a flight check, behavior is:
 *  - return an error to halt start-up if there is any error in the client check
 *  - check all external backend locations (instead of just one random location per external backend)
 *  - create a container for an Azure location if one is missing