### PR TITLE
ft: support http proxy for AWS backend

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const { EventEmitter } = require('events');
 const fs = require('fs');
 const path = require('path');
+const url = require('url');
 
 const uuid = require('node-uuid');
 
@@ -144,6 +145,27 @@ function locationConstraintAssert(locationConstraints) {
                 'bad config: credentials must include accessKey as string');
             assert(typeof details.credentials.secretKey === 'string',
                 'bad config: credentials must include secretKey as string');
+        }
+        if (details.proxy !== undefined) {
+            const { protocol, hostname, port } = url.parse(details.proxy);
+            assert(protocol === 'http:' || protocol === 'https:',
+                'bad config: protocol must be http or https in ' +
+                'locationConstraints[region].details');
+            assert(typeof hostname === 'string' && hostname !== '',
+                'bad config: hostname must be a non-empty string');
+            if (port) {
+                const portInt = Number.parseInt(port, 10);
+                assert(!Number.isNaN(portInt) && portInt > 0, 'bad config: ' +
+                    'locationConstraints[region].details port must be a ' +
+                    'number greater than 0');
+            }
+        }
+        if (details.https !== undefined) {
+            assert(typeof details.https === 'boolean', 'bad config: ' +
+                'locationConstraints[region].details https must be a boolean');
+        } else {
+            // eslint-disable-next-line no-param-reassign
+            locationConstraints[l].details.https = 'true';
         }
         if (locationConstraints[l].type === 'azure') {
             azureLocationConstraintAssert(l, locationConstraints[l]);

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -1,6 +1,7 @@
-const Sproxy = require('sproxydclient');
-const AWS = require('aws-sdk');
+const http = require('http');
 const https = require('https');
+const AWS = require('aws-sdk');
+const Sproxy = require('sproxydclient');
 
 const DataFileBackend = require('./file/backend');
 const inMemory = require('./in_memory/backend').backend;
@@ -37,20 +38,25 @@ function parseLC() {
             clients[location].clientType = 'scality';
         }
         if (locationObj.type === 'aws_s3') {
+            const connectionAgent = locationObj.details.https ?
+                new https.Agent({ keepAlive: true }) :
+                new http.Agent({ keepAlive: true });
+            const protocol = locationObj.details.https ? 'https' : 'http';
+            const httpOptions = locationObj.details.proxy ?
+                { proxy: locationObj.details.proxy, agent: connectionAgent }
+                : { agent: connectionAgent };
+            const sslEnabled = locationObj.details.https === true;
             const s3Params = {
-                endpoint: `https://${locationObj.details.awsEndpoint}`,
+                endpoint: `${protocol}://${locationObj.details.awsEndpoint}`,
                 debug: false,
                 // Not implemented yet for streams in node sdk,
                 // and has no negative impact if stream, so let's
                 // leave it in for future use
                 computeChecksums: true,
-                httpOptions: {
-                    agent: new https.Agent({
-                        keepAlive: true,
-                    }),
-                },
+                httpOptions,
                 // needed for encryption
                 signatureVersion: 'v4',
+                sslEnabled,
             };
             // users can either include the desired profile name from their
             // ~/.aws/credentials file or include the accessKeyId and


### PR DESCRIPTION
This commit adds support for a HTTP ONLY proxy for AWS client
used in AWS location constraint/backend setup.