### PR TITLE
Ft/zenko endpoints

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 # modifying config.json
 JQ_FILTERS_CONFIG="."
 
-# ENDPOINT var accepts comma separated values
+# ENDPOINT var can accept comma separated values
 # for multiple endpoint locations
 if [[ "$ENDPOINT" ]]; then
     IFS="," read -ra HOST_NAMES <<< "$ENDPOINT"
@@ -83,7 +83,7 @@ if [[ "$METADATA_HOST" ]]; then
 fi
 
 if [[ "$MONGODB_HOSTS" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.hosts=\"$MONGODB_HOSTS\""
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.replicaSetHosts=\"$MONGODB_HOSTS\""
 fi
 
 if [[ "$MONGODB_RS" ]]; then


### PR DESCRIPTION
Updates to the docker entry point script that allows csv style strings for multiple endpoint to be passed through. Still retains compatibility when only one endpoint is specified.

2nd commit fixes the mongodb hosts pass through since there was a name change from "hosts" to "replicaSetHosts"