### PR TITLE
chore: add keep-alive to real awsclient config

### DIFF
--- a/tests/functional/aws-node-sdk/test/support/awsConfig.js
+++ b/tests/functional/aws-node-sdk/test/support/awsConfig.js
@@ -2,6 +2,7 @@ const AWS = require('aws-sdk');
 const fs = require('fs');
 const path = require('path');
 const { config } = require('../../../../../lib/Config');
+const https = require('https');
 
 function getAwsCredentials(profile, credFile) {
     const filename = path.join(process.env.HOME, credFile);
@@ -25,6 +26,11 @@ function getRealAwsConfig(awsLocation) {
         return { credentials, signatureVersion: 'v4' };
     }
     return {
+        httpOptions: {
+            agent: new https.Agent({
+                keepAlive: true,
+            }),
+        },
         accessKeyId: locCredentials.accessKey,
         secretAccessKey: locCredentials.secretKey,
         signatureVersion: 'v4',


### PR DESCRIPTION
May help save the time of re-establishing the connection between each request to AWS.