### PR TITLE
Ft/zenko 20

### DIFF
--- a/lib/utilities/internalHandlers.js
+++ b/lib/utilities/internalHandlers.js
@@ -1,11 +1,13 @@
 const { healthcheckHandler } = require('./healthcheckHandler');
 const routeBackbeat = require('../routes/routeBackbeat');
 const { reportHandler } = require('./reportHandler');
+const { monitoringHandler } = require('./monitoringHandler');
 
 const internalHandlers = {
     healthcheck: healthcheckHandler,
     backbeat: routeBackbeat,
     report: reportHandler,
+    monitoring: monitoringHandler,
 };
 
 module.exports = {

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -19,7 +19,7 @@ function writeResponse(res, error, log, results, cb) {
 
 
 function routeHandler(req, res, log, cb) {
-    if (req.method !== 'GET' && req.method !== 'POST') {
+    if (req.method !== 'GET') {
         return cb(errors.BadRequest, []);
     }
     client.collectDefaultMetrics();

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -26,7 +26,7 @@ function routeHandler(req, res, log, cb) {
     const promMetrics = client.register.metrics();
     const contentLen = Buffer.byteLength(promMetrics, 'utf8');
     res.setHeader('content-length', contentLen);
-    res.setHeader('content-type', 'application/json');
+    res.setHeader('content-type', client.register.contentType);
     res.end(promMetrics);
     return undefined;
 }

--- a/lib/utilities/monitoringHandler.js
+++ b/lib/utilities/monitoringHandler.js
@@ -1,0 +1,65 @@
+const errors = require('arsenal');
+const client = require('prom-client');
+
+function writeResponse(res, error, log, results, cb) {
+    let statusCode = 200;
+    if (error) {
+        if (Number.isInteger(error.code)) {
+            statusCode = error.code;
+        } else {
+            statusCode = 500;
+        }
+    }
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+    res.write(JSON.stringify(results));
+    res.end(() => {
+        cb(error, results);
+    });
+}
+
+
+function routeHandler(req, res, log, cb) {
+    if (req.method !== 'GET' && req.method !== 'POST') {
+        return cb(errors.BadRequest, []);
+    }
+    client.collectDefaultMetrics();
+    const promMetrics = client.register.metrics();
+    const contentLen = Buffer.byteLength(promMetrics, 'utf8');
+    res.setHeader('content-length', contentLen);
+    res.setHeader('content-type', 'application/json');
+    res.end(promMetrics);
+    return undefined;
+}
+
+/**
+ * Checks if client IP address is allowed to make http request to
+ * S3 server. Defines function 'montiroingEndHandler', which is
+ * called if IP not allowed or passed as callback.
+ * @param {object} clientIP - IP address of client
+ * @param {object} req - http request object
+ * @param {object} res - http response object
+ * @param {object} log - werelogs logger instance
+ * @return {undefined}
+ */
+function monitoringHandler(clientIP, req, res, log) {
+    function monitoringEndHandler(err, results) {
+        writeResponse(res, err, log, results, error => {
+            if (error) {
+                return log.end().warn('monitoring error', { err: error });
+            }
+            return log.end();
+        });
+    }
+    if (req.method !== 'GET') {
+        return monitoringEndHandler(res, errors.MethodNotAllowed);
+    }
+    const monitoring = (req.url === '/_/monitoring/metrics');
+    if (!monitoring) {
+        return monitoringEndHandler(res, errors.MethodNotAllowed);
+    }
+    return routeHandler(req, res, log, monitoringEndHandler);
+}
+
+module.exports = {
+    monitoringHandler,
+};

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "uuid": "^3.0.1",
     "vaultclient": "scality/vaultclient",
     "werelogs": "scality/werelogs",
-    "xml2js": "~0.4.16"
+    "xml2js": "~0.4.16",
+    "prom-client": "^10.2.3"
   },
   "devDependencies": {
     "bluebird": "^3.3.1",


### PR DESCRIPTION
## Prom Client Integration into S3

###  This pull request is for Zenko. A Prometheus server will pull metrics from S3 at the route: '/_/monitoring/metrics'. I created a new route handler for the same.

This change is required as all the components in Zenko are monitored by Prometheus. We need S3 too.