### PR TITLE
Fix/s3 c 1120 aws proxy http payloads

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -173,7 +173,7 @@ function locationConstraintAssert(locationConstraints) {
                 'locationConstraints[region].details https must be a boolean');
         } else {
             // eslint-disable-next-line no-param-reassign
-            locationConstraints[l].details.https = 'true';
+            locationConstraints[l].details.https = true;
         }
         if (locationConstraints[l].type === 'azure') {
             azureLocationConstraintAssert(l, locationConstraints[l]);

--- a/lib/data/locationConstraintParser.js
+++ b/lib/data/locationConstraintParser.js
@@ -46,6 +46,10 @@ function parseLC() {
                 { proxy: locationObj.details.proxy, agent: connectionAgent }
                 : { agent: connectionAgent };
             const sslEnabled = locationObj.details.https === true;
+            // TODO: HTTP requests to AWS are not supported with V4 auth for
+            // non-file streams which are used by Backbeat. This option will be
+            // removed once CA certs, proxy setup feature is implemented.
+            const signatureVersion = !sslEnabled ? 'v2' : 'v4';
             const s3Params = {
                 endpoint: `${protocol}://${locationObj.details.awsEndpoint}`,
                 debug: false,
@@ -55,7 +59,7 @@ function parseLC() {
                 computeChecksums: true,
                 httpOptions,
                 // needed for encryption
-                signatureVersion: 'v4',
+                signatureVersion,
                 sslEnabled,
             };
             // users can either include the desired profile name from their


### PR DESCRIPTION
**fix: use V2 auth for HTTP only AWS requests**

 To use an AWS location constraint in an HTTP only proxy environment in the context of Backbeat, V2 auth is used to avoid the body signing exception thrown by AWS SDK.
