### PR TITLE
S3C-1412: start s3 unconditionally

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -159,20 +159,20 @@ class S3Server {
     initiateStartup(log) {
         clientCheck(true, log, (err, results) => {
             if (err) {
-                log.info('initial health check failed, delaying startup', {
+                log.error('initial health check failed', {
                     error: err,
                     healthStatus: results,
                 });
-                setTimeout(() => this.initiateStartup(log), 2000);
             } else {
                 log.debug('initial health check succeeded');
-                if (_config.listenOn.length > 0) {
-                    _config.listenOn.forEach(item => {
-                        this.startup(item.port, item.ip);
-                    });
-                } else {
-                    this.startup(_config.port);
-                }
+            }
+
+            if (_config.listenOn.length > 0) {
+                _config.listenOn.forEach(item => {
+                    this.startup(item.port, item.ip);
+                });
+            } else {
+                this.startup(_config.port);
             }
         });
     }


### PR DESCRIPTION
# Pull request

## Description

This PR makes S3 finish its initialization even if a sub-component fails.

### Motivation and context

Since 7.4.0, bucketd returns a 500 error to healthcheck requests as soon as a raft session doesn't have a leader. And this is a really helpful information we needed since a long time ago.

But it means that, even when 7 bucket raft sessions work properly, S3 won't start because its initial deep healthcheck prevents it to complete its startup.

This can lead to a total service interruption if the S3 connectors are rebooted/restarted when some, not all, buckets are unavailable.

## Checklist

### Add tests to cover the changes

No tests added.

### Code conforms with the [style guide](https://github.com/scality/Guidelines/blob/master/CONTRIBUTING.md#coding-style-guidelines)

