### PR TITLE
FX: HTTP requests to AWS

### DIFF
--- a/lib/management.js
+++ b/lib/management.js
@@ -128,6 +128,7 @@ function patchConfiguration(instanceId, newConf, log, cb) {
                                 Boolean(l.details.serverSideEncryption),
                             awsEndpoint: l.details.endpoint ||
                                 's3.amazonaws.com',
+                            https: true,
                         };
                     }
                     break;
@@ -145,6 +146,7 @@ function patchConfiguration(instanceId, newConf, log, cb) {
                             bucketMatch: l.details.bucketMatch,
                             gcpEndpoint: l.details.endpoint ||
                                 'storage.googleapis.com',
+                            https: true,
                         };
                     }
                     break;


### PR DESCRIPTION
Error: `NetworkingError: Protocol "http:" not supported. Expected "https:"`