### PR TITLE
bf: close/end readable/response streams on errors

### DIFF
--- a/lib/utilities/retrieveData.js
+++ b/lib/utilities/retrieveData.js
@@ -1,31 +1,74 @@
-export default function retrieveData(locations, dataRetrievalFn,
-    response, logger, errorHandlerFn) {
-    if (locations.length === 0) {
-        return response.end();
-    }
-    if (errorHandlerFn === undefined) {
-        // eslint-disable-next-line
-        errorHandlerFn = () => { response.connection.destroy(); };
-    }
-    const current = locations.shift();
-    return dataRetrievalFn(current, logger,
-        (err, readable) => {
+const { eachSeries } = require('async');
+const responseErr = new Error();
+responseErr.code = 'ResponseError';
+responseErr.message = 'response closed by client request before all data sent';
+
+export default function retrieveData(locations, retrieveDataFn, response, log) {
+    let responseDestroyed = false;
+    const _destroyResponse = () => {
+        // destroys the socket if available
+        response.destroy();
+        responseDestroyed = true;
+    };
+    response.once('close', () => {
+        log.debug('received close event before response end');
+        _destroyResponse();
+    });
+
+    eachSeries(locations,
+        (current, next) => retrieveDataFn(current, log, (err, readable) => {
+            let cbCalled = false;
+            const _next = err => {
+                // Avoid multiple callbacks since it's possible that response's
+                // close event and the readable's end event are emitted at
+                //  the same time.
+                if (!cbCalled) {
+                    cbCalled = true;
+                    next(err);
+                }
+            };
+
             if (err) {
-                logger.error('failed to get object', {
+                log.error('failed to get object', {
                     error: err,
                     method: 'retrieveData',
                 });
-                return errorHandlerFn(err);
+                _destroyResponse();
+                return _next(err);
             }
-            readable.on('error', err => {
-                logger.error('error piping data from source');
-                errorHandlerFn(err);
+            if (responseDestroyed) {
+                log.debug('response destroyed before readable could stream');
+                readable.emit('close');
+                return _next(responseErr);
+            }
+            // client closed the connection abruptly
+            response.once('close', () => {
+                log.debug('received close event before readable end');
+                if (!responseDestroyed) {
+                    _destroyResponse();
+                }
+                readable.emit('close');
+                return _next(responseErr);
             });
+            // readable stream successfully consumed
             readable.on('end', () => {
-                process.nextTick(retrieveData,
-                locations, dataRetrievalFn, response, logger);
+                log.debug('readable stream end reached');
+                return _next();
             });
-            readable.pipe(response, { end: false });
-            return undefined;
-        });
+            // errors on server side with readable stream
+            readable.on('error', err => {
+                log.error('error piping data from source');
+                return _next(err);
+            });
+            return readable.pipe(response, { end: false });
+        }), err => {
+            if (err) {
+                log.debug('abort response due to client error', {
+                    error: err.code, errMsg: err.message });
+            }
+            // call end for all cases (error/success) per node.js docs
+            // recommendation
+            response.end();
+        }
+    );
 }

--- a/tests/unit/utils/responseStreamData.js
+++ b/tests/unit/utils/responseStreamData.js
@@ -91,15 +91,18 @@ describe('responseStreamData:', () => {
         const response = httpMocks.createResponse({
             eventEmitter: EventEmitter,
         });
-        response.connection = {
-            destroy: () => {
-                data.get = prev;
-                done();
-            },
+        let destroyed = false;
+        response.destroy = () => {
+            data.get = prev;
+            destroyed = true;
         };
         response.on('end', () => {
             data.get = prev;
-            done(new Error('end reached instead of destroying connection'));
+            if (!destroyed) {
+                return done(new Error('end reached instead of destroying ' +
+                    'connection'));
+            }
+            return done();
         });
         return responseStreamData(errCode, overrideHeaders,
             resHeaders, dataLocations, response, null, log);


### PR DESCRIPTION
This fixes the leakage of sockets in CLOSE_WAIT state by closing the streams and
destroying the sockets when the client has abruptly closed the connection.
Depends on https://github.com/scality/sproxydclient/pull/132