### PR TITLE
Fix: limit exported config items

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -11,10 +11,9 @@ const metadata = require('../metadata/wrapper');
 const REPORT_MODEL_VERSION = 1;
 
 function cleanup(obj) {
-    const ret = JSON.parse(JSON.stringify(obj));
-    delete ret.authData;
-    delete ret.reportToken;
-    return ret;
+    return {
+        overlayVersion: obj.overlayVersion,
+    };
 }
 
 function isAuthorized(clientIP, req) {

--- a/tests/functional/report/checkRoutes.js
+++ b/tests/functional/report/checkRoutes.js
@@ -85,6 +85,15 @@ describe('Report route', () => {
         });
     });
 
+    it('should remove unwanted sections from config', done => {
+        queryReport(done, response => {
+            if (response.config && response.config.mongodb) {
+                return done(new Error('config contains unwanted sections'));
+            }
+            return done();
+        });
+    });
+
     it('should remove report token from config', done => {
         queryReport(done, response => {
             if (response.config && response.config.reportToken) {


### PR DESCRIPTION
Only send `overlayVersion` for now to avoid sending unwanted items.