### PR TITLE
fix: validate & re-encode version id marker [S3C-368]

### DIFF
--- a/lib/api/bucketGet.js
+++ b/lib/api/bucketGet.js
@@ -80,6 +80,31 @@ const versionIdUtils = versioning.VersionID;
 */
 /* eslint-enable max-len */
 
+function getListParams(params, actualMaxKeys) {
+    const listParams = {
+        maxKeys: actualMaxKeys,
+        delimiter: params.delimiter,
+        prefix: params.prefix,
+    };
+
+    if (params.versions === undefined) {
+        listParams.listingType = 'DelimiterMaster';
+        listParams.marker = params.marker;
+    } else {
+        listParams.listingType = 'DelimiterVersions';
+        listParams.keyMarker = params['key-marker'];
+        const versionIdMarker = params['version-id-marker'] || undefined;
+        listParams.versionIdMarker =
+            versionIdMarker && versionIdMarker !== 'null' ?
+            versionIdUtils.decode(versionIdMarker) : versionIdMarker;
+        if (listParams.versionIdMarker instanceof Error) {
+            return { error: errors.InvalidArgument
+                .customizeDescription('Invalid version id specified') };
+        }
+    }
+    return listParams;
+}
+
 function processVersions(bucketName, listParams, list) {
     const xml = [];
     xml.push(
@@ -104,8 +129,11 @@ function processVersions(bucketName, listParams, list) {
         querystring.escape : escapeForXML;
     xmlParams.forEach(p => {
         if (p.value) {
-            const val = p.tag !== 'NextVersionIdMarker' || p.value === 'null' ?
-                p.value : versionIdUtils.encode(p.value);
+            let val = p.value;
+            if ((p.tag === 'NextVersionIdMarker' || p.tag === 'VersionIdMarker')
+            && p.value !== 'null') {
+                val = versionIdUtils.encode(p.value);
+            }
             xml.push(`<${p.tag}>${escapeXmlFn(val)}</${p.tag}>`);
         }
     });
@@ -235,13 +263,11 @@ function bucketGet(authInfo, request, log, callback) {
         bucketName,
         requestType: 'bucketGet',
     };
-    const listParams = {
-        listingType: 'DelimiterMaster',
-        maxKeys: actualMaxKeys,
-        delimiter: params.delimiter,
-        marker: params.marker,
-        prefix: params.prefix,
-    };
+
+    const listParams = getListParams(request.query, actualMaxKeys);
+    if (listParams.error) {
+        return process.nextTick(callback, listParams.error);
+    }
 
     metadataValidateBucket(metadataValParams, log, (err, bucket) => {
         const corsHeaders = collectCorsHeaders(request.headers.origin,
@@ -249,13 +275,6 @@ function bucketGet(authInfo, request, log, callback) {
         if (err) {
             log.debug('error processing request', { error: err });
             return callback(err, null, corsHeaders);
-        }
-        if (params.versions !== undefined) {
-            listParams.listingType = 'DelimiterVersions';
-            delete listParams.marker;
-            listParams.keyMarker = params['key-marker'];
-            listParams.versionIdMarker = params['version-id-marker'] ?
-                versionIdUtils.decode(params['version-id-marker']) : undefined;
         }
         return services.getObjectListing(bucketName, listParams, log,
         (err, list) => {

--- a/lib/metadata/in_memory/backend.js
+++ b/lib/metadata/in_memory/backend.js
@@ -205,22 +205,7 @@ const metastore = {
 
     listObject(bucketName, params, log, cb) {
         process.nextTick(() => {
-            const { prefix, marker, delimiter, maxKeys } = params;
-            if (prefix && typeof prefix !== 'string') {
-                return cb(errors.InvalidArgument);
-            }
-
-            if (marker && typeof marker !== 'string') {
-                return cb(errors.InvalidArgument);
-            }
-
-            if (delimiter && typeof delimiter !== 'string') {
-                return cb(errors.InvalidArgument);
-            }
-
-            if (maxKeys && typeof maxKeys !== 'number') {
-                return cb(errors.InvalidArgument);
-            }
+            const { maxKeys } = params;
 
             // If paramMaxKeys is undefined, the default parameter will set it.
             // However, if it is null, the default parameter will not set it.


### PR DESCRIPTION
Depends on https://github.com/scality/Integration/pull/608

Some versioning clean-up fixes: we were returning an unencoded version id marker in list versions (if a version id marker was provided in the first place) and not returning InvalidArgument if an invalid version ID is provided.