### PR TITLE
FIX: S3C-1087 put and copy metadata for external backends

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -455,7 +455,7 @@ class AwsClient {
         });
     }
     copyObject(request, destLocationConstraintName, sourceKey,
-    sourceLocationConstraintName, log, callback) {
+    sourceLocationConstraintName, storeMetadataParams, log, callback) {
         const destBucketName = request.bucketName;
         const destObjectKey = request.objectKey;
         const destAwsKey = this._createAwsKey(destBucketName, destObjectKey,

--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -3,7 +3,7 @@ const url = require('url');
 const { errors, s3middleware } = require('arsenal');
 const azure = require('azure-storage');
 const createLogger = require('../multipleBackendLogger');
-const { logHelper } = require('./utils');
+const { logHelper, translateAzureMetaHeaders } = require('./utils');
 const { config } = require('../../Config');
 const { validateAndFilterMpuParts } =
     require('../../api/apiUtils/object/processMpuParts');
@@ -58,26 +58,6 @@ class AzureClient {
         return `${requestBucketName}/${requestObjectKey}`;
     }
 
-    _translateMetaHeaders(metaHeaders, tags) {
-        const translatedMetaHeaders = {};
-        if (tags) {
-            // tags are passed as string of format 'key1=value1&key2=value2'
-            const tagObj = {};
-            const tagArr = tags.split('&');
-            tagArr.forEach(keypair => {
-                const equalIndex = keypair.indexOf('=');
-                const key = keypair.substring(0, equalIndex);
-                tagObj[key] = keypair.substring(equalIndex + 1);
-            });
-            translatedMetaHeaders.tags = JSON.stringify(tagObj);
-        }
-        Object.keys(metaHeaders).forEach(headerName => {
-            const translated = headerName.replace(/-/g, '_');
-            translatedMetaHeaders[translated] = metaHeaders[headerName];
-        });
-        return translatedMetaHeaders;
-    }
-
     _getMetaHeaders(objectMD) {
         const metaHeaders = {};
         Object.keys(objectMD).forEach(mdKey => {
@@ -86,7 +66,7 @@ class AzureClient {
                 metaHeaders[mdKey] = objectMD[mdKey];
             }
         });
-        return this._translateMetaHeaders(metaHeaders);
+        return translateAzureMetaHeaders(metaHeaders);
     }
 
     // Before putting or deleting object on Azure, check if MPU exists with
@@ -135,7 +115,7 @@ class AzureClient {
             const azureKey = this._createAzureKey(keyContext.bucketName,
                 keyContext.objectKey, this._bucketMatch);
             const options = { metadata:
-                this._translateMetaHeaders(keyContext.metaHeaders,
+                translateAzureMetaHeaders(keyContext.metaHeaders,
                 keyContext.tagging) };
             if (size === 0) {
                 return this._errorWrapper('put', 'createBlockBlobFromText',
@@ -363,7 +343,7 @@ class AzureClient {
     }
 
     copyObject(request, destLocationConstraintName, sourceKey,
-    sourceLocationConstraintName, log, callback) {
+    sourceLocationConstraintName, storeMetadataParams, log, callback) {
         const destContainerName = request.bucketName;
         const destObjectKey = request.objectKey;
 
@@ -374,10 +354,16 @@ class AzureClient {
         config.locationConstraints[sourceLocationConstraintName]
         .details.azureContainerName;
 
+        let options;
+        if (storeMetadataParams.metaHeaders) {
+            options = { metadata:
+            translateAzureMetaHeaders(storeMetadataParams.metaHeaders) };
+        }
+
         this._errorWrapper('copyObject', 'startCopyBlob',
             [`${this._azureStorageEndpoint}` +
                 `${sourceContainerName}/${sourceKey}`,
-                this._azureContainerName, destAzureKey,
+                this._azureContainerName, destAzureKey, options,
             (err, res) => {
                 if (err) {
                     if (err.code === 'CannotVerifyCopySource') {

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -112,6 +112,25 @@ const utils = {
         }
         return cb();
     },
+    translateAzureMetaHeaders(metaHeaders, tags) {
+        const translatedMetaHeaders = {};
+        if (tags) {
+            // tags are passed as string of format 'key1=value1&key2=value2'
+            const tagObj = {};
+            const tagArr = tags.split('&');
+            tagArr.forEach(keypair => {
+                const equalIndex = keypair.indexOf('=');
+                const key = keypair.substring(0, equalIndex);
+                tagObj[key] = keypair.substring(equalIndex + 1);
+            });
+            translatedMetaHeaders.tags = JSON.stringify(tagObj);
+        }
+        Object.keys(metaHeaders).forEach(headerName => {
+            const translated = headerName.substring(11).replace(/-/g, '_');
+            translatedMetaHeaders[translated] = metaHeaders[headerName];
+        });
+        return translatedMetaHeaders;
+    },
 };
 
 module.exports = utils;

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -45,7 +45,6 @@ const multipleBackendGateway = {
                 return callback(errors.InternalError);
             }
         }
-
         return client.put(writeStream, size, keyContext,
             reqUids, (err, key, dataStoreVersionId) => {
                 const log = createLogger(reqUids);
@@ -236,12 +235,12 @@ const multipleBackendGateway = {
     // NOTE: using copyObject only if copying object from one external
     // backend to the same external backend
     copyObject: (request, destLocationConstraintName, externalSourceKey,
-    sourceLocationConstraintName, log, cb) => {
+    sourceLocationConstraintName, storeMetadataParams, log, cb) => {
         const client = clients[destLocationConstraintName];
         if (client.copyObject) {
             return client.copyObject(request, destLocationConstraintName,
-            externalSourceKey, sourceLocationConstraintName, log,
-            (err, key, dataStoreVersionId) => {
+            externalSourceKey, sourceLocationConstraintName,
+            storeMetadataParams, log, (err, key, dataStoreVersionId) => {
                 const dataRetrievalInfo = {
                     key,
                     dataStoreName: destLocationConstraintName,

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -431,8 +431,8 @@ const data = {
             const objectGetInfo = dataLocator[0];
             const externalSourceKey = objectGetInfo.key;
             return client.copyObject(request, destLocationConstraintName,
-            externalSourceKey, sourceLocationConstraintName, log,
-            (error, objectRetrievalInfo) => {
+            externalSourceKey, sourceLocationConstraintName,
+            storeMetadataParams, log, (error, objectRetrievalInfo) => {
                 if (error) {
                     return cb(error);
                 }

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
@@ -101,6 +101,8 @@ destBucket, destLoc, azureKey, mdDirective, objSize, callback) {
         if (mdDirective === 'COPY') {
             assert.strictEqual(sourceRes.Metadata['test-header'],
                 destRes.Metadata['test-header']);
+            assert.strictEqual(azureRes[0].metadata.test_header,
+                destRes.Metadata['test-header']);
         }
         assert.strictEqual(sourceRes.ContentLength, destRes.ContentLength);
         assert.strictEqual(sourceRes.Metadata[locMetaHeader], sourceLoc);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
@@ -9,7 +9,7 @@ const { getRealAwsConfig } = require('../../support/awsConfig');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
 const { describeSkipIfNotMultiple, awsS3, memLocation, awsLocation,
-    awsLocation2, awsLocationMismatch, awsLocationEncryption } =
+    azureLocation, awsLocation2, awsLocationMismatch, awsLocationEncryption } =
     require('../utils');
 const bucket = 'buckettestmultiplebackendobjectcopy';
 const bucketAws = 'bucketawstestmultiplebackendobjectcopy';
@@ -180,6 +180,30 @@ function testSuite() {
                     assert.strictEqual(result.CopyObjectResult.ETag,
                         `"${correctMD5}"`);
                     assertGetObjects(key, bucket, memLocation, copyKey,
+                        bucketAws, awsLocation, copyKey, 'COPY', false, awsS3,
+                        awsLocation, done);
+                });
+            });
+        });
+
+        it('should copy an object from Azure to AWS relying on ' +
+        'destination bucket location',
+        done => {
+            putSourceObj(azureLocation, false, bucket, key => {
+                const copyKey = `copyKey-${Date.now()}`;
+                const copyParams = {
+                    Bucket: bucketAws,
+                    Key: copyKey,
+                    CopySource: `/${bucket}/${key}`,
+                    MetadataDirective: 'COPY',
+                };
+                process.stdout.write('Copying object\n');
+                s3.copyObject(copyParams, (err, result) => {
+                    assert.equal(err, null, 'Expected success but got ' +
+                    `error: ${err}`);
+                    assert.strictEqual(result.CopyObjectResult.ETag,
+                        `"${correctMD5}"`);
+                    assertGetObjects(key, bucket, azureLocation, copyKey,
                         bucketAws, awsLocation, copyKey, 'COPY', false, awsS3,
                         awsLocation, done);
                 });

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putAzure.js
@@ -26,7 +26,7 @@ const normalMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const keys = getAzureKeys();
 /* eslint-disable camelcase */
 const azureMetadata = {
-    x_amz_meta_scal_location_constraint: azureLocation,
+    scal_location_constraint: azureLocation,
 };
 /* eslint-enable camelcase */
 
@@ -130,7 +130,7 @@ describeF() {
                 };
                 const azureMetadataMismatch = {
                     /* eslint-disable camelcase */
-                    x_amz_meta_scal_location_constraint: azureLocationMismatch,
+                    scal_location_constraint: azureLocationMismatch,
                     /* eslint-enable camelcase */
                 };
                 s3.putObject(params, err => {


### PR DESCRIPTION
- When copying to Azure we want to keep metadata up to date on the Azure side.

- Put and copying to Azure we want to trim `x-amz-meta`prefix from metadata header keys.