### PR TITLE
FIX: Get datastoreVersionId from metadata

### DIFF
--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -1,9 +1,8 @@
 const url = require('url');
 const async = require('async');
 
-const { auth, errors, s3middleware } = require('arsenal');
+const { auth, errors } = require('arsenal');
 const { responseJSONBody } = require('arsenal').s3routes.routesUtils;
-const { parseTagXml } = s3middleware.tagging;
 const vault = require('../auth/vault');
 const metadata = require('../metadata/wrapper');
 const locationConstraintCheck = require(
@@ -11,7 +10,8 @@ const locationConstraintCheck = require(
 const { dataStore } = require('../api/apiUtils/object/storeObject');
 const prepareRequestContexts = require(
 '../api/apiUtils/authorization/prepareRequestContexts');
-const { metadataValidateBucketAndObj } = require('../metadata/metadataUtils');
+const { metadataValidateBucketAndObj,
+    metadataGetObject } = require('../metadata/metadataUtils');
 const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
 const { locationConstraints } = require('../Config').config;
 const multipleBackendGateway = require('../data/multipleBackendGateway');
@@ -89,11 +89,23 @@ function _checkMultipleBackendRequest(request, log) {
         log.error(errMessage);
         return errors.BadRequest.customizeDescription(errMessage);
     }
-    if ((operation === 'puttagging' || operation === 'deletetagging') &&
-        headers['x-scal-data-store-version-id'] === undefined) {
-        errMessage = 'bad request: missing x-scal-data-store-version-id header';
-        log.error(errMessage);
-        return errors.BadRequest.customizeDescription(errMessage);
+    if (operation === 'puttagging' || operation === 'deletetagging') {
+        if (headers['x-scal-data-store-version-id'] === undefined) {
+            errMessage =
+                'bad request: missing x-scal-data-store-version-id header';
+            log.error(errMessage);
+            return errors.BadRequest.customizeDescription(errMessage);
+        }
+        if (headers['x-scal-source-bucket'] === undefined) {
+            errMessage = 'bad request: missing x-scal-source-bucket header';
+            log.error(errMessage);
+            return errors.BadRequest.customizeDescription(errMessage);
+        }
+        if (headers['x-scal-source-version-id'] === undefined) {
+            errMessage = 'bad request: missing x-scal-source-version-id header';
+            log.error(errMessage);
+            return errors.BadRequest.customizeDescription(errMessage);
+        }
     }
     if (operation === 'putobject' &&
         headers['content-md5'] === undefined) {
@@ -126,6 +138,38 @@ function _checkMultipleBackendRequest(request, log) {
         return errors.InvalidRequest.customizeDescription(errMessage);
     }
     return undefined;
+}
+
+function handleTaggingOperation(request, response, type, dataStoreVersionId,
+    log, callback) {
+    const storageLocation = request.headers['x-scal-storage-class'];
+    const objectMD = {
+        dataStoreName: storageLocation,
+        location: [{ dataStoreVersionId }],
+    };
+    if (type === 'Put') {
+        try {
+            const tags = JSON.parse(request.headers['x-scal-tags']);
+            objectMD.tags = tags;
+        } catch (err) {
+            // FIXME: add error type MalformedJSON
+            return callback(errors.MalformedPOSTRequest);
+        }
+    }
+    return multipleBackendGateway.objectTagging(type, request.objectKey,
+    request.bucketName, objectMD, log, err => {
+        if (err) {
+            log.error(`error during object tagging: ${type}`, {
+                error: err,
+                method: 'handleTaggingOperation',
+            });
+            return callback(err);
+        }
+        const dataRetrievalInfo = {
+            versionId: dataStoreVersionId,
+        };
+        return _respond(response, dataRetrievalInfo, log, callback);
+    });
 }
 
 /*
@@ -438,34 +482,25 @@ function putObjectTagging(request, response, log, callback) {
     if (err) {
         return callback(err);
     }
-    const storageLocation = request.headers['x-scal-storage-class'];
-    const dataStoreVersionId = request.headers['x-scal-data-store-version-id'];
-    const data = [];
-    let totalLength = 0;
-    request.on('data', chunk => {
-        totalLength += chunk.length;
-        data.push(chunk);
-    });
-    request.on('end', () =>
-        parseTagXml(Buffer.concat(data, totalLength), log, (err, tags) => {
-            const objectMD = {
-                dataStoreName: storageLocation,
-                location: [{ dataStoreVersionId }],
-                tags,
-            };
-            return multipleBackendGateway.objectTagging('Put',
-            request.objectKey, request.bucketName, objectMD, log, err => {
+    const sourceVersionId = request.headers['x-scal-source-version-id'];
+    const sourceBucket = request.headers['x-scal-source-bucket'];
+    let dataStoreVersionId = request.headers['x-scal-data-store-version-id'];
+    // If the tagging request is made before the replication has completed, the
+    // Kafka entry will not have the dataStoreVersionId available so we
+    // retrieve it from metadata here.
+    if (dataStoreVersionId === '') {
+        return metadataGetObject(sourceBucket, request.objectKey,
+            sourceVersionId, log, (err, objMD) => {
                 if (err) {
-                    log.error('error putting object tagging', {
-                        error: err,
-                        method: 'putObjectTagging',
-                    });
                     return callback(err);
                 }
-                return _respond(response, {}, log, callback);
+                dataStoreVersionId = objMD.replicationInfo.dataStoreVersionId;
+                return handleTaggingOperation(request, response, 'Put',
+                    dataStoreVersionId, log, callback);
             });
-        }));
-    return undefined;
+    }
+    return handleTaggingOperation(request, response, 'Put', dataStoreVersionId,
+        log, callback);
 }
 
 function deleteObjectTagging(request, response, log, callback) {
@@ -473,23 +508,25 @@ function deleteObjectTagging(request, response, log, callback) {
     if (err) {
         return callback(err);
     }
-    const storageLocation = request.headers['x-scal-storage-class'];
-    const dataStoreVersionId = request.headers['x-scal-data-store-version-id'];
-    const objectMD = {
-        dataStoreName: storageLocation,
-        location: [{ dataStoreVersionId }],
-    };
-    return multipleBackendGateway.objectTagging('Delete', request.objectKey,
-    request.bucketName, objectMD, log, err => {
-        if (err) {
-            log.error('error deleting object tagging', {
-                error: err,
-                method: 'deleteObjectTagging',
+    const sourceVersionId = request.headers['x-scal-source-version-id'];
+    const sourceBucket = request.headers['x-scal-source-bucket'];
+    let dataStoreVersionId = request.headers['x-scal-data-store-version-id'];
+    // If the tagging request is made before the replication has completed, the
+    // Kafka entry will not have the dataStoreVersionId available so we
+    // retrieve it from metadata here.
+    if (dataStoreVersionId === '') {
+        return metadataGetObject(sourceBucket, request.objectKey,
+            sourceVersionId, log, (err, objMD) => {
+                if (err) {
+                    return callback(err);
+                }
+                dataStoreVersionId = objMD.replicationInfo.dataStoreVersionId;
+                return handleTaggingOperation(request, response, 'Delete',
+                    dataStoreVersionId, log, callback);
             });
-            return callback(err);
-        }
-        return _respond(response, {}, log, callback);
-    });
+    }
+    return handleTaggingOperation(request, response, 'Delete',
+        dataStoreVersionId, log, callback);
 }
 
 const backbeatRoutes = {


### PR DESCRIPTION
Depends on https://github.com/scality/backbeat/pull/135.

Object tagging operations that are made before the source object has completed replication do not have the `datastoreVersionId` in the Kafka entry. 

Because all operations for the multiple backend are serialized, when any tagging operation is being replicated we can guarantee that the source object's metadata will have been updated at this point. Hence we need to retrieve the `replicationInfo.datastoreVersionId` from the source S3 before making the request to an external location.