### PR TITLE
transient source

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -164,6 +164,10 @@ function locationConstraintAssert(locationConstraints) {
             === 'boolean',
             'bad config: locationConstraints[region]' +
             '.legacyAwsBehavior is mandatory and must be a boolean');
+        assert(['undefined', 'boolean'].includes(
+            typeof locationConstraints[l].isTransient),
+               'bad config: locationConstraints[region]' +
+               '.isTransient must be a boolean');
         const details = locationConstraints[l].details;
         assert(typeof details === 'object',
             'bad config: locationConstraints[region].details is ' +
@@ -384,6 +388,12 @@ class Config extends EventEmitter {
                     'must be a string');
                 assert.notStrictEqual(site, '', 'bad config: `site` property ' +
                     "of object in `replicationEndpoints` must not be ''");
+                if (replicationEndpoint.default !== undefined) {
+                    assert.strictEqual(typeof replicationEndpoint.default,
+                        'boolean',
+                        'bad config: `default` property of object in ' +
+                        '`replicationEndpoints` must be a boolean');
+                }
                 if (type !== undefined) {
                     assert(externalBackends[type], 'bad config: `type` ' +
                         'property of `replicationEndpoints` object must be ' +
@@ -404,6 +414,15 @@ class Config extends EventEmitter {
                     });
                 }
             });
+            const defaultEndpoint = replicationEndpoints.find(
+                endpoint => endpoint.default);
+            if (Object.keys(this.locationConstraints)
+                .map(k => this.locationConstraints[k])
+                .some(location => location.isTransient)) {
+                assert(defaultEndpoint.type, 'bad config: ' +
+                    'default replication endpoint must be external when ' +
+                    'a transient source is configured');
+            }
             this.replicationEndpoints = replicationEndpoints;
         }
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -414,8 +414,11 @@ class Config extends EventEmitter {
                     });
                 }
             });
-            const defaultEndpoint = replicationEndpoints.find(
+            let defaultEndpoint = replicationEndpoints.find(
                 endpoint => endpoint.default);
+            if (!defaultEndpoint) {
+                defaultEndpoint = replicationEndpoints[0];
+            }
             if (Object.keys(this.locationConstraints)
                 .map(k => this.locationConstraints[k])
                 .some(location => location.isTransient)) {
@@ -958,6 +961,11 @@ class Config extends EventEmitter {
     getLocationConstraintType(locationConstraint) {
         const dataStoreName = this.locationConstraints[locationConstraint];
         return dataStoreName && dataStoreName.type;
+    }
+
+    locationConstraintIsTransient(locationConstraint) {
+        const lc = this.locationConstraints[locationConstraint];
+        return lc && Boolean(lc.isTransient);
     }
 
     setRestEndpoints(restEndpoints) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -164,17 +164,15 @@ function locationConstraintAssert(locationConstraints) {
             === 'boolean',
             'bad config: locationConstraints[region]' +
             '.legacyAwsBehavior is mandatory and must be a boolean');
-        if (locationConstraints[l].details.serverSideEncryption !== undefined) {
-            assert(typeof locationConstraints[l].details.serverSideEncryption
-              === 'boolean',
+        const details = locationConstraints[l].details;
+        assert(typeof details === 'object',
+            'bad config: locationConstraints[region].details is ' +
+            'mandatory and must be an object');
+        if (details.serverSideEncryption !== undefined) {
+            assert(typeof details.serverSideEncryption === 'boolean',
               'bad config: locationConstraints[region]' +
               '.details.serverSideEncryption must be a boolean');
         }
-        assert(typeof locationConstraints[l].details
-            === 'object',
-            'bad config: locationConstraints[region].details is ' +
-            'mandatory and must be an object');
-        const details = locationConstraints[l].details;
         const stringFields = [
             'awsEndpoint',
             'bucketName',

--- a/lib/api/apiUtils/object/createAndStoreObject.js
+++ b/lib/api/apiUtils/object/createAndStoreObject.js
@@ -143,6 +143,19 @@ function createAndStoreObject(bucketName, bucketMD, objectKey, objMD, authInfo,
         config.getLocationConstraintType(location);
     metadataStoreParams.dataStoreName = location;
 
+    // create non-transient location field as 'PENDING:preferred_site'
+    // when the location is transient and CRR is enabled, it will be
+    // set by the CRR processor of preferred CRR target to the actual
+    // preferred location.
+    if (config.locationConstraintIsTransient(location)
+        && metadataStoreParams.replicationInfo
+        && metadataStoreParams.replicationInfo.status === 'PENDING') {
+        const defaultCloudReplicationEndpoint =
+                  config.replicationEndpoints.find(
+                      endpoint => endpoint.default);
+        metadataStoreParams.nonTransientLocation =
+            `PENDING:${defaultCloudReplicationEndpoint.site}`;
+    }
     if (versioningNotImplBackends[locationType]) {
         const vcfg = bucketMD.getVersioningConfiguration();
         const isVersionedObj = vcfg && vcfg.Status === 'Enabled';

--- a/lib/api/completeMultipartUpload.js
+++ b/lib/api/completeMultipartUpload.js
@@ -267,7 +267,7 @@ function completeMultipartUpload(authInfo, request, log, callback) {
             metadataKeysToPull.forEach(item => {
                 metaHeaders[item] = storedMetadata[item];
             });
-
+            const location = storedMetadata.controllingLocationConstraint;
             const metaStoreParams = {
                 authInfo,
                 objectKey,
@@ -286,6 +286,20 @@ function completeMultipartUpload(authInfo, request, log, callback) {
                     false, calculatedSize, REPLICATION_ACTION),
                 log,
             };
+            // create non-transient location field as
+            // 'PENDING:preferred_site' when the location is transient
+            // and CRR is enabled, it will be set by the CRR processor
+            // of preferred CRR target to the actual preferred
+            // location.
+            if (config.locationConstraintIsTransient(location)
+                && metaStoreParams.replicationInfo
+                && metaStoreParams.replicationInfo.status === 'PENDING') {
+                const defaultCloudReplicationEndpoint =
+                          config.replicationEndpoints.find(
+                              endpoint => endpoint.default);
+                metaStoreParams.nonTransientLocation =
+                    `PENDING:${defaultCloudReplicationEndpoint.site}`;
+            }
             const serverSideEncryption =
                       destBucket.getServerSideEncryption();
             let pseudoCipherBundle = null;

--- a/lib/api/objectCopy.js
+++ b/lib/api/objectCopy.js
@@ -121,6 +121,9 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
     const locationMatch =
     sourceLocationConstraintName === destLocationConstraintName;
 
+    const destLocationIsTransient = config.locationConstraintIsTransient(
+        destLocationConstraintName);
+
     // If tagging directive is REPLACE but you don't specify any
     // tags in the request, the destination object will
     // not have any tags.
@@ -167,6 +170,19 @@ function _prepMetadata(request, sourceObjMD, headers, sourceIsDestination,
     // request headers, make sure to keep the original header instead
     if (!storeMetadataParams.contentType) {
         storeMetadataParams.contentType = sourceObjMD['content-type'];
+    }
+    // create non-transient location field as 'PENDING:preferred_site'
+    // when the location is transient and CRR is enabled, it will be
+    // set by the CRR processor of preferred CRR target to the actual
+    // preferred location.
+    if (destLocationIsTransient
+        && storeMetadataParams.replicationInfo
+        && storeMetadataParams.replicationInfo.status === 'PENDING') {
+        const defaultCloudReplicationEndpoint =
+                  config.replicationEndpoints.find(
+                      endpoint => endpoint.default);
+        storeMetadataParams.nonTransientLocation =
+            `PENDING:${defaultCloudReplicationEndpoint.site}`;
     }
     return { storeMetadataParams, sourceLocationConstraintName,
       backendInfoDest: backendInfoObjDest.backendInfo };

--- a/lib/routes/routeBackbeat.js
+++ b/lib/routes/routeBackbeat.js
@@ -5,6 +5,7 @@ const { auth, errors, s3middleware } = require('arsenal');
 const { responseJSONBody } = require('arsenal').s3routes.routesUtils;
 const { getSubPartIds } = s3middleware.azureHelper.mpuUtils;
 const vault = require('../auth/vault');
+const data = require('../data/wrapper');
 const metadata = require('../metadata/wrapper');
 const locationConstraintCheck = require(
     '../api/apiUtils/object/locationConstraintCheck');
@@ -12,11 +13,14 @@ const { dataStore } = require('../api/apiUtils/object/storeObject');
 const prepareRequestContexts = require(
 '../api/apiUtils/authorization/prepareRequestContexts');
 const { decodeVersionId } = require('../api/apiUtils/object/versioning');
+const { generateMpuPartStorageInfo } =
+    require('../api/apiUtils/object/processMpuParts');
 const { metadataValidateBucketAndObj,
     metadataGetObject } = require('../metadata/metadataUtils');
 const { BackendInfo } = require('../api/apiUtils/object/BackendInfo');
 const { config } = require('../Config');
 const multipleBackendGateway = require('../data/multipleBackendGateway');
+const { skipMpuPartProcessing } = require('../data/external/utils');
 const constants = require('../../constants');
 
 auth.setHandler(vault);
@@ -316,6 +320,14 @@ function putMetadata(request, response, bucketInfo, objMd, log, callback) {
                     });
                     return callback(err);
                 }
+                if (headers['x-scal-delete-old-location'] === 'true') {
+                    log.debug('trigger batch delete on locations', {
+                        objectKey: request.objectKey,
+                        locations: objMd.locations,
+                    });
+                    data.batchDelete(objMd.location, 'DELETE',
+                                     objMd.dataStoreName, log);
+                }
                 return _respond(response, md, log, callback);
             });
     });
@@ -374,6 +386,7 @@ function putObject(request, response, log, callback) {
                 return callback(errors.BadDigest);
             }
             const dataRetrievalInfo = {
+                Location: Object.assign({}, retrievalInfo),
                 // TODO: Remove '' when versioning implemented for Azure.
                 versionId: retrievalInfo.dataStoreVersionId || '',
             };
@@ -533,7 +546,7 @@ function completeMultipartUpload(request, response, log, callback) {
         };
         return multipleBackendGateway.completeMPU(request.objectKey, uploadId,
             storageLocation, partList, undefined, request.bucketName,
-            metaHeaders, contentSettings, log, (err, retrievalInfo) => {
+            metaHeaders, contentSettings, log, (err, completeObjData) => {
                 if (err) {
                     log.error('error completing MPU', {
                         error: err,
@@ -541,9 +554,43 @@ function completeMultipartUpload(request, response, log, callback) {
                     });
                     return callback(err);
                 }
+                // FIXME ideally all this code should be part of
+                // multipleBackendGateway implementation because it's
+                // duplicating what is done in
+                // completeMultipartUpload.js.
+
+                let dataLocation;
+                if (skipMpuPartProcessing(completeObjData)) {
+                    dataLocation = {
+                        key: completeObjData.key,
+                        size: completeObjData.contentLength,
+                        start: 0,
+                        dataStoreVersionId:
+                        completeObjData.dataStoreVersionId,
+                        dataStoreName: storageLocation,
+                        dataStoreETag: completeObjData.eTag,
+                        dataStoreType: completeObjData.dataStoreType,
+                    };
+                } else {
+                    const { filteredPartsObj } = completeObjData;
+                    const partsInfo =
+                        generateMpuPartStorageInfo(filteredPartsObj.partList);
+                    if (partsInfo.error) {
+                        return callback(partsInfo.error);
+                    }
+                    dataLocation = {
+                        key: completeObjData.key,
+                        size: partsInfo.calculatedSize,
+                        start: 0,
+                        dataStoreName: storageLocation,
+                        dataStoreETag: partsInfo.aggregateETag,
+                        dataStoreType: completeObjData.dataStoreType,
+                    };
+                }
                 const dataRetrievalInfo = {
+                    Location: dataLocation,
                     // TODO: Remove '' when versioning implemented for Azure.
-                    versionId: retrievalInfo.dataStoreVersionId || '',
+                    versionId: completeObjData.dataStoreVersionId || '',
                 };
                 return _respond(response, dataRetrievalInfo, log, callback);
             });

--- a/lib/services.js
+++ b/lib/services.js
@@ -95,7 +95,7 @@ const services = {
             contentType, cacheControl, contentDisposition, contentEncoding,
             expires, multipart, headers, overrideMetadata, log,
             lastModifiedDate, versioning, versionId, tagging, taggingCopy,
-            replicationInfo, dataStoreName } = params;
+            replicationInfo, dataStoreName, nonTransientLocation } = params;
         log.trace('storing object in metadata');
         assert.strictEqual(typeof bucketName, 'string');
         const md = new ObjectMD();
@@ -109,6 +109,7 @@ const services = {
             .setContentType(contentType)
             .setContentMd5(contentMD5)
             .setLocation(dataGetInfo)
+            .setNonTransientLocation(nonTransientLocation)
             // If an IAM user uploads a resource, the owner should be the parent
             // account. http://docs.aws.amazon.com/AmazonS3/
             // latest/dev/access-control-overview.html

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal",
+    "arsenal": "scality/Arsenal#ft/ZENKO-143-transient-source",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",


### PR DESCRIPTION
Linked to https://github.com/scality/backbeat/pull/228 and https://github.com/scality/Arsenal/pull/454

ft: set nonTransientLocation property in object metadata

Set the nonTransientLocation property to 'PENDING:preferred_site' in
object metadata (plain, mpu and copy), when the object location has
the 'isTransient' attribute set.

This will be used by CRR processors and status processor to know if
the object location has to be transitioned to the preferred CRR
target.

Return the Location attribute from backbeat route for backbeat to
write the proper non-transient location in the object metadata once
CRRed.
