### PR TITLE
S3C-1026: tcp leak

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -69,6 +69,11 @@ class S3Server {
         this.server.on('request', (req, res) => {
             // disable nagle algorithm
             req.socket.setNoDelay();
+            res.on('close', () => {
+                // this is tested by retrieveData
+                // eslint-disable-next-line no-param-reassign
+                res.isclosed = true;
+            });
             routes(req, res, logger);
         });
         this.server.on('listening', () => {

--- a/lib/utilities/retrieveData.js
+++ b/lib/utilities/retrieveData.js
@@ -4,64 +4,58 @@ responseErr.code = 'ResponseError';
 responseErr.message = 'response closed by client request before all data sent';
 
 export default function retrieveData(locations, retrieveDataFn, response, log) {
+    // response is of type http.ServerResponse
     let responseDestroyed = false;
+    let currentStream = null; // reference to the stream we are reading from
     const _destroyResponse = () => {
         // destroys the socket if available
         response.destroy();
         responseDestroyed = true;
     };
+    // the S3-client might close the connection while we are processing it
     response.once('close', () => {
         log.debug('received close event before response end');
-        _destroyResponse();
+        responseDestroyed = true;
+        if (currentStream) {
+            currentStream.destroy();
+        }
     });
 
     eachSeries(locations,
         (current, next) => retrieveDataFn(current, log, (err, readable) => {
-            let cbCalled = false;
-            const _next = err => {
-                // Avoid multiple callbacks since it's possible that response's
-                // close event and the readable's end event are emitted at
-                //  the same time.
-                if (!cbCalled) {
-                    cbCalled = true;
-                    next(err);
-                }
-            };
-
+            // NB: readable is of IncomingMessage type
             if (err) {
                 log.error('failed to get object', {
                     error: err,
                     method: 'retrieveData',
                 });
                 _destroyResponse();
-                return _next(err);
+                return next(err);
             }
-            if (responseDestroyed) {
+            // response.isclosed is set by the S3 server. Might happen if the
+            // S3-client closes the connection before the first request to
+            // the backend is started.
+            if (responseDestroyed || response.isclosed) {
                 log.debug('response destroyed before readable could stream');
-                readable.emit('close');
-                return _next(responseErr);
+                readable.destroy();
+                return next(responseErr);
             }
-            // client closed the connection abruptly
-            response.once('close', () => {
-                log.debug('received close event before readable end');
-                if (!responseDestroyed) {
-                    _destroyResponse();
-                }
-                readable.emit('close');
-                return _next(responseErr);
-            });
             // readable stream successfully consumed
             readable.on('end', () => {
+                currentStream = null;
                 log.debug('readable stream end reached');
-                return _next();
+                return next();
             });
             // errors on server side with readable stream
             readable.on('error', err => {
                 log.error('error piping data from source');
-                return _next(err);
+                _destroyResponse();
+                return next(err);
             });
+            currentStream = readable;
             return readable.pipe(response, { end: false });
         }), err => {
+            currentStream = null;
             if (err) {
                 log.debug('abort response due to client error', {
                     error: err.code, errMsg: err.message });


### PR DESCRIPTION
Harden handling of events at different stages, so that we close sockets fds in
all situations, especially when the S3 client aborts the connection while we
are processing a GET request. This used to generate a FD leak, leading to
unread tcp buffers and memory leak (observed in netstat output).