### PR TITLE
FIX: Add Accept-Ranges header to response

### DIFF
--- a/lib/utilities/collectResponseHeaders.js
+++ b/lib/utilities/collectResponseHeaders.js
@@ -38,6 +38,9 @@ function collectResponseHeaders(objectMD, corsHeaders, versioningCfg,
         responseMetaHeaders['x-amz-server-side-encryption-aws-kms-key-id']
             = objectMD['x-amz-server-side-encryption-aws-kms-key-id'];
     }
+
+    responseMetaHeaders['Accept-Ranges'] = 'bytes';
+
     if (objectMD['cache-control']) {
         responseMetaHeaders['Cache-Control'] = objectMD['cache-control'];
     }

--- a/tests/functional/aws-node-sdk/test/object/get.js
+++ b/tests/functional/aws-node-sdk/test/object/get.js
@@ -224,7 +224,7 @@ describe('GET object', () => {
             });
 
         describe('Additional headers: [Cache-Control, Content-Disposition, ' +
-            'Content-Encoding, Expires]', () => {
+            'Content-Encoding, Expires, Accept-Ranges]', () => {
             describe('if specified in put object request', () => {
                 before(done => {
                     const params = {
@@ -255,6 +255,7 @@ describe('GET object', () => {
                           assert.strictEqual(res.ContentType, contentType);
                           assert.strictEqual(res.Expires,
                               new Date(expires).toGMTString());
+                          assert.strictEqual(res.AcceptRanges, 'bytes');
                           return done();
                       });
                 });

--- a/tests/unit/utils/collectResponseHeaders.js
+++ b/tests/unit/utils/collectResponseHeaders.js
@@ -19,4 +19,9 @@ describe('Middleware: Collect Response Headers', () => {
                 undefined);
         });
     });
+
+    it('should add the Accept-Ranges header', () => {
+        const headers = collectResponseHeaders({});
+        assert.strictEqual(headers['Accept-Ranges'], 'bytes');
+    });
 });


### PR DESCRIPTION
Compatibility fix for AWS S3.

AWS returns a `Accept-Ranges: bytes` header with a GET or HEAD request for an object.

 ```
{
    "AcceptRanges": "bytes",
    "ContentType": "binary/octet-stream",
    "LastModified": "Tue, 10 Apr 2018 05:42:07 GMT",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "Metadata": {}
}
```
Cloudserver was missing this header, which can cause programs relying upon the `Range` header to be unable to detect support.

See #1134 
