### PR TITLE
fix: error on versioning put to azure loc bucket

### DIFF
--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -6,6 +6,12 @@ const collectCorsHeaders = require('../utilities/collectCorsHeaders');
 const metadata = require('../metadata/wrapper');
 const { metadataValidateBucket } = require('../metadata/metadataUtils');
 const { pushMetric } = require('../utapi/utilities');
+const versioningNotImplBackends =
+    require('../../constants').versioningNotImplBackends;
+const { config } = require('../Config');
+
+const externalVersioningErrorMessage = 'We do not currently support putting ' +
+'a versioned object to a location-constraint of type Azure.';
 
 /**
  * Format of xml request:
@@ -50,6 +56,16 @@ function _parseXML(request, log, cb) {
     });
 }
 
+function _checkBackendVersioningImplemented(bucket) {
+    const bucketLocation = bucket.getLocationConstraint();
+    const bucketLocationType = config.getLocationConstraintType(bucketLocation);
+
+    if (versioningNotImplBackends[bucketLocationType]) {
+        return false;
+    }
+    return true;
+}
+
 /**
  * Bucket Put Versioning - Create or update bucket Versioning
  * @param {AuthInfo} authInfo - Instance of AuthInfo class with requester's info
@@ -76,6 +92,16 @@ function bucketPutVersioning(authInfo, request, log, callback) {
             // just for linting; there should not be any parsing error here
             if (err) {
                 return next(err, bucket);
+            }
+            // _checkBackendVersioningImplemented returns false if versioning
+            // is not implemented on the bucket backend
+            if (!_checkBackendVersioningImplemented(bucket)) {
+                log.debug(externalVersioningErrorMessage,
+                    { method: 'bucketPutVersioning',
+                    error: errors.NotImplemented });
+                const error = errors.NotImplemented.customizeDescription(
+                    externalVersioningErrorMessage);
+                return next(error, bucket);
             }
             const versioningConfiguration = {};
             if (result.VersioningConfiguration.Status) {

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -16,7 +16,7 @@ const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type AWS or Azure.';
+'a versioned object to a location-constraint of type Azure.';
 
 /*
 Sample xml response:

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -70,11 +70,26 @@ describeF() {
         });
         describe('with bucket location header', () => {
             beforeEach(done =>
-              s3.createBucket({ Bucket: azureContainerName,
-                  CreateBucketConfiguration: {
-                      LocationConstraint: azureLocation,
-                  },
-              }, done));
+                s3.createBucket({ Bucket: azureContainerName,
+                    CreateBucketConfiguration: {
+                        LocationConstraint: azureLocation,
+                    },
+                }, done));
+
+            it('should return a NotImplemented error if try to put ' +
+            'versioning to bucket with Azure location', done => {
+                const params = {
+                    Bucket: azureContainerName,
+                    VersioningConfiguration: {
+                        Status: 'Enabled',
+                    },
+                };
+                s3.putBucketVersioning(params, err => {
+                    assert.strictEqual(err.code, 'NotImplemented');
+                    done();
+                });
+            });
+
             it('should put an object to Azure, with no object location ' +
             'header, based on bucket location', function it(done) {
                 const params = {


### PR DESCRIPTION
For buckets put to backend locations that do not support versioning (Azure atm), we should return a NotImplemented error if the user tries to put versioning on the bucket.