### PR TITLE
Fix mongo tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,6 +29,8 @@ machine:
 
 dependencies:
   override:
+    - docker run -d -p 27018:27018 -p 27019:27018 -p 27020:27018
+      --name ci-mongo scality/ci-mongo:3.4
     - rm -rf node_modules
     - yarn install --pure-lockfile
   post:

--- a/config.json
+++ b/config.json
@@ -81,7 +81,7 @@
         "recordLogName": "s3-recordlog"
     },
     "mongodb": {
-       "replicaSetHosts": "localhost:27017,localhost:27018,localhost:27019",
+       "replicaSetHosts": "localhost:27018,localhost:27019,localhost:27020",
        "writeConcern": "majority",
        "replicaSet": "rs0",
        "readPreference": "primary",

--- a/tests.bash
+++ b/tests.bash
@@ -134,11 +134,25 @@ then
 
   killandsleep 8000
 
-  docker pull mongo:3.6.2
-  mkdir /tmp/mongodb
-  docker run -d -p 27018:27017 -v /tmp/mongodb:/data/db mongo:3.6.2
-  bash wait_for_local_port.bash 27018 40
-  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_awssdk.txt & bash wait_for_local_port.bash 8000 40 && S3DATA=file npm run ft_test
+  # Run with mongdb backend ; run ft_tests 
+
+  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_awssdk.txt & bash wait_for_local_port.bash 8000 40 && S3DATA=file npm run ft_awssdk
+
+  killandsleep 8000
+
+  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_s3cmd.txt & bash wait_for_local_port.bash 8000 40 && S3DATA=file npm run ft_s3cmd
+
+  killandsleep 8000
+ 
+  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_s3curl.txt & bash wait_for_local_port.bash 8000 40 && S3DATA=file npm run ft_s3curl
+
+  killandsleep 8000
+
+  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_healthchecks.txt & bash wait_for_local_port.bash 8000 40 && S3DATA=file npm run ft_healthchecks
+
+  killandsleep 8000
+
+  S3BACKEND=mem MPU_TESTING=yes S3METADATA=mongodb npm start > $CIRCLE_ARTIFACTS/server_mongodb_management.txt & bash wait_for_local_port.bash 8000 40 && npm run ft_management
 
   killandsleep 8000
 
@@ -197,4 +211,4 @@ then
 
 fi
 
-exit 0
+exit $?


### PR DESCRIPTION
Fixes the problem where the functional tests with mongo would not run correctly causing CircleCi to falsely pass. 

Uploaded a new ci-mongo docker image based off Federation and that self initializes to a single node replica set for compatibility.