### PR TITLE
bf: parse content length to int

### DIFF
--- a/lib/data/external/AwsClient.js
+++ b/lib/data/external/AwsClient.js
@@ -384,7 +384,8 @@ class AwsClient {
                 completeObjData.eTag = completeMpuRes.ETag
                     .substring(1, completeMpuRes.ETag.length - 1);
                 completeObjData.dataStoreVersionId = completeMpuRes.VersionId;
-                completeObjData.contentLength = objHeaders.ContentLength;
+                completeObjData.contentLength =
+                    Number.parseInt(objHeaders.ContentLength, 10);
                 return callback(null, completeObjData);
             });
         });

--- a/lib/data/external/GcpClient.js
+++ b/lib/data/external/GcpClient.js
@@ -172,7 +172,8 @@ class GcpClient extends AwsClient {
             // remove quotes from eTag because they're added later
             completeObjData.eTag = removeQuotes(completeMpuRes.ETag);
             completeObjData.dataStoreVersionId = completeMpuRes.VersionId;
-            completeObjData.contentLength = completeMpuRes.ContentLength;
+            completeObjData.contentLength =
+                Number.parseInt(completeMpuRes.ContentLength, 10);
             return callback(null, completeObjData);
         });
     }

--- a/tests/unit/DummyService.js
+++ b/tests/unit/DummyService.js
@@ -1,0 +1,23 @@
+const uuid = require('uuid/v4');
+
+class DummyService {
+    headObject(params, callback) {
+        const retObj = {
+            ContentLength: `${1024 * 1024 * 1024}`,
+        };
+        return callback(null, retObj);
+    }
+    completeMultipartUpload(params, callback) {
+        const retObj = {
+            Bucket: params.Bucket,
+            Key: params.Key,
+            VersionId: uuid().replace(/-/g, ''),
+            ETag: `"${uuid().replace(/-/g, '')}"`,
+            ContentLength: `${1024 * 1024 * 1024}`,
+        };
+        return callback(null, retObj);
+    }
+    // To-Do: add tests for other methods
+}
+
+module.exports = DummyService;

--- a/tests/unit/multipleBackend/ExternalBackendClient.js
+++ b/tests/unit/multipleBackend/ExternalBackendClient.js
@@ -1,0 +1,74 @@
+const assert = require('assert');
+const AwsClient = require('../../../lib/data/external/AwsClient');
+const GcpClient = require('../../../lib/data/external/GcpClient');
+const DummyService = require('../DummyService');
+const { DummyRequestLogger } = require('../helpers');
+
+const backendClients = [
+    {
+        Class: AwsClient,
+        name: 'AwsClient',
+        config: {
+            s3Params: {},
+            bucketName: 'awsTestBucketName',
+            dataStoreName: 'awsDataStore',
+            serverSideEncryption: false,
+            type: 'aws',
+        },
+    },
+    {
+        Class: GcpClient,
+        name: 'GcpClient',
+        config: {
+            s3Params: {},
+            bucketName: 'gcpTestBucketName',
+            mpuBucket: 'gcpTestMpuBucketName',
+            dataStoreName: 'gcpDataStore',
+            type: 'gcp',
+        },
+    },
+];
+
+backendClients.forEach(backend => {
+    let testClient;
+
+    before(() => {
+        testClient = new backend.Class(backend.config);
+        testClient._client = new DummyService(backend.config);
+    });
+
+    describe(`${backend.name} completeMPU:`, () => {
+        it('should return correctly typed mpu results', done => {
+            const jsonList = {
+                Part: [
+                    {
+                        PartNumber: [1],
+                        ETag: ['testpart0001etag'],
+                    },
+                    {
+                        PartNumber: [2],
+                        ETag: ['testpart0002etag'],
+                    },
+                    {
+                        PartNumber: [3],
+                        ETag: ['testpart0003etag'],
+                    },
+                ],
+            };
+            const key = 'externalBackendTestKey';
+            const bucketName = 'externalBackendTestBucket';
+            const uploadId = 'externalBackendTestUploadId';
+            const log = new DummyRequestLogger();
+
+            testClient.completeMPU(jsonList, null, key, uploadId, bucketName,
+            log, (err, res) => {
+                assert.strictEqual(typeof res.key, 'string');
+                assert.strictEqual(typeof res.eTag, 'string');
+                assert.strictEqual(typeof res.dataStoreVersionId, 'string');
+                assert.strictEqual(typeof res.contentLength, 'number');
+                return done();
+            });
+        });
+    });
+    // To-Do: test the other external client methods
+});


### PR DESCRIPTION
externally handled MPU will return ContentLength as string, and this is failing the utapi push metrics assertion, in which requires ContentLength must be an integer