### PR TITLE
FX: GCP Credentials

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -990,8 +990,15 @@ class Config extends EventEmitter {
             process.env[`${locationConstraint}_GCP_SERVICE_KEYFILE`];
         const serviceEmailFromEnv =
             process.env[`${locationConstraint}_GCP_SERVICE_EMAIL`];
-        const serviceKeyFromEnv =
+        let serviceKeyFromEnv =
             process.env[`${locationConstraint}_GCP_SERVICE_KEY`];
+        // the environment variable is a RSA private key.
+        // when read directly, the newline '\n' will
+        // be interpreted as '\\n', so the following check will
+        // fix this by replacing '\\n' with the actual newline char '\n'
+        if (typeof serviceKeyFromEnv === 'string') {
+            serviceKeyFromEnv = serviceKeyFromEnv.replace(/\\n/g, '\n');
+        }
         const serviceScopeFromEnv =
             process.env[`${locationConstraint}_GCP_SERVICE_SCOPE`];
         return {

--- a/tests.bash
+++ b/tests.bash
@@ -17,15 +17,6 @@ aws_access_key_id = $AWS_ACCESS_KEY_ID_GOOGLE_2
 aws_secret_access_key = $AWS_SECRET_ACCESS_KEY_GOOGLE_2
 EOF
 
-mkdir ${HOME}/.gcp #create directory for GCP service credential
-cat >>${HOME}/.gcp/servicekey <<EOF
-{
-  "type": "service_account",
-  "private_key": "$GOOGLE_SERVICE_KEY",
-  "client_email": "$GOOGLE_SERVICE_EMAIL"
-}
-EOF
-
 MYPWD=$(pwd)
 
 killandsleep () {

--- a/tests/locationConfig/locationConfigTests.json
+++ b/tests/locationConfig/locationConfigTests.json
@@ -134,8 +134,8 @@
             "gcpEndpoint": "storage.googleapis.com",
             "jsonEndpoint": "www.googleapis.com",
             "bucketName": "zenko-gcp-bucket-2",
-            "mpuBucketName": "zenko-gcp-mpu",
-            "overflowBucketName": "zenko-gcp-overflow",
+            "mpuBucketName": "zenko-gcp-mpu-2",
+            "overflowBucketName": "zenko-gcp-overflow-2",
             "bucketMatch": true,
             "credentialsProfile": "google_2",
             "serviceCredentials": {


### PR DESCRIPTION
Fixes the bug where it doesn't handle retrieving environment variables
with '\n', newline, correctly: '\n' will be retrieved as '\\\n'.

Changes the method for supplying the service credentials for the JSON api (from keyfile to email/key pair)
Adds gcpbackend2's own mpu bucket and overflow bucket.