### PR TITLE
fx: add err

### DIFF
--- a/lib/data/external/GCP/GcpManagedUpload.js
+++ b/lib/data/external/GCP/GcpManagedUpload.js
@@ -341,7 +341,7 @@ class GcpManagedUpload {
                 this.multipartReq =
                     this.service.createMultipartUpload(params, (err, res) => {
                         if (err) {
-                            return this.cleanUp();
+                            return this.cleanUp(err);
                         }
                         this.uploadId = res.UploadId;
                         this.uploadChunk(chunk, partNumber);


### PR DESCRIPTION
the missing err argument will cause S3 to crash as the logger will attempt to read the `message` property from an `undefined`.
fix: passes err to be returned in callback

