### PR TITLE
[FIX] GCP Healthcheck

### DIFF
--- a/lib/data/external/GcpClient.js
+++ b/lib/data/external/GcpClient.js
@@ -48,10 +48,10 @@ class GcpClient extends AwsClient {
      */
     healthcheck(location, callback) {
         const checkBucketHealth = (bucket, cb) => {
-            const bucketResp = {};
+            let bucketResp;
             this._client.headBucket({ Bucket: bucket }, err => {
                 if (err) {
-                    bucketResp[bucket] = {
+                    bucketResp = {
                         gcpBucket: bucket,
                         error: err,
                         external: true };
@@ -60,20 +60,20 @@ class GcpClient extends AwsClient {
                 return this._client.getBucketVersioning({ Bucket: bucket },
                 (err, data) => {
                     if (err) {
-                        bucketResp[bucket] = {
+                        bucketResp = {
                             gcpBucket: bucket,
                             error: err,
                             external: true,
                         };
                     } else if (!data.Status || data.Status === 'Suspended') {
-                        bucketResp[bucket] = {
+                        bucketResp = {
                             gcpBucket: bucket,
                             versioningStatus: data.Status,
                             error: 'Versioning must be enabled',
                             external: true,
                         };
                     } else {
-                        bucketResp[bucket] = {
+                        bucketResp = {
                             gcpBucket: bucket,
                             versioningStatus: data.Status,
                             message: 'Congrats! You own the bucket',


### PR DESCRIPTION
Removes one layer of nesting that leads to errors not being detected.