### PR TITLE
fix: try-catch should catch getAws thrown errors

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
@@ -2,9 +2,9 @@ const assert = require('assert');
 const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { describeSkipIfNotMultiple, awsS3, awsBucket, getAzureClient,
-    getAzureContainerName, convertMD5, memLocation, fileLocation, awsLocation,
-    azureLocation } = require('../utils');
+const { describeSkipIfNotMultiple, awsS3, awsBucket, getAwsRetry,
+    getAzureClient, getAzureContainerName, convertMD5, memLocation,
+    fileLocation, awsLocation, azureLocation } = require('../utils');
 
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName(azureLocation);
@@ -54,8 +54,7 @@ function getAndAssertObjectTags(tagParams, callback) {
 
 function awsGet(key, tagCheck, isEmpty, isMpu, callback) {
     process.stdout.write('Getting object from AWS\n');
-    awsS3.getObject({ Bucket: awsBucket, Key: key },
-    (err, res) => {
+    getAwsRetry({ key }, 0, (err, res) => {
         assert.equal(err, null);
         if (isEmpty) {
             assert.strictEqual(res.ETag, `"${emptyMD5}"`);
@@ -117,9 +116,7 @@ function getObject(key, backend, tagCheck, isEmpty, isMpu, callback) {
         });
     }
     if (backend === 'awsbackend') {
-        setTimeout(() => {
-            get(() => awsGet(key, tagCheck, isEmpty, isMpu, callback));
-        }, cloudTimeout);
+        get(() => awsGet(key, tagCheck, isEmpty, isMpu, callback));
     } else if (backend === 'azurebackend') {
         setTimeout(() => {
             get(() => azureGet(key, tagCheck, isEmpty, callback));

--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -243,8 +243,8 @@ utils.getAndAssertResult = (s3, params, cb) => {
         });
 };
 
-utils.awsGetLatestVerId = (key, body, cb, retryNumber) => {
-    const _retryNumber = retryNumber === undefined ? 0 : retryNumber;
+utils.getAwsRetry = (params, retryNumber, assertCb) => {
+    const { key, versionId } = params;
     const retryTimeout = {
         0: 0,
         1: awsFirstTimeout,
@@ -252,26 +252,33 @@ utils.awsGetLatestVerId = (key, body, cb, retryNumber) => {
     };
     const maxRetries = 2;
     const getObject = awsS3.getObject.bind(awsS3);
-    const timeout = retryTimeout[_retryNumber];
-    return setTimeout(getObject, timeout, { Bucket: awsBucket, Key: key },
-        (err, result) => {
-            if (err && _retryNumber !== maxRetries) {
-                // retry operation with longer timeout
-                return utils.awsGetLatestVerId(key, body, cb, _retryNumber + 1);
+    const timeout = retryTimeout[retryNumber];
+    return setTimeout(getObject, timeout, { Bucket: awsBucket, Key: key,
+        VersionId: versionId },
+        (err, res) => {
+            try {
+                // note: this will only catch exceptions thrown before an
+                // asynchronous call
+                return assertCb(err, res);
+            } catch (e) {
+                if (retryNumber !== maxRetries) {
+                    return utils.getAwsRetry(params, retryNumber + 1,
+                        assertCb);
+                }
+                throw e;
             }
-            assert.strictEqual(err, null, 'Expected success ' +
-                `getting object from AWS, got error ${err}`);
-            const resultMD5 = utils.expectedETag(result.Body, false);
-            const expectedMD5 = utils.expectedETag(body, false);
-            if (resultMD5 !== expectedMD5 && _retryNumber !== maxRetries) {
-                // retry operation with longer timeout
-                return utils.awsGetLatestVerId(key, body, cb, _retryNumber + 1);
-            }
-            assert.strictEqual(resultMD5, expectedMD5,
-                'expected different body');
-            return cb(null, result.VersionId);
         });
 };
+
+utils.awsGetLatestVerId = (key, body, cb) =>
+    utils.getAwsRetry({ key }, 0, (err, result) => {
+        assert.strictEqual(err, null, 'Expected success ' +
+            `getting object from AWS, got error ${err}`);
+        const resultMD5 = utils.expectedETag(result.Body, false);
+        const expectedMD5 = utils.expectedETag(body, false);
+        assert.strictEqual(resultMD5, expectedMD5, 'expected different body');
+        return cb(null, result.VersionId);
+    });
 
 utils.tagging = {};
 


### PR DESCRIPTION
We tried to reduce the length of end to end runs before by skipping timeouts on first attempts to get data from AWS, but some thrown errors were not getting caught because try-catch scopes do not extend to code inside an asynchronous function's callback.

Refactored so we only use try-catch when we are nesting the statements which may throw errors we expect to be caught immediately within.