### PR TITLE
TEST: Add content length check on get

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -225,6 +225,10 @@ utils.getAndAssertResult = (s3, params, cb) => {
                 `getting object, got error ${err}`);
             if (body) {
                 assert(data.Body, 'expected object body in response');
+                assert.equal(data.Body.length, data.ContentLength,
+                    `received data of length ${data.Body.length} does not ` +
+                    'equal expected based on ' +
+                    `content length header of ${data.ContentLength}`);
                 const expectedMD5 = utils.expectedETag(body, false);
                 const resultMD5 = utils.expectedETag(data.Body, false);
                 assert.strictEqual(resultMD5, expectedMD5);


### PR DESCRIPTION
Node sdk right now apparently does not check that body size is what was expected. I spent some time trying to figure out why we had an etag mismatch on a test with the aws backend --
 http://ci.ironmann.io/gh/scality/S3/9975

After looking through the logs, it's clear the connection with aws dropped before all of the data was retrieved but this was not apparent from the test.  This should help in the future.