### PR TITLE
S3C-1115 FT: Adds GCP Backend healthcheck

### DIFF
--- a/lib/data/external/GCP/GcpService.js
+++ b/lib/data/external/GCP/GcpService.js
@@ -63,6 +63,13 @@ const GCP = Service.defineService('gcp', ['2017-11-01'], {
         }
     },
 
+    // Implemented APIs
+    // Bucket API
+    getBucket(params, callback) {
+        return this.listObjects(params, callback);
+    },
+
+    // TO-DO: Implemented the following APIs
     upload(params, options, callback) {
         return callback(errors.NotImplemented
             .customizeDescription('GCP: upload not implemented'));
@@ -85,19 +92,14 @@ const GCP = Service.defineService('gcp', ['2017-11-01'], {
             .customizeDescription('GCP: deleteBucket not implemented'));
     },
 
-    headBucket(params, callback) {
-        return callback(errors.NotImplemented
-            .customizeDescription('GCP: headBucket not implemented'));
-    },
-
-    listObjects(params, callback) {
-        return callback(errors.NotImplemented
-            .customizeDescription('GCP: listObjects not implemented'));
-    },
-
     listObjectVersions(params, callback) {
         return callback(errors.NotImplemented
-            .customizeDescription('GCP: listObjecVersions not implemented'));
+            .customizeDescription('GCP: listObjectVersions not implemented'));
+    },
+
+    createBucket(params, callback) {
+        return callback(errors.NotImplemented
+            .customizeDescription('GCP: createBucket not implemented'));
     },
 
     putBucket(params, callback) {

--- a/lib/data/external/GCP/gcp-2017-11-01.api.json
+++ b/lib/data/external/GCP/gcp-2017-11-01.api.json
@@ -12,6 +12,194 @@
         "timestampFormat": "rfc822",
         "uid": "gcp-2017-11-01"
     },
-    "operations": {},
-    "shapes": {}
+    "operations": {
+        "HeadBucket": {
+            "http": {
+                "method": "HEAD",
+                "requestUri": "/{Bucket}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "ProjectId": {
+                        "location": "header",
+                        "locationName": "x-goog-project-id"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "MetaVersionId": {
+                        "location": "header",
+                        "locationName": "x-goog-metageneration"
+                    }
+                }
+            }
+        },
+        "listObjects": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/{Bucket}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Delimiter": {
+                        "location": "querystring",
+                        "locationName": "delimiter"
+                    },
+                    "Marker": {
+                        "location": "querystring",
+                        "locationName": "marker"
+                    },
+                    "MaxKeys": {
+                        "location": "querystring",
+                        "locationName": "max-keys",
+                        "type": "integer"
+                    },
+                    "Prefix": {
+                        "location": "querystring",
+                        "locationName": "prefix"
+                    },
+                    "ProjectId": {
+                        "location": "header",
+                        "locationName": "x-goog-project-id"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "IsTruncated": {
+                        "type": "boolean"
+                    },
+                    "Marker": {},
+                    "NextMarker": {},
+                    "Contents": {
+                        "shape": "ContentsShape"
+                    },
+                    "Name": {},
+                    "Prefix": {},
+                    "Delimiter": {},
+                    "MaxKeys": {
+                        "type": "integer"
+                    },
+                    "CommonPrefixes": {
+                        "shape": "CommonPrefixShape"
+                    }
+                }
+            }
+        },
+        "PutBucketVersioning": {
+            "http": {
+                "method": "PUT",
+                "requestUri": "/{Bucket}?versioning"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "VersioningConfiguration"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "ContentMD5": {
+                        "location": "header",
+                        "locationName": "Content-MD5"
+                    },
+                    "VersioningConfiguration": {
+                        "locationName": "VersioningConfiguration",
+                        "type": "structure",
+                        "members": {
+                            "Status": {}
+                        }
+                    }
+                },
+                "payload": "VersioningConfiguration"
+            }
+        },
+        "GetBucketVersioning": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/{Bucket}?versioning"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "Status": {}
+                }
+            }
+        }
+    },
+    "shapes": {
+        "OwnerShape": {
+            "locationName": "Owner",
+            "type": "structure",
+            "members": {
+                "ID": {},
+                "DisplayName": {}
+            }
+        },
+        "ContentsShape": {
+            "type": "list",
+            "member": {
+                "type": "structure",
+                "members": {
+                    "Key": {},
+                    "LastModified": {
+                        "type": "timestamp"
+                    },
+                    "ETag": {},
+                    "Size": {
+                        "type": "integer"
+                    },
+                    "StorageClass": {},
+                    "Owner": {
+                        "shape": "OwnerShape"
+                    }
+                }
+            },
+            "flattened": true
+        },
+        "CommonPrefixShape": {
+            "type": "list",
+            "member": {
+                "type": "structure",
+                "members": {
+                    "Prefix": {}
+                }
+            },
+            "flattened": true
+        }
+    }
 }

--- a/lib/data/external/GcpClient.js
+++ b/lib/data/external/GcpClient.js
@@ -1,3 +1,6 @@
+const async = require('async');
+const { errors } = require('arsenal');
+
 const { GCP } = require('./GCP');
 const AwsClient = require('./AwsClient');
 
@@ -33,6 +36,76 @@ class GcpClient extends AwsClient {
             authParams: config.authParams,
         });
         this._client = new GCP(this._gcpParams);
+    }
+
+    /**
+     * healthcheck - the gcp health requires checking multiple buckets:
+     * main, mpu, and overflow buckets
+     * @param {string} location - location name
+     * @param {function} callback - callback function to call with the bucket
+     * statuses
+     * @return {undefined}
+     */
+    healthcheck(location, callback) {
+        const checkBucketHealth = (bucket, cb) => {
+            const bucketResp = {};
+            this._client.headBucket({ Bucket: bucket }, err => {
+                if (err) {
+                    bucketResp[bucket] = {
+                        gcpBucket: bucket,
+                        error: err,
+                        external: true };
+                    return cb(null, bucketResp);
+                }
+                return this._client.getBucketVersioning({ Bucket: bucket },
+                (err, data) => {
+                    if (err) {
+                        bucketResp[bucket] = {
+                            gcpBucket: bucket,
+                            error: err,
+                            external: true,
+                        };
+                    } else if (!data.Status || data.Status === 'Suspended') {
+                        bucketResp[bucket] = {
+                            gcpBucket: bucket,
+                            versioningStatus: data.Status,
+                            error: 'Versioning must be enabled',
+                            external: true,
+                        };
+                    } else {
+                        bucketResp[bucket] = {
+                            gcpBucket: bucket,
+                            versioningStatus: data.Status,
+                            message: 'Congrats! You own the bucket',
+                        };
+                    }
+                    return cb(null, bucketResp);
+                });
+            });
+        };
+        const bucketList = [
+            this._gcpBucketName,
+            this._mpuBucketName,
+            this._overflowBucketname,
+        ];
+        async.map(bucketList, checkBucketHealth, (err, results) => {
+            const gcpResp = {};
+            gcpResp[location] = {
+                buckets: [],
+            };
+            if (err) {
+                // err should always be undefined
+                return callback(errors.InternalFailure
+                    .customizeDescription('Unable to perform health check'));
+            }
+            results.forEach(bucketResp => {
+                if (bucketResp.error) {
+                    gcpResp[location].error = true;
+                }
+                gcpResp[location].buckets.push(bucketResp);
+            });
+            return callback(null, gcpResp);
+        });
     }
 }
 

--- a/lib/data/external/utils.js
+++ b/lib/data/external/utils.js
@@ -2,14 +2,22 @@ const async = require('async');
 const constants = require('../../../constants');
 const { config } = require('../../../lib/Config');
 
-const awsHealth = {
-    response: undefined,
-    time: 0,
+/* eslint-disable camelcase */
+const backendHealth = {
+    aws_s3: {
+        response: undefined,
+        time: 0,
+    },
+    azure: {
+        response: undefined,
+        time: 0,
+    },
+    gcp: {
+        reponse: undefined,
+        time: 0,
+    },
 };
-const azureHealth = {
-    response: undefined,
-    time: 0,
-};
+/* eslint-enable camelcase */
 
 const utils = {
     logHelper(log, level, description, error, dataStoreName) {
@@ -91,7 +99,7 @@ const utils = {
 
     checkExternalBackend(clients, locations, type, flightCheckOnStartUp,
       externalBackendHealthCheckInterval, cb) {
-        const checkStatus = type === 'aws_s3' ? awsHealth : azureHealth;
+        const checkStatus = backendHealth[type] || {};
         if (locations.length === 0) {
             return process.nextTick(cb, null, []);
         }

--- a/lib/data/multipleBackendGateway.js
+++ b/lib/data/multipleBackendGateway.js
@@ -121,6 +121,7 @@ const multipleBackendGateway = {
         const multBackendResp = {};
         const awsArray = [];
         const azureArray = [];
+        const gcpArray = [];
         async.each(Object.keys(clients), (location, cb) => {
             const client = clients[location];
             if (client.clientType === 'scality') {
@@ -139,6 +140,9 @@ const multipleBackendGateway = {
             } else if (client.clientType === 'azure') {
                 azureArray.push(location);
                 return cb();
+            } else if (client.clientType === 'gcp') {
+                gcpArray.push(location);
+                return cb();
             }
             // if backend type isn't 'scality' or 'aws_s3', it will be
             //  'mem' or 'file', for which the default response is 200 OK
@@ -151,6 +155,9 @@ const multipleBackendGateway = {
                   externalBackendHealthCheckInterval, next),
                 next => checkExternalBackend(
                   clients, azureArray, 'azure', flightCheckOnStartUp,
+                  externalBackendHealthCheckInterval, next),
+                next => checkExternalBackend(
+                  clients, gcpArray, 'gcp', flightCheckOnStartUp,
                   externalBackendHealthCheckInterval, next),
             ], (errNull, externalResp) => {
                 const externalLocResults = [];

--- a/tests/functional/raw-node/test/GCP/README.MD
+++ b/tests/functional/raw-node/test/GCP/README.MD
@@ -1,0 +1,5 @@
+This directory contains GCP API functional tests.  
+
+These tests will verify that the GCP API implementation located in
+`lib/data/external/GCP` behaves as intended: correct error responses, edge case
+handling, and correct responses.

--- a/tests/functional/raw-node/test/GCP/bucket/get.js
+++ b/tests/functional/raw-node/test/GCP/bucket/get.js
@@ -1,0 +1,176 @@
+const assert = require('assert');
+const async = require('async');
+const { GCP } = require('../../../../../../lib/data/external/GCP');
+const { makeGcpRequest } = require('../../../utils/makeRequest');
+const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { getRealAwsConfig } =
+    require('../../../../aws-node-sdk/test/support/awsConfig');
+const constants = require('../../../../../../constants');
+
+const credentialOne = 'gcpbackend';
+
+describe('GCP: GET Bucket', function testSuite() {
+    this.timeout(180000);
+    const config = getRealAwsConfig(credentialOne);
+    const gcpClient = new GCP(config);
+
+    describe('without existing bucket', () => {
+        beforeEach(function beforeFn(done) {
+            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            return done();
+        });
+
+        it('should return 404 and NoSuchBucket', function testFn(done) {
+            gcpClient.getBucket({
+                Bucket: this.test.bucketName,
+            }, err => {
+                assert(err);
+                assert.strictEqual(err.statusCode, 404);
+                assert.strictEqual(err.code, 'NoSuchBucket');
+                return done();
+            });
+        });
+    });
+
+    describe('with existing bucket', () => {
+        let numberObjects;
+        beforeEach(function beforeFn(done) {
+            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            this.currentTest.createdObjects = Array.from(
+                Array(numberObjects).keys()).map(i => `someObject-${i}`);
+            process.stdout
+                .write(`Creating test bucket\n`);
+            return async.waterfall([
+                next => gcpRequestRetry({
+                    method: 'PUT',
+                    bucket: this.currentTest.bucketName,
+                    authCredentials: config.credentials,
+                }, 0, err => {
+                    if (err) {
+                        process.stdout.write(`err creating bucket ${err.code}`);
+                    }
+                    return next(err);
+                }),
+                next => {
+                    process.stdout.write(
+                        `Putting ${numberObjects} objects into bucket\n`);
+                    async.mapLimit(this.currentTest.createdObjects, 10,
+                    (object, moveOn) => {
+                        makeGcpRequest({
+                            method: 'PUT',
+                            bucket: this.currentTest.bucketName,
+                            objectKey: object,
+                            authCredentials: config.credentials,
+                        }, err => moveOn(err));
+                    }, err => {
+                        if (err) {
+                            process.stdout
+                                .write(`err putting objects ${err.code}`);
+                        }
+                        return next(err);
+                    });
+                },
+            ], err => done(err));
+        });
+
+        afterEach(function afterFn(done) {
+            return async.waterfall([
+                next => {
+                    process.stdout.write(
+                        `Deleting ${numberObjects} objects from bucket\n`);
+                    async.mapLimit(this.currentTest.createdObjects, 10,
+                    (object, moveOn) => {
+                        makeGcpRequest({
+                            method: 'DELETE',
+                            bucket: this.currentTest.bucketName,
+                            objectKey: object,
+                            authCredentials: config.credentials,
+                        }, err => moveOn(err));
+                    }, err => {
+                        if (err) {
+                            process.stdout
+                                .write(`err deleting objects ${err.code}`);
+                        }
+                        return next(err);
+                    });
+                },
+                next => gcpRequestRetry({
+                    method: 'DELETE',
+                    bucket: this.currentTest.bucketName,
+                    authCredentials: config.credentials,
+                }, 0, err => {
+                    if (err) {
+                        process.stdout.write(`err deleting bucket ${err.code}`);
+                    }
+                    return next(err);
+                }),
+            ], err => done(err));
+        });
+
+        describe('with less than listingHardLimit number of objects', () => {
+            before('Number of objects: 20', () => {
+                numberObjects = 20;
+            });
+
+            it('should list all 20 created objects',
+            function testFn(done) {
+                return gcpClient.listObjects({
+                    Bucket: this.test.bucketName,
+                }, (err, res) => {
+                    assert.equal(err, null, `Expected success, but got ${err}`);
+                    assert.strictEqual(res.Contents.length, numberObjects);
+                    return done();
+                });
+            });
+
+            describe('with MaxKeys at 10', () => {
+                it('should list MaxKeys number of objects',
+                function testFn(done) {
+                    return gcpClient.listObjects({
+                        Bucket: this.test.bucketName,
+                        MaxKeys: 10,
+                    }, (err, res) => {
+                        assert.equal(err, null,
+                            `Expected success, but got ${err}`);
+                        assert.strictEqual(res.Contents.length, 10);
+                        return done();
+                    });
+                });
+            });
+        });
+
+        describe('with more than listingHardLimit number of objects', () => {
+            before('Number of objects: 1001', () => {
+                numberObjects = constants.listingHardLimit + 1;
+            });
+
+            it('should list at max 1000 of objects created',
+            function testFn(done) {
+                return gcpClient.listObjects({
+                    Bucket: this.test.bucketName,
+                }, (err, res) => {
+                    assert.equal(err, null, `Expected success, but got ${err}`);
+                    assert.strictEqual(res.Contents.length,
+                        constants.listingHardLimit);
+                    return done();
+                });
+            });
+
+            describe('with MaxKeys at 1001', () => {
+                it('should list at max 1000, ignoring MaxKeys',
+                function testFn(done) {
+                    return gcpClient.listObjects({
+                        Bucket: this.test.bucketName,
+                        MaxKeys: 1001,
+                    }, (err, res) => {
+                        assert.equal(err, null,
+                            `Expected success, but got ${err}`);
+                        assert.strictEqual(res.Contents.length,
+                            constants.listingHardLimit);
+                        return done();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/tests/functional/raw-node/test/GCP/bucket/getVersioning.js
+++ b/tests/functional/raw-node/test/GCP/bucket/getVersioning.js
@@ -1,0 +1,107 @@
+const assert = require('assert');
+const async = require('async');
+const { GCP } = require('../../../../../../lib/data/external/GCP');
+const { makeGcpRequest } = require('../../../utils/makeRequest');
+const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { getRealAwsConfig } =
+    require('../../../../aws-node-sdk/test/support/awsConfig');
+
+const credentialOne = 'gcpbackend';
+const verEnabledObj = { Status: 'Enabled' };
+const verDisabledObj = { Status: 'Suspended' };
+const xmlEnable =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<VersioningConfiguration>' +
+    '<Status>Enabled</Status>' +
+    '</VersioningConfiguration>';
+const xmlDisable =
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<VersioningConfiguration>' +
+    '<Status>Suspended</Status>' +
+    '</VersioningConfiguration>';
+
+describe('GCP: GET Bucket Versioning', () => {
+    const config = getRealAwsConfig(credentialOne);
+    const gcpClient = new GCP(config);
+
+    beforeEach(function beforeFn(done) {
+        this.currentTest.bucketName = `somebucket-${Date.now()}`;
+        gcpRequestRetry({
+            method: 'PUT',
+            bucket: this.currentTest.bucketName,
+            authCredentials: config.credentials,
+        }, 0, err => {
+            if (err) {
+                process.stdout.write(`err in creating bucket ${err}\n`);
+            } else {
+                process.stdout.write('Created bucket\n');
+            }
+            return done(err);
+        });
+    });
+
+    afterEach(function afterFn(done) {
+        gcpRequestRetry({
+            method: 'DELETE',
+            bucket: this.currentTest.bucketName,
+            authCredentials: config.credentials,
+        }, 0, err => {
+            if (err) {
+                process.stdout.write(`err in deleting bucket ${err}\n`);
+            } else {
+                process.stdout.write('Deleted bucket\n');
+            }
+            return done(err);
+        });
+    });
+
+    it('should verify bucket versioning is enabled', function testFn(done) {
+        return async.waterfall([
+            next => makeGcpRequest({
+                method: 'PUT',
+                bucket: this.test.bucketName,
+                authCredentials: config.credentials,
+                queryObj: { versioning: {} },
+                requestBody: xmlEnable,
+            }, err => {
+                if (err) {
+                    process.stdout.write(`err in setting versioning ${err}`);
+                }
+                return next(err);
+            }),
+            next => gcpClient.getBucketVersioning({
+                Bucket: this.test.bucketName,
+            }, (err, res) => {
+                assert.equal(err, null,
+                    `Expected success, but got err ${err}`);
+                assert.deepStrictEqual(res, verEnabledObj);
+                return next();
+            }),
+        ], err => done(err));
+    });
+
+    it('should verify bucket versioning is disabled', function testFn(done) {
+        return async.waterfall([
+            next => makeGcpRequest({
+                method: 'PUT',
+                bucket: this.test.bucketName,
+                authCredentials: config.credentials,
+                queryObj: { versioning: {} },
+                requestBody: xmlDisable,
+            }, err => {
+                if (err) {
+                    process.stdout.write(`err in setting versioning ${err}`);
+                }
+                return next(err);
+            }),
+            next => gcpClient.getBucketVersioning({
+                Bucket: this.test.bucketName,
+            }, (err, res) => {
+                assert.equal(err, null,
+                    `Expected success, but got err ${err}`);
+                assert.deepStrictEqual(res, verDisabledObj);
+                return next();
+            }),
+        ], err => done(err));
+    });
+});

--- a/tests/functional/raw-node/test/GCP/bucket/head.js
+++ b/tests/functional/raw-node/test/GCP/bucket/head.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const { GCP } = require('../../../../../../lib/data/external/GCP');
+const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { getRealAwsConfig } =
+    require('../../../../aws-node-sdk/test/support/awsConfig');
+
+const credentialOne = 'gcpbackend';
+
+describe('GCP: HEAD Bucket', () => {
+    const config = getRealAwsConfig(credentialOne);
+    const gcpClient = new GCP(config);
+
+    describe('without existing bucket', () => {
+        beforeEach(function beforeFn(done) {
+            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            return done();
+        });
+
+        it('should return 404', function testFn(done) {
+            gcpClient.headBucket({
+                Bucket: this.test.bucketName,
+            }, err => {
+                assert(err);
+                assert.strictEqual(err.statusCode, 404);
+                return done();
+            });
+        });
+    });
+
+    describe('with existing bucket', () => {
+        beforeEach(function beforeFn(done) {
+            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            process.stdout
+                .write(`Creating test bucket ${this.currentTest.bucketName}\n`);
+            gcpRequestRetry({
+                method: 'PUT',
+                bucket: this.currentTest.bucketName,
+                authCredentials: config.credentials,
+            }, 0, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+                if (!res) {
+                    // should not happen
+                    return done(
+                        new Error('Error: success response does not result'));
+                }
+                this.currentTest.bucketObj = {
+                    MetaVersionId: res.headers['x-goog-metageneration'],
+                };
+                return done();
+            });
+        });
+
+        afterEach(function afterFn(done) {
+            gcpRequestRetry({
+                method: 'DELETE',
+                bucket: this.currentTest.bucketName,
+                authCredentials: config.credentials,
+            }, 0, err => {
+                if (err) {
+                    process.stdout
+                        .write(`err deleting bucket: ${err.code}\n`);
+                } else {
+                    process.stdout.write('Deleted bucket\n');
+                }
+                return done(err);
+            });
+        });
+
+        it('should get bucket information', function testFn(done) {
+            gcpClient.headBucket({
+                Bucket: this.test.bucketName,
+            }, (err, res) => {
+                assert.equal(err, null, `Expected success, but got ${err}`);
+                assert.deepStrictEqual(this.test.bucketObj, res);
+                return done();
+            });
+        });
+    });
+});

--- a/tests/functional/raw-node/test/GCP/bucket/putVersioning.js
+++ b/tests/functional/raw-node/test/GCP/bucket/putVersioning.js
@@ -1,0 +1,113 @@
+const assert = require('assert');
+const async = require('async');
+const xml2js = require('xml2js');
+const { GCP } = require('../../../../../../lib/data/external/GCP');
+const { makeGcpRequest } = require('../../../utils/makeRequest');
+const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { getRealAwsConfig } =
+    require('../../../../aws-node-sdk/test/support/awsConfig');
+
+const credentialOne = 'gcpbackend';
+const verEnabledObj = { VersioningConfiguration: { Status: ['Enabled'] } };
+const verDisabledObj = { VersioningConfiguration: { Status: ['Suspended'] } };
+
+function resParseAndAssert(xml, compareObj, callback) {
+    return xml2js.parseString(xml, (err, res) => {
+        if (err) {
+            process.stdout.write(`err in parsing response ${err}\n`);
+            return callback(err);
+        }
+        assert.deepStrictEqual(res, compareObj);
+        return callback();
+    });
+}
+
+describe('GCP: PUT Bucket Versioning', () => {
+    const config = getRealAwsConfig(credentialOne);
+    const gcpClient = new GCP(config);
+
+    beforeEach(function beforeFn(done) {
+        this.currentTest.bucketName = `somebucket-${Date.now()}`;
+        gcpRequestRetry({
+            method: 'PUT',
+            bucket: this.currentTest.bucketName,
+            authCredentials: config.credentials,
+        }, 0, err => {
+            if (err) {
+                process.stdout.write(`err in creating bucket ${err}\n`);
+            } else {
+                process.stdout.write('Created bucket\n');
+            }
+            return done(err);
+        });
+    });
+
+    afterEach(function afterFn(done) {
+        gcpRequestRetry({
+            method: 'DELETE',
+            bucket: this.currentTest.bucketName,
+            authCredentials: config.credentials,
+        }, 0, err => {
+            if (err) {
+                process.stdout.write(`err in deleting bucket ${err}\n`);
+            } else {
+                process.stdout.write('Deleted bucket\n');
+            }
+            return done(err);
+        });
+    });
+
+    it('should enable bucket versioning', function testFn(done) {
+        return async.waterfall([
+            next => gcpClient.putBucketVersioning({
+                Bucket: this.test.bucketName,
+                VersioningConfiguration: {
+                    Status: 'Enabled',
+                },
+            }, err => {
+                assert.equal(err, null,
+                    `Expected success, but got err ${err}`);
+                return next();
+            }),
+            next => makeGcpRequest({
+                method: 'GET',
+                bucket: this.test.bucketName,
+                authCredentials: config.credentials,
+                queryObj: { versioning: {} },
+            }, (err, res) => {
+                if (err) {
+                    process.stdout.write(`err in retrieving bucket ${err}`);
+                    return next(err);
+                }
+                return resParseAndAssert(res.body, verEnabledObj, next);
+            }),
+        ], err => done(err));
+    });
+
+    it('should disable bucket versioning', function testFn(done) {
+        return async.waterfall([
+            next => gcpClient.putBucketVersioning({
+                Bucket: this.test.bucketName,
+                VersioningConfiguration: {
+                    Status: 'Suspended',
+                },
+            }, err => {
+                assert.equal(err, null,
+                    `Expected success, but got err ${err}`);
+                return next();
+            }),
+            next => makeGcpRequest({
+                method: 'GET',
+                bucket: this.test.bucketName,
+                authCredentials: config.credentials,
+                queryObj: { versioning: {} },
+            }, (err, res) => {
+                if (err) {
+                    process.stdout.write(`err in retrieving bucket ${err}`);
+                    return next(err);
+                }
+                return resParseAndAssert(res.body, verDisabledObj, next);
+            }),
+        ], err => done(err));
+    });
+});

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -159,42 +159,5 @@
                 "servieKey": "fake001"
             }
         }
-    },
-    "gcpbackendproxy": {
-        "type": "gcp",
-        "legacyAwsBehavior": true,
-        "details": {
-            "proxy": "https://proxy.server",
-            "https": true,
-            "gcpEndpoint": "storage.googleapis.com",
-            "bucketName": "zenko-gcp-bucket",
-            "mpuBucketName": "zenko-gcp-mpu",
-            "overflowBucketName": "zenko-gcp-overflow",
-            "bucketMatch": false,
-            "credentialsProfile": "google",
-            "serviceCredentials": {
-                "scopes": "https://www.googleapis.com/auth/cloud-platform",
-                "serviceEmail": "fake001",
-                "servieKey": "fake001"
-            }
-        }
-    },
-    "gcpbackendnoproxy": {
-        "type": "gcp",
-        "legacyAwsBehavior": true,
-        "details": {
-            "https": false,
-            "gcpEndpoint": "storage.googleapis.com",
-            "bucketName": "zenko-gcp-bucket",
-            "mpuBucketName": "zenko-gcp-mpu",
-            "overflowBucketName": "zenko-gcp-overflow",
-            "bucketMatch": false,
-            "credentialsProfile": "google",
-            "serviceCredentials": {
-                "scopes": "https://www.googleapis.com/auth/cloud-platform",
-                "serviceEmail": "fake001",
-                "servieKey": "fake001"
-            }
-        }
     }
 }


### PR DESCRIPTION
Implements the APIs to enable backend healthcheck of GCP storages buckets

For client backend healthcheck.
Reference Docs:
HEAD API: https://cloud.google.com/storage/docs/xml-api/head-bucket
GET API: https://cloud.google.com/storage/docs/xml-api/get-bucket-list
PUT Versioning: https://cloud.google.com/storage/docs/xml-api/put-bucket-versioning
GET Versioning: https://cloud.google.com/storage/docs/xml-api/get-bucket-versioning