### PR TITLE
[WIP] Fix versioning-related Utapi metrics [SC3-368]

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -23,6 +23,7 @@ function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,
                 return callback(err);
             }
             if (dataToDelete) {
+                // TODO: update to check if dataGetInfo[0] exists?
                 const newDataStoreName = Array.isArray(dataGetInfo) ?
                     dataGetInfo[0].dataStoreName : null;
                 data.batchDelete(dataToDelete, requestMethod,
@@ -177,7 +178,8 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
             metadataStoreParams.nullVersionId = options.nullVersionId;
             return _storeInMDandDeleteData(bucketName, infoArr,
                 cipherBundle, metadataStoreParams,
-                options.dataToDelete, requestLogger, request.method, next);
+                options.dataToDelete, requestLogger, request.method,
+                (err, result) => next(err, result, options.oldByteLength));
         },
     ], callback);
 }

--- a/lib/api/apiUtils/object/versioning.js
+++ b/lib/api/apiUtils/object/versioning.js
@@ -78,7 +78,7 @@ function _storeNullVersionMD(bucketName, objKey, objMD, options, log, cb) {
 * @param {string} options.versionId - version to get from metadata
 * @param {RequestLogger} log - logger instanceof
 * @param {function} cb - callback
-* @return {undefined} - and call callback with (err, dataToDelete)
+* @return {undefined} - and call callback with err, dataToDelete, oldByteLength
 */
 function _getDeleteLocations(bucketName, objKey, options, log, cb) {
     return metadata.getObjectMD(bucketName, objKey, options, log,
@@ -95,14 +95,15 @@ function _getDeleteLocations(bucketName, objKey, options, log, cb) {
             }
             const dataToDelete = Array.isArray(versionMD.location) ?
                 versionMD.location : [versionMD.location];
-            return cb(null, dataToDelete);
+            const oldByteLength = versionMD['content-length'];
+            return cb(null, dataToDelete, oldByteLength);
         });
 }
 
 function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
     // before deleting null version md, retrieve location of data to delete
     return _getDeleteLocations(bucketName, objKey, options, log,
-        (err, nullDataToDelete) => {
+        (err, nullDataToDelete, oldByteLength) => {
             if (err) {
                 log.warn('could not find null version metadata', {
                     error: err,
@@ -117,7 +118,7 @@ function _deleteNullVersionMD(bucketName, objKey, options, log, cb) {
                         { error: err, method: '_deleteNullVersionMD' });
                         return cb(err);
                     }
-                    return cb(null, nullDataToDelete);
+                    return cb(null, nullDataToDelete, oldByteLength);
                 });
         });
 }
@@ -133,6 +134,7 @@ function processVersioningState(mst, vstat, cb) {
             options.versionId = '';
             options.isNull = true;
             options.dataToDelete = mst.objLocation;
+            options.oldByteLength = mst.size;
             // if null version exists, clean it up prior to put
             if (mst.isNull) {
                 delOptions.versionId = mst.versionId;
@@ -172,13 +174,15 @@ function processVersioningState(mst, vstat, cb) {
 
 function getMasterState(objMD) {
     if (!objMD) {
-        return {};
+        return { size: null };
     }
+
     const mst = {
         exists: true,
         versionId: objMD.versionId,
         isNull: objMD.isNull,
         nullVersionId: objMD.nullVersionId,
+        size: objMD['content-length'],
     };
     if (objMD.location) {
         mst.objLocation = Array.isArray(objMD.location) ?
@@ -212,6 +216,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
     // bucket is not versioning configured
     if (!vCfg) {
         options.dataToDelete = mst.objLocation;
+        options.oldByteLength = mst.size;
         return process.nextTick(callback, null, options);
     }
     // bucket is versioning configured
@@ -237,7 +242,7 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
                 return process.nextTick(next, null, options);
             }
             return _deleteNullVersionMD(bucketName, objectKey, delOptions, log,
-            (err, nullDataToDelete) => {
+            (err, nullDataToDelete, oldByteLength) => {
                 if (err) {
                     log.warn('unexpected error deleting null version md', {
                         error: err,
@@ -250,7 +255,10 @@ function versioningPreprocessing(bucketName, bucketMD, objectKey, objMD,
                     }
                     return next(errors.InternalError);
                 }
-                Object.assign(options, { dataToDelete: nullDataToDelete });
+                Object.assign(options, {
+                    dataToDelete: nullDataToDelete,
+                    oldByteLength,
+                });
                 return next(null, options);
             });
         },

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -212,10 +212,12 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             // if extra parts, need to delete the data when done with completing
             // mpu so extract the info to delete here
             const extraPartLocations = [];
+            let bytesToDelete = 0;
             if (partLength < storedPartsAsObjects.length) {
                 const extraParts = storedPartsAsObjects.slice(partLength);
                 extraParts.forEach(part => {
                     const locations = part.locations;
+                    bytesToDelete += part.size;
                     locations.forEach(location => {
                         if (!location || typeof location !== 'object') {
                             return;
@@ -338,13 +340,13 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     }
                     return next(null, destBucket, objMD, mpuBucket,
                         storedMetadata, aggregateETag, calculatedSize,
-                        dataLocations, mpuOverviewKey,
-                        storedPartsAsObjects, extraPartLocations);
+                        dataLocations, mpuOverviewKey, storedPartsAsObjects,
+                        extraPartLocations, bytesToDelete);
                 });
         },
         function prepForStoring(destBucket, objMD, mpuBucket, storedMetadata,
             aggregateETag, calculatedSize, dataLocations, mpuOverviewKey,
-            storedPartsAsObjects, extraPartLocations, next) {
+            storedPartsAsObjects, extraPartLocations, bytesToDelete, next) {
             const metaHeaders = {};
             const keysNotNeeded =
                 ['initiator', 'partLocations', 'key',
@@ -399,19 +401,25 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     metaStoreParams.versioning = options.versioning;
                     metaStoreParams.isNull = options.isNull;
                     metaStoreParams.nullVersionId = options.nullVersionId;
+                    if (options.oldByteLength) {
+                        // eslint-disable-next-line no-param-reassign
+                        bytesToDelete += options.oldByteLength;
+                    }
                     return next(null, destBucket, dataLocations,
                         metaStoreParams, mpuBucket, mpuOverviewKey,
                         aggregateETag, storedPartsAsObjects, objMD,
-                        extraPartLocations, pseudoCipherBundle, dataToDelete);
+                        extraPartLocations, pseudoCipherBundle, dataToDelete,
+                        bytesToDelete);
                 });
         },
         function storeAsNewObj(destinationBucket, dataLocations,
             metaStoreParams, mpuBucket, mpuOverviewKey, aggregateETag,
             storedPartsAsObjects, objMD, extraPartLocations, pseudoCipherBundle,
-            dataToDelete, next) {
+            dataToDelete, bytesToDelete, next) {
             return services.metadataStoreObject(destinationBucket.getName(),
                 dataLocations, pseudoCipherBundle, metaStoreParams,
                 (err, res) => {
+                    const isOverwrite = Boolean(dataToDelete);
                     if (err) {
                         return next(err, destinationBucket);
                     }
@@ -426,24 +434,27 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     }
                     return next(null, mpuBucket, mpuOverviewKey, aggregateETag,
                         storedPartsAsObjects, extraPartLocations,
-                        destinationBucket, generatedVersionId);
+                        destinationBucket, generatedVersionId, bytesToDelete,
+                        isOverwrite);
                 });
         },
         function deletePartsMetadata(mpuBucket, mpuOverviewKey, aggregateETag,
             storedPartsAsObjects, extraPartLocations, destinationBucket,
-            generatedVersionId, next) {
+            generatedVersionId, bytesToDelete, isOverwrite, next) {
             const keysToDelete = storedPartsAsObjects.map(item => item.key);
             keysToDelete.push(mpuOverviewKey);
             services.batchDeleteObjectMetadata(mpuBucket.getName(),
                 keysToDelete, log, err => next(err, destinationBucket,
-                    aggregateETag, generatedVersionId));
+                    aggregateETag, generatedVersionId, bytesToDelete,
+                    isOverwrite));
             if (extraPartLocations.length > 0) {
                 data.batchDelete(extraPartLocations, request.method, null,
                     logger.newRequestLoggerFromSerializedUids(log
                     .getSerializedUids()));
             }
         },
-    ], (err, destinationBucket, aggregateETag, generatedVersionId) => {
+    ], (err, destinationBucket, aggregateETag, generatedVersionId,
+        bytesDeleted, isOverwrite) => {
         const resHeaders =
             collectCorsHeaders(request.headers.origin, request.method,
                 destinationBucket);
@@ -458,6 +469,10 @@ function completeMultipartUpload(authInfo, request, log, callback) {
         const xml = _convertToXml(xmlParams);
         pushMetric('completeMultipartUpload', log, {
             authInfo,
+             // no extra data is put during complete mpu,
+             // but extra or old data may be deleted
+            byteLength: bytesDeleted,
+            isOverwrite,
             bucket: bucketName,
         });
         return callback(null, xml, resHeaders);

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -374,13 +374,15 @@ function objectCopy(authInfo, request, sourceBucket,
                     // eslint-disable-next-line
                     storeMetadataParams.nullVersionId = options.nullVersionId;
                     const dataToDelete = options.dataToDelete;
+                    const destObjPrevSize = options.oldByteLength;
                     return next(null, storeMetadataParams, destDataGetInfoArr,
                         destObjMD, serverSideEncryption, destBucketMD,
-                        dataToDelete);
+                        dataToDelete, destObjPrevSize);
                 });
         },
         function storeNewMetadata(storeMetadataParams, destDataGetInfoArr,
-            destObjMD, serverSideEncryption, destBucketMD, dataToDelete, next) {
+            destObjMD, serverSideEncryption, destBucketMD, dataToDelete,
+            destObjPrevSize, next) {
             return services.metadataStoreObject(destBucketName,
                 destDataGetInfoArr, serverSideEncryption,
                 storeMetadataParams, (err, result) => {
@@ -398,9 +400,6 @@ function objectCopy(authInfo, request, sourceBucket,
                                     log.getSerializedUids()));
                     }
                     const sourceObjSize = storeMetadataParams.size;
-                    const destObjPrevSize = (destObjMD &&
-                        destObjMD['content-length'] !== undefined) ?
-                        destObjMD['content-length'] : null;
                     return next(null, result, destBucketMD, storeMetadataParams,
                         serverSideEncryption, sourceObjSize, destObjPrevSize);
                 });
@@ -444,7 +443,7 @@ function objectCopy(authInfo, request, sourceBucket,
             authInfo,
             bucket: destBucketName,
             newByteLength: sourceObjSize,
-            oldByteLength: isVersioned ? null : destObjPrevSize,
+            oldByteLength: destObjPrevSize,
         });
         // Add expiration header if lifecycle enabled
         return callback(null, xml, additionalHeaders);

--- a/lib/api/objectPut.js
+++ b/lib/api/objectPut.js
@@ -84,29 +84,18 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
                 bucket, objectKey, objMD, authInfo, canonicalID, cipherBundle,
                 request, false, streamingV4Params, log, next);
             },
-        ], (err, storingResult) => {
+        ], (err, storingResult, oldByteLength) => {
             if (err) {
                 return callback(err, responseHeaders);
             }
-            const newByteLength = request.parsedContentLength;
+            const vcfg = bucket.getVersioningConfiguration();
+            const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
 
-            // Utapi expects null or a number for oldByteLength:
-            // * null - new object
-            // * 0 or > 0 - existing object with content-length 0 or > 0
-            // objMD here is the master version that we would
-            // have overwritten if there was an existing version or object
-            //
-            // TODO: Handle utapi metrics for null version overwrites.
-            const oldByteLength = objMD && objMD['content-length']
-                !== undefined ? objMD['content-length'] : null;
             if (storingResult) {
                 // ETag's hex should always be enclosed in quotes
                 responseHeaders.ETag = `"${storingResult.contentMD5}"`;
-            }
-            const vcfg = bucket.getVersioningConfiguration();
-            const isVersionedObj = vcfg && vcfg.Status === 'Enabled';
-            if (isVersionedObj) {
-                if (storingResult && storingResult.versionId) {
+
+                if (isVersionedObj && storingResult.versionId) {
                     responseHeaders['x-amz-version-id'] =
                         versionIdUtils.encode(storingResult.versionId);
                 }
@@ -114,8 +103,8 @@ function objectPut(authInfo, request, streamingV4Params, log, callback) {
             pushMetric('putObject', log, {
                 authInfo,
                 bucket: bucketName,
-                newByteLength,
-                oldByteLength: isVersionedObj ? null : oldByteLength,
+                newByteLength: request.parsedContentLength,
+                oldByteLength,
             });
             return callback(null, responseHeaders);
         });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "node-uuid": "^1.4.3",
     "npm-run-all": "~4.0.2",
     "sproxydclient": "scality/sproxydclient#rel/7.0",
-    "utapi": "scality/utapi#rel/7.0",
+    "utapi": "scality/utapi#fix/utapi-versioning-metrics",
     "utf8": "~2.1.1",
     "vaultclient": "scality/vaultclient#rel/7.0",
     "werelogs": "scality/werelogs#rel/7.0",

--- a/tests/functional/aws-node-sdk/test/object/completeMPU.js
+++ b/tests/functional/aws-node-sdk/test/object/completeMPU.js
@@ -97,7 +97,14 @@ describe('Complete MPU', () => {
 
             it('should complete an MPU with fewer parts than were ' +
                 'originally put without returning a version id', done => {
-                _completeMpuAndCheckVid(uploadId, eTag, undefined, done);
+                s3.uploadPart({ Bucket: bucket, Key: key,
+                      PartNumber: 2, UploadId: uploadId, Body: 'foo2' },
+                      err => {
+                          assert.strictEqual(err, null,
+                              'Unexpected error putting part');
+                          _completeMpuAndCheckVid(uploadId, eTag, undefined,
+                              done);
+                      });
             });
         });
 


### PR DESCRIPTION
To-do: 
 * objectPut, objectCopy, completeMpu: track correct old content length when overwriting null version that is not the latest version;
  * deleteObject: when creating a delete marker when versioning is suspended: 
     * - decrement storage utilized by the null version, if any.
     * - number of objects should remain unchanged (since we both delete a version, and put a delete marker).