### PR TITLE
Fix GCP CopyObject Result Parse

### DIFF
--- a/lib/data/external/GCP/GcpApis/copyObject.js
+++ b/lib/data/external/GCP/GcpApis/copyObject.js
@@ -67,15 +67,21 @@ function copyObject(params, callback) {
             return callback(err);
         }
         const md5Hash = result.md5Hash ?
-            Buffer.from(result.md5Hash, 'base64').toString('hex') : null;
-        const resObj = {
-            CopyObjectResult: {
-                ETag: md5Hash,
-                LastModified: result.updated,
-            },
-            ContentLength: result.size,
-            VersionId: result.generation,
-        };
+            Buffer.from(result.md5Hash, 'base64').toString('hex') : undefined;
+        const resObj = { CopyObjectResult: {} };
+        if (md5Hash !== undefined) {
+            resObj.CopyObjectResult.ETag = md5Hash;
+        }
+        if (result.updated !== undefined) {
+            resObj.CopyObjectResult.LastModified = result.updated;
+        }
+        if (result.size !== undefined && !isNaN(result.size) &&
+        (typeof result.size === 'string' || typeof result.size === 'number')) {
+            resObj.ContentLength = parseInt(result.size, 10);
+        }
+        if (result.generation !== undefined) {
+            resObj.VersionId = result.generation;
+        }
         return callback(null, resObj);
     });
 }


### PR DESCRIPTION
Bug: copyObject result parses all elements as strings
Fix: parse result elements with correct type.