### PR TITLE
FT: Protect reserved bucketname

### DIFF
--- a/lib/api/bucketPut.js
+++ b/lib/api/bucketPut.js
@@ -117,6 +117,12 @@ function bucketPut(authInfo, request, log, callback) {
     }
     const { bucketName } = request;
 
+    if (request.bucketName === 'METADATA') {
+        return callback(errors.AccessDenied
+            .customizeDescription('The bucket METADATA is used ' +
+            'for internal purposes'));
+    }
+
     return waterfall([
         next => _parseXML(request, log, next),
         // Check policies in Vault for a user.

--- a/tests/functional/aws-node-sdk/test/bucket/put.js
+++ b/tests/functional/aws-node-sdk/test/bucket/put.js
@@ -126,6 +126,12 @@ describe('PUT Bucket - AWS.S3.createBucket', () => {
                 testFn(shortName, done);
             });
 
+            it('should return 403 if name is reserved (e.g., METADATA)',
+                done => {
+                    const reservedName = 'METADATA';
+                    testFn(reservedName, done, 403, 'AccessDenied');
+                });
+
             itSkipIfAWS('should return 400 if name is longer than 63 chars',
                 done => {
                     const longName = 'x'.repeat(64);


### PR DESCRIPTION
This used to be protected by virtue of having capitalized letters but now that it is permitted in arsenal, protect here.
