### PR TITLE
FIX: Do not include untrimmed headers

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -219,14 +219,13 @@ class AwsClient {
                 metaHeadersTrimmed[headerKey] = metaHeaders[header];
             }
         });
-        Object.assign(metaHeaders, metaHeadersTrimmed);
         const awsBucket = this._awsBucketName;
         const awsKey = this._createAwsKey(bucketName, key, this._bucketMatch);
         const params = {
             Bucket: awsBucket,
             Key: awsKey,
             WebsiteRedirectLocation: websiteRedirectHeader,
-            Metadata: metaHeaders,
+            Metadata: metaHeadersTrimmed,
             ContentType: contentType,
             CacheControl: cacheControl,
             ContentDisposition: contentDisposition,

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -424,8 +424,8 @@ function initiateMultipartUpload(request, response, log, callback) {
     const contentDisposition = request.headers['x-scal-content-disposition'];
     const contentEncoding = request.headers['x-scal-content-encoding'];
     const metaHeaders = {
-        'scal-replication-status': 'REPLICA',
-        'scal-version-id': sourceVersionId,
+        'x-amz-meta-scal-replication-status': 'REPLICA',
+        'x-amz-meta-scal-version-id': sourceVersionId,
     };
     if (userMetadata !== undefined) {
         try {

--- a/tests/multipleBackend/multipartUpload.js
+++ b/tests/multipleBackend/multipartUpload.js
@@ -41,7 +41,7 @@ const bucketName = 'bucketname';
 const awsBucket = config.locationConstraints[awsLocation].details.bucketName;
 const smallBody = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
-const locMetaHeader = 'x-amz-meta-scal-location-constraint';
+const locMetaHeader = 'scal-location-constraint';
 const bucketPutRequest = {
     bucketName,
     namespace,
@@ -222,7 +222,8 @@ function assertObjOnBackend(expectedBackend, objectKey, cb) {
     return objectGet(authInfo, getObjectGetRequest(zenkoObjectKey), false, log,
     (err, result, metaHeaders) => {
         assert.equal(err, null, `Error getting object on S3: ${err}`);
-        assert.strictEqual(metaHeaders[locMetaHeader], expectedBackend);
+        assert.strictEqual(metaHeaders[`x-amz-meta-${locMetaHeader}`],
+            expectedBackend);
         if (expectedBackend === awsLocation) {
             return s3.headObject({ Bucket: awsBucket, Key: objectKey },
             (err, result) => {


### PR DESCRIPTION
When putting an MPU object using an AWS location constraint, any user metadata is included twice.

Example response from a headObject request:

```
{
    "AcceptRanges": "bytes",
    "ContentType": "application/octet-stream",
    "LastModified": "Tue, 20 Mar 2018 22:11:39 GMT",
    "ContentLength": 10485762,
    "VersionId": "rbu8wlrAt7Jd_HUV9VctoSp3mIjQtg4M",
    "ETag": "\"794898c411e565027c2c3ba534b00e2d-2\"",
    "Metadata": {
        "x-amz-meta-customkey": "customValue",
        "customkey": "customValue"
    }
}
```