### PR TITLE
Removes versioning check as part of GCP backend healthcheck

### DIFF
--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -17,7 +17,7 @@ const validateWebsiteHeader = require('./websiteServing')
 const { externalBackends, versioningNotImplBackends } = constants;
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type Azure.';
+'a versioned object to a location-constraint of type Azure or GCP.';
 
 
 function _storeInMDandDeleteData(bucketName, dataGetInfo, cipherBundle,

--- a/lib/api/bucketPutVersioning.js
+++ b/lib/api/bucketPutVersioning.js
@@ -11,7 +11,7 @@ const versioningNotImplBackends =
 const { config } = require('../Config');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type Azure.';
+'a versioned object to a location-constraint of type Azure or GCP.';
 
 /**
  * Format of xml request:

--- a/lib/api/initiateMultipartUpload.js
+++ b/lib/api/initiateMultipartUpload.js
@@ -16,7 +16,7 @@ const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
 
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type Azure.';
+'a versioned object to a location-constraint of type Azure or GCP.';
 
 /*
 Sample xml response:

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -25,7 +25,7 @@ const versionIdUtils = versioning.VersionID;
 const locationHeader = constants.objectLocationConstraintHeader;
 const versioningNotImplBackends = constants.versioningNotImplBackends;
 const externalVersioningErrorMessage = 'We do not currently support putting ' +
-'a versioned object to a location-constraint of type AWS or Azure.';
+'a versioned object to a location-constraint of type AWS or Azure or GCP.';
 
 /**
  * Preps metadata to be saved (based on copy or replace request header)

--- a/lib/data/external/GcpClient.js
+++ b/lib/data/external/GcpClient.js
@@ -60,30 +60,11 @@ class GcpClient extends AwsClient {
                         external: true };
                     return cb(null, bucketResp);
                 }
-                return this._client.getBucketVersioning({ Bucket: bucket },
-                (err, data) => {
-                    if (err) {
-                        bucketResp = {
-                            gcpBucket: bucket,
-                            error: err,
-                            external: true,
-                        };
-                    } else if (!data.Status || data.Status === 'Suspended') {
-                        bucketResp = {
-                            gcpBucket: bucket,
-                            versioningStatus: data.Status,
-                            error: 'Versioning must be enabled',
-                            external: true,
-                        };
-                    } else {
-                        bucketResp = {
-                            gcpBucket: bucket,
-                            versioningStatus: data.Status,
-                            message: 'Congrats! You own the bucket',
-                        };
-                    }
-                    return cb(null, bucketResp);
-                });
+                bucketResp = {
+                    gcpBucket: bucket,
+                    message: 'Congrats! You own the bucket',
+                };
+                return cb(null, bucketResp);
             });
         };
         const bucketList = [


### PR DESCRIPTION
Removes GCP versioning check on buckets.
Adds to `externalVersioningErrorMessage` to cover GCP.
The `externalVersioningErrorMessage` is currently hard coded.