### PR TITLE
S3C-1026 S3 consumes too much TCP memory

### DIFF
--- a/lib/utilities/retrieveData.js
+++ b/lib/utilities/retrieveData.js
@@ -33,7 +33,6 @@ export default function retrieveData(locations, retrieveDataFn, response, log) {
                     error: err,
                     method: 'retrieveData',
                 });
-                _destroyResponse();
                 return _next(err);
             }
             if (responseDestroyed) {
@@ -47,17 +46,19 @@ export default function retrieveData(locations, retrieveDataFn, response, log) {
                 if (!responseDestroyed) {
                     _destroyResponse();
                 }
-                readable.emit('close');
+                readable.destroy();
                 return _next(responseErr);
             });
             // readable stream successfully consumed
-            readable.on('end', () => {
+            readable.once('end', () => {
+                readable.unpipe(response);
                 log.debug('readable stream end reached');
                 return _next();
             });
             // errors on server side with readable stream
-            readable.on('error', err => {
+            readable.once('error', err => {
                 log.error('error piping data from source');
+                _destroyResponse();
                 return _next(err);
             });
             return readable.pipe(response, { end: false });
@@ -65,6 +66,7 @@ export default function retrieveData(locations, retrieveDataFn, response, log) {
             if (err) {
                 log.debug('abort response due to client error', {
                     error: err.code, errMsg: err.message });
+		return _destroyResponse();
             }
             // call end for all cases (error/success) per node.js docs
             // recommendation


### PR DESCRIPTION
destroy() the readable end (sproxyd) when the client closes the connection,
instead of sending a 'close' event.
Cleanup other error cases on the way.

# Pull request template

## Description

### Motivation and context

Why is this change required? What problem does it solve?

### Related issues

Please use the following link syntaxes #600 to reference issues in the
current repository

## Checklist

### Add tests to cover the changes

New tests added or existing tests modified to cover all changes

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

### Sign your work

In order to contribute to the project, you must sign your work
https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#sign-your-work

Thank you again for contributing! We will try to test and integrate the change
as soon as we can.
