### PR TITLE
FIX: WebsiteRedirectLocation header response

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -15,8 +15,7 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
   returnTagCount) {
     // Add user meta headers from objectMD
     const responseMetaHeaders = Object.assign({}, corsHeaders);
-    Object.keys(objectMD).filter(val => (val.substr(0, 11) === 'x-amz-meta-' ||
-        val === 'x-amz-website-redirect-location'))
+    Object.keys(objectMD).filter(val => (val.substr(0, 11) === 'x-amz-meta-'))
         .forEach(id => { responseMetaHeaders[id] = objectMD[id]; });
 
     // TODO: When implement lifecycle, add additional response headers
@@ -25,6 +24,10 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
     responseMetaHeaders['x-amz-version-id'] =
         getVersionIdResHeader(versioningCfg, objectMD);
 
+    if (objectMD['x-amz-website-redirect-location']) {
+        responseMetaHeaders['x-amz-website-redirect-location'] =
+        objectMD['x-amz-website-redirect-location'];
+    }
     if (objectMD['x-amz-storage-class'] !== 'STANDARD') {
         responseMetaHeaders['x-amz-storage-class'] =
             objectMD['x-amz-storage-class'];

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -299,24 +299,54 @@ describe('GET object', () => {
         });
 
         describe('x-amz-website-redirect-location header', () => {
-            before(done => {
+            it('should return website redirect header if specified in ' +
+                'objectPUT request', done => {
                 const params = {
                     Bucket: bucketName,
                     Key: objectName,
                     WebsiteRedirectLocation: '/',
                 };
-                s3.putObject(params, err => done(err));
+                s3.putObject(params, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    return s3.getObject({
+                        Bucket: bucketName,
+                        Key: objectName,
+                    },
+                    (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.strictEqual(res.WebsiteRedirectLocation, '/');
+                        return done();
+                    });
+                });
             });
-            it('should return website redirect header if specified in ' +
+
+            it('should not return website redirect header if omitted in ' +
                 'objectPUT request', done => {
-                s3.getObject({ Bucket: bucketName, Key: objectName },
-                  (err, res) => {
-                      if (err) {
-                          return done(err);
-                      }
-                      assert.strictEqual(res.WebsiteRedirectLocation, '/');
-                      return done();
-                  });
+                const params = {
+                    Bucket: bucketName,
+                    Key: objectName,
+                };
+                return s3.putObject(params, err => {
+                    if (err) {
+                        return done(err);
+                    }
+                    return s3.getObject({
+                        Bucket: bucketName,
+                        Key: objectName,
+                    },
+                    (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+                        assert.strictEqual(res.WebsiteRedirectLocation,
+                            undefined);
+                        return done();
+                    });
+                });
             });
         });
 

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -299,6 +299,11 @@ describe('GET object', () => {
         });
 
         describe('x-amz-website-redirect-location header', () => {
+            afterEach(done => s3.deleteObject({
+                Bucket: bucketName,
+                Key: objectName,
+            }, done));
+
             it('should return website redirect header if specified in ' +
                 'objectPUT request', done => {
                 const params = {

--- a/tests/functional/aws-node-sdk/test/object/objectHead.js
+++ b/tests/functional/aws-node-sdk/test/object/objectHead.js
@@ -409,5 +409,36 @@ describe('HEAD object, conditions', () => {
                 done();
             });
         });
+
+        it('WebsiteRedirectLocation is set & it appears in response', done => {
+            const redirBktwBody = {
+                Bucket: bucketName,
+                Key: 'redir_present',
+                WebsiteRedirectLocation: 'http://google.com',
+                Body: 'hello',
+            };
+            const redirBkt = {
+                Bucket: bucketName,
+                Key: 'redir_present',
+            };
+            s3.putObject(redirBktwBody, err => {
+                checkNoError(err);
+                s3.headObject(redirBkt, (err, data) => {
+                    checkNoError(err);
+                    assert.strictEqual(data.WebsiteRedirectLocation,
+                            'http://google.com');
+                    return done();
+                });
+            });
+        });
+
+        it('WebsiteRedirectLocation is not set & is absent', done => {
+            requestHead({}, (err, data) => {
+                checkNoError(err);
+                assert.strictEqual('WebsiteRedirectLocation' in data,
+                  false, 'WebsiteRedirectLocation header is present.');
+                done();
+            });
+        });
     });
 });

--- a/tests/unit/utils/collectResponseHeaders.js
+++ b/tests/unit/utils/collectResponseHeaders.js
@@ -19,4 +19,19 @@ describe('Middleware: Collect Response Headers', () => {
                 undefined);
         });
     });
+
+    it('should return an undefined value when x-amz-website-redirect-location' +
+       ' is empty', () => {
+        const objectMD = { 'x-amz-website-redirect-location': '' };
+        const headers = collectResponseHeaders(objectMD);
+        assert.strictEqual(headers['x-amz-website-redirect-location'],
+          undefined);
+    });
+
+    it('should return the (nonempty) value of WebsiteRedirectLocation', () => {
+        const obj = { 'x-amz-website-redirect-location': 'google.com' };
+        const headers = collectResponseHeaders(obj);
+        assert.strictEqual(headers['x-amz-website-redirect-location'],
+            'google.com');
+    });
 });


### PR DESCRIPTION
Compatibility fix with AWS S3. The WebsiteRedirectLocation will not be included in the get object or head responses if it was not set on the object.

AWS S3 output:
```json
{
    "AcceptRanges": "bytes",
    "ContentType": "binary/octet-stream",
    "LastModified": "Tue, 10 Apr 2018 05:42:07 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "Metadata": {}
}
```

Cloudserver previous output:
```json
{
    "LastModified": "Tue, 10 Apr 2018 05:46:03 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "WebsiteRedirectLocation": "",
    "Metadata": {}
}
```