### PR TITLE
S3C-1412: Interpret healthCheck Status from Bucketd

### DIFF
--- a/lib/metadata/bucketclient/backend.js
+++ b/lib/metadata/bucketclient/backend.js
@@ -179,6 +179,9 @@ class BucketClientInterface {
                         body: reason,   // Provide analysis data
                     };
                     if (failure) {
+                        // Setting the `error` field is how the healthCheck
+                        // logic interprets it as an error. Don't forget it !
+                        respBody[implName].error = err;
                         respBody[implName].code = err.code; // original error
                     }
                     // error returned as null so async parallel doesn't return

--- a/lib/metadata/bucketclient/backend.js
+++ b/lib/metadata/bucketclient/backend.js
@@ -5,41 +5,6 @@ const BucketInfo = require('arsenal').models.BucketInfo;
 const logger = require('../../utilities/logger');
 const { config } = require('../../Config');
 
-function analyzeHealthFailure(log, callback) {
-    let doFail = false;
-    const reason = { msg: 'Map is available and failure ratio is acceptable' };
-
-    // The healthCheck exposed by Bucketd is a light one, we need
-    // to inspect all the RaftSession's statuses to make sense of
-    // it:
-    return this.client.getAllRafts(undefined, (error, payload) => {
-        let statuses = null;
-        try {
-            statuses = JSON.parse(payload);
-        } catch (e) {
-            doFail = true;
-            reason.msg = 'could not interpret status: invalid payload';
-            // Can't do anything anymore if we fail here. return.
-            return callback(doFail, reason);
-        }
-
-        const reducer = (acc, payload) => acc + !payload.connectedToLeader;
-        reason.ratio = statuses.reduce(reducer, 0) / statuses.length;
-        /* NOTE FIXME/TODO: acceptableRatio could be configured later on */
-        reason.acceptableRatio = 0.5;
-        /* If the RaftSession 0 (map) does not work, fail anyways */
-        if (!doFail && !statuses[0].connectedToLeader) {
-            doFail = true;
-            reason.msg = 'Bucket map unavailable';
-        }
-        if (!doFail && reason.ratio > reason.acceptableRatio) {
-            doFail = true;
-            reason.msg = 'Ratio of failing Raft Sessions is too high';
-        }
-        return callback(doFail, reason);
-    }, log);
-}
-
 class BucketClientInterface {
     constructor() {
         assert(config.bucketd.bootstrap.length > 0,
@@ -148,6 +113,43 @@ class BucketClientInterface {
         return null;
     }
 
+    _analyzeHealthFailure(log, callback) {
+        let doFail = false;
+        const reason = {
+            msg: 'Map is available and failure ratio is acceptable',
+        };
+
+        // The healthCheck exposed by Bucketd is a light one, we need
+        // to inspect all the RaftSession's statuses to make sense of
+        // it:
+        return this.client.getAllRafts(undefined, (error, payload) => {
+            let statuses = null;
+            try {
+                statuses = JSON.parse(payload);
+            } catch (e) {
+                doFail = true;
+                reason.msg = 'could not interpret status: invalid payload';
+                // Can't do anything anymore if we fail here. return.
+                return callback(doFail, reason);
+            }
+
+            const reducer = (acc, payload) => acc + !payload.connectedToLeader;
+            reason.ratio = statuses.reduce(reducer, 0) / statuses.length;
+            /* NOTE FIXME/TODO: acceptableRatio could be configured later on */
+            reason.acceptableRatio = 0.5;
+            /* If the RaftSession 0 (map) does not work, fail anyways */
+            if (!doFail && !statuses[0].connectedToLeader) {
+                doFail = true;
+                reason.msg = 'Bucket map unavailable';
+            }
+            if (!doFail && reason.ratio > reason.acceptableRatio) {
+                doFail = true;
+                reason.msg = 'Ratio of failing Raft Sessions is too high';
+            }
+            return callback(doFail, reason);
+        }, log);
+    }
+
     /*
      * Bucketd offers a behavior that diverges from other sub-components on the
      * healthCheck: If any of the pieces making up the bucket storage fail (ie:
@@ -166,7 +168,7 @@ class BucketClientInterface {
         return this.client.healthcheck(log, (err, result) => {
             const respBody = {};
             if (err) {
-                return analyzeHealthFailure(log, (failure, reason) => {
+                return this._analyzeHealthFailure(log, (failure, reason) => {
                     const message = reason.msg;
                     // Remove 'msg' from the reason payload.
                     // eslint-disable-next-line no-param-reassign

--- a/lib/metadata/bucketclient/backend.js
+++ b/lib/metadata/bucketclient/backend.js
@@ -5,6 +5,41 @@ const BucketInfo = require('arsenal').models.BucketInfo;
 const logger = require('../../utilities/logger');
 const { config } = require('../../Config');
 
+function analyzeHealthFailure(log, callback) {
+    let doFail = false;
+    const reason = { msg: 'Map is available and failure ratio is acceptable' };
+
+    // The healthCheck exposed by Bucketd is a light one, we need
+    // to inspect all the RaftSession's statuses to make sense of
+    // it:
+    return this.client.getAllRafts(undefined, (error, payload) => {
+        let statuses = null;
+        try {
+            statuses = JSON.parse(payload);
+        } catch (e) {
+            doFail = true;
+            reason.msg = 'could not interpret status: invalid payload';
+            // Can't do anything anymore if we fail here. return.
+            return callback(doFail, reason);
+        }
+
+        const reducer = (acc, payload) => acc + !payload.connectedToLeader;
+        reason.ratio = statuses.reduce(reducer, 0) / statuses.length;
+        /* NOTE FIXME/TODO: acceptableRatio could be configured later on */
+        reason.acceptableRatio = 0.5;
+        /* If the RaftSession 0 (map) does not work, fail anyways */
+        if (!doFail && !statuses[0].connectedToLeader) {
+            doFail = true;
+            reason.msg = 'Bucket map unavailable';
+        }
+        if (!doFail && reason.ratio > reason.acceptableRatio) {
+            doFail = true;
+            reason.msg = 'Ratio of failing Raft Sessions is too high';
+        }
+        return callback(doFail, reason);
+    }, log);
+}
+
 class BucketClientInterface {
     constructor() {
         assert(config.bucketd.bootstrap.length > 0,
@@ -113,17 +148,41 @@ class BucketClientInterface {
         return null;
     }
 
+    /*
+     * Bucketd offers a behavior that diverges from other sub-components on the
+     * healthCheck: If any of the pieces making up the bucket storage fail (ie:
+     * if any Raft Session is down), bucketd returns a 500 for the healthCheck.
+     *
+     * As seen in S3C-1412, this may become an issue for S3, whenever the
+     * system is only partly failing.
+     *
+     * This means that S3 needs to analyze the situation, and interpret this
+     * status depending on the analysis. S3 will then assess the situation as
+     * critical (and consider it a failure), or not (and consider it a success
+     * anyways, thus not diverging from the healthCheck behavior of other
+     * components).
+     */
     checkHealth(implName, log, cb) {
         return this.client.healthcheck(log, (err, result) => {
             const respBody = {};
             if (err) {
-                log.error(`error from ${implName}`, { error: err });
-                respBody[implName] = {
-                    error: err,
-                };
-                // error returned as null so async parallel doesn't return
-                // before all backends are checked
-                return cb(null, respBody);
+                return analyzeHealthFailure(log, (failure, reason) => {
+                    const message = reason.msg;
+                    // Remove 'msg' from the reason payload.
+                    // eslint-disable-next-line no-param-reassign
+                    reason.msg = undefined;
+                    respBody[implName] = {
+                        code: 200,
+                        message,        // Provide interpreted reason msg
+                        body: reason,   // Provide analysis data
+                    };
+                    if (failure) {
+                        respBody[implName].code = err.code; // original error
+                    }
+                    // error returned as null so async parallel doesn't return
+                    // before all backends are checked
+                    return cb(null, respBody);
+                }, log);
             }
             const parseResult = JSON.parse(result);
             respBody[implName] = {


### PR DESCRIPTION
## Description

As discussed in S3C-1412, it is necessary for S3 to interpret Bucketd health
status in order to provide more flexibility (relatively to the health check
mechanism) than failing due to a light partial unavailability of the platform.

This is done in the bucketclient backend's healthcheck method, in order to
comply with all the other backends.

Fixes S3C-1412


Note:
I still need to check whether tests exist for the modified piece of code (Doubtful given that it relies on an external service, which isn't supposed to be used in S3 unit/func testing), and update them if any is present.

