### PR TITLE
FT: S3C-1065: sparse objects

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -108,6 +108,10 @@ const constants = {
     legacyLocations: ['sproxyd', 'legacy'],
     /* eslint-disable camelcase */
     externalBackends: { aws_s3: true, azure: true },
+    // some of the available data backends  (if called directly rather
+    // than through the multiple backend gateway) need a key provided
+    // as a string as first parameter of the get/delete methods.
+    clientsRequireStringKey: { sproxyd: true, cdmi: true },
     // healthcheck default call from nginx is every 2 seconds
     // for external backends, don't call unless at least 1 minute
     // (60,000 milliseconds) since last call

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -90,7 +90,7 @@ const multipleBackendGateway = {
         // for backwards compatibility
         if (typeof objectGetInfo === 'string') {
             key = objectGetInfo;
-            client = clients.legacy;
+            client = clients.sproxyd;
         } else {
             key = objectGetInfo.key;
             client = clients[objectGetInfo.dataStoreName];
@@ -107,7 +107,7 @@ const multipleBackendGateway = {
         // for backwards compatibility
         if (typeof objectGetInfo === 'string') {
             key = objectGetInfo;
-            client = clients.legacy;
+            client = clients.sproxyd;
         } else {
             key = objectGetInfo.key;
             client = clients[objectGetInfo.dataStoreName];

--- a/lib/data/wrapper.js
+++ b/lib/data/wrapper.js
@@ -8,6 +8,7 @@ const multipleBackendGateway = require('./multipleBackendGateway');
 const utils = require('./external/utils');
 const { config } = require('../Config');
 const MD5Sum = s3middleware.MD5Sum;
+const NullStream = s3middleware.NullStream;
 const assert = require('assert');
 const kms = require('../kms/wrapper');
 const externalBackends = require('../../constants').externalBackends;
@@ -172,18 +173,28 @@ const data = {
     },
 
     get: (objectGetInfo, response, log, cb) => {
-        // If objectGetInfo.key exists the md-model-version is 2 or greater.
-        // Otherwise, the objectGetInfo is just the key string.
-        const objGetInfo = (implName === 'sproxyd' || implName === 'cdmi') ?
-            objectGetInfo.key : objectGetInfo;
+        const isMdModelVersion2 = typeof(objectGetInfo) === 'string';
+        const isRequiredStringKey = constants.clientsRequireStringKey[implName];
+        const key = isMdModelVersion2 ? objectGetInfo : objectGetInfo.key;
+        const clientGetInfo = isRequiredStringKey ? key : objectGetInfo;
         const range = objectGetInfo.range;
-        log.debug('sending get to datastore', { implName,
-            key: objectGetInfo.key, range, method: 'get' });
-        // We need to use response as a writtable stream for AZURE GET
-        if (response) {
-            objGetInfo.response = response;
+
+        // If the key is explicitly set to null, the part to
+        // be read doesn't really exist and is only made of zeroes.
+        // This functionality is used by Scality-NFSD.
+        // Otherwise, the key is always defined
+        assert(key === null || key !== undefined);
+        if (key === null) {
+            cb(null, new NullStream(objectGetInfo.size, range));
+            return;
         }
-        client.get(objGetInfo, range, log.getSerializedUids(),
+        log.debug('sending get to datastore', { implName,
+            key, range, method: 'get' });
+        // We need to use response as a writable stream for AZURE GET
+        if (!isMdModelVersion2 && !isRequiredStringKey && response) {
+            clientGetInfo.response = response;
+        }
+        client.get(clientGetInfo, range, log.getSerializedUids(),
             (err, stream) => {
                 if (err) {
                     log.error('get error from datastore',
@@ -219,16 +230,23 @@ const data = {
 
     delete: (objectGetInfo, log, cb) => {
         const callback = cb || log.end;
-        // If objectGetInfo.key exists the md-model-version is 2 or greater.
-        // Otherwise, the objectGetInfo is just the key string.
-        const objGetInfo = (implName === 'sproxyd' || implName === 'cdmi') ?
-            objectGetInfo.key : objectGetInfo;
+        const isMdModelVersion2 = typeof(objectGetInfo) === 'string';
+        const isRequiredStringKey = constants.clientsRequireStringKey[implName];
+        const key = isMdModelVersion2 ? objectGetInfo : objectGetInfo.key;
+        const clientGetInfo = isRequiredStringKey ? key : objectGetInfo;
+
         log.trace('sending delete to datastore', {
-            implName,
-            key: objectGetInfo.key,
-            method: 'delete',
-        });
-        _retryDelete(objGetInfo, log, 0, err => {
+            implName, key, method: 'delete' });
+        // If the key is explicitly set to null, the part to
+        // be deleted doesn't really exist.
+        // This functionality is used by Scality-NFSD.
+        // Otherwise, the key is always defined
+        assert(key === null || key !== undefined);
+        if (key === null) {
+            callback(null);
+            return;
+        }
+        _retryDelete(clientGetInfo, log, 0, err => {
             if (err) {
                 log.error('delete error from datastore',
                     { error: err, key: objectGetInfo.key, moreRetries: 'no' });
@@ -252,7 +270,7 @@ const data = {
             method: 'batchDelete',
         });
         async.eachLimit(locations, 5, (loc, next) => {
-            data.delete(loc, log, next);
+            process.nextTick(() => data.delete(loc, log, next));
         },
         err => {
             if (err) {

--- a/tests/unit/api/objectCopy.js
+++ b/tests/unit/api/objectCopy.js
@@ -95,7 +95,7 @@ describe('objectCopy with versioning', () => {
         objectCopy(authInfo, testObjectCopyRequest, sourceBucketName, objectKey,
             undefined, log, err => {
                 assert.ifError(err, `Unexpected err: ${err}`);
-                process.nextTick(() => {
+                setImmediate(() => {
                     versioningTestUtils
                         .assertDataStoreValues(ds, expectedValues);
                     done();

--- a/tests/unit/api/objectPut.js
+++ b/tests/unit/api/objectPut.js
@@ -266,7 +266,7 @@ describe('objectPut API', () => {
                         // orphan objects don't get deleted
                         // until the next tick
                         // in memory
-                        process.nextTick(() => {
+                        setImmediate(() => {
                             // Data store starts at index 1
                             assert.strictEqual(ds[0], undefined);
                             assert.strictEqual(ds[1], undefined);
@@ -308,7 +308,7 @@ describe('objectPut API with versioning', () => {
                 undefined, log, err => {
                     // wait until next tick since mem backend executes
                     // deletes in the next tick
-                    process.nextTick(() => {
+                    setImmediate(() => {
                         // old null version should be deleted
                         versioningTestUtils.assertDataStoreValues(ds,
                             [undefined, objData[1]]);
@@ -318,7 +318,7 @@ describe('objectPut API with versioning', () => {
             // create another null version
             callback => objectPut(authInfo, testPutObjectRequests[2],
                 undefined, log, err => {
-                    process.nextTick(() => {
+                    setImmediate(() => {
                         // old null version should be deleted
                         versioningTestUtils.assertDataStoreValues(ds,
                             [undefined, undefined, objData[2]]);
@@ -362,7 +362,7 @@ describe('objectPut API with versioning', () => {
             objectPut(authInfo, testPutObjectRequests[2], undefined,
                 log, err => {
                     assert.ifError(err, `Unexpected err: ${err}`);
-                    process.nextTick(() => {
+                    setImmediate(() => {
                         // old null version should be deleted after putting
                         // new null version
                         versioningTestUtils.assertDataStoreValues(ds,
@@ -391,7 +391,7 @@ describe('objectPut API with versioning', () => {
                 // orphan objects don't get deleted
                 // until the next tick
                 // in memory
-                process.nextTick(() => {
+                setImmediate(() => {
                     // Data store starts at index 1
                     assert.strictEqual(ds[0], undefined);
                     assert.strictEqual(ds[1], undefined);


### PR DESCRIPTION
# FT: S3C-1065: sparse objects

## Description

handle null parts on sparse objects

### Motivation and context

Null parts are parts with null keys which are generated by the NFS server when growing a file with truncate

### Related issues

* scality/scality-nfsd#103
* scality/Arsenal#377
* scality/Integration#601
