### PR TITLE
rf: use uuid instead of date

### DIFF
--- a/tests/functional/aws-node-sdk/test/multipleBackend/acl/aclAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/acl/aclAwsVersioning.js
@@ -11,10 +11,11 @@ const {
     getAndAssertResult,
     describeSkipIfNotMultiple,
     getOwnerInfo,
+    genUniqID,
 } = require('../utils');
 
 const someBody = 'testbody';
-const bucket = 'buckettestmultiplebackendaclsawsversioning';
+const bucket = `alcawsversioning${genUniqID()}`;
 
 class _AccessControlPolicy {
     constructor(params) {
@@ -176,7 +177,7 @@ function testSuite() {
 
         it('versioning not configured: should put/get acl successfully when ' +
         'versioning not configured', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             putObjectAndAcl(s3, key, someBody, testAcp, (err, versionId) => {
                 assert.strictEqual(versionId, undefined);
                 getObjectAndAssertAcl(s3, { bucket, key, body: someBody,
@@ -187,7 +188,7 @@ function testSuite() {
         it('versioning suspended then enabled: should put/get acl on null ' +
         'version successfully even when latest version is not null version',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [undefined],
                     err => next(err)),
@@ -202,7 +203,7 @@ function testSuite() {
 
         it('versioning enabled: should get correct acl using version IDs',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const acps = ['READ', 'FULL_CONTROL', 'READ_ACP', 'WRITE_ACP']
             .map(perm => {
                 const acp = new _AccessControlPolicy(ownerParams);
@@ -227,7 +228,7 @@ function testSuite() {
 
         it('versioning enabled: should get correct acl when getting ' +
         'without version ID', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const acps = ['READ', 'FULL_CONTROL', 'READ_ACP', 'WRITE_ACP']
             .map(perm => {
                 const acp = new _AccessControlPolicy(ownerParams);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/delete.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/delete.js
@@ -8,15 +8,16 @@ const {
     fileLocation,
     awsLocation,
     awsLocationMismatch,
+    genUniqID,
 } = require('../utils');
 
-const bucket = 'buckettestmultiplebackenddelete';
-const memObject = `memObject-${Date.now()}`;
-const fileObject = `fileObject-${Date.now()}`;
-const awsObject = `awsObject-${Date.now()}`;
-const emptyObject = `emptyObject-${Date.now()}`;
-const bigObject = `bigObject-${Date.now()}`;
-const mismatchObject = `mismatchOjbect-${Date.now()}`;
+const bucket = `deleteaws${genUniqID()}`;
+const memObject = `memObject-${genUniqID()}`;
+const fileObject = `fileObject-${genUniqID()}`;
+const awsObject = `awsObject-${genUniqID()}`;
+const emptyObject = `emptyObject-${genUniqID()}`;
+const bigObject = `bigObject-${genUniqID()}`;
+const mismatchObject = `mismatchOjbect-${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteAwsVersioning.js
@@ -19,10 +19,11 @@ const {
     getAndAssertResult,
     awsGetLatestVerId,
     getAwsRetry,
+    genUniqID,
 } = require('../utils');
 
 const someBody = 'testbody';
-const bucket = 'buckettestmultiplebackenddeleteversioning';
+const bucket = `deleteawsversioning${genUniqID()}`;
 
 // order of items by index:
 // 0 - whether to expect a version id
@@ -142,7 +143,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning not configured: if specifying "null" version, should ' +
         'delete specific version in AWS backend', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putToAwsBackend(s3, bucket, key, someBody,
                     err => next(err)),
@@ -157,7 +158,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning not configured: specifying any version id other ' +
         'than null should not result in its deletion in AWS backend', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putToAwsBackend(s3, bucket, key, someBody,
                     err => next(err)),
@@ -175,7 +176,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning suspended: should delete a specific version in AWS ' +
         'backend successfully', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [someBody],
                     err => next(err)),
@@ -190,7 +191,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning enabled: should delete a specific version in AWS ' +
         'backend successfully', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     (err, versionIds) => next(err, versionIds[0])),
@@ -207,7 +208,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
         it('versioning not configured: deleting existing object should ' +
         'not return version id or x-amz-delete-marker: true but should ' +
         'create a delete marker in aws ', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putToAwsBackend(s3, bucket, key, someBody,
                     err => next(err)),
@@ -222,7 +223,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning suspended: should create a delete marker in s3 ' +
         'and aws successfully when deleting existing object', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [someBody],
                     err => next(err)),
@@ -242,7 +243,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
         'existing null version that is the latest version in s3 metadata,' +
         ' but the data of the first null version will remain in AWS',
         function itF(done) {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [someBody],
                     err => next(err)),
@@ -277,7 +278,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
         'existing null version that is not the latest version in s3 metadata,' +
         ' but the data of the first null version will remain in AWS',
         function itF(done) {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [undefined, 'data1'];
             async.waterfall([
                 // put null version
@@ -326,7 +327,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning enabled: should create a delete marker in s3 and ' +
         'aws successfully when deleting existing object', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     err => next(err)),
@@ -341,7 +342,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning enabled: should delete a delete marker in s3 and ' +
         'aws successfully', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     (err, versionIds) => next(err, versionIds[0])),
@@ -363,7 +364,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('multiple delete markers: should be able to get pre-existing ' +
         'versions after creating and deleting several delete markers', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     (err, versionIds) => next(err, versionIds[0])),
@@ -381,7 +382,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('multiple delete markers: should get NoSuchObject if only ' +
         'one of the delete markers is deleted', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     err => next(err)),
@@ -399,7 +400,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('should get the new latest version after deleting the latest' +
         'specific version', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [...Array(4).keys()].map(i => i.toString());
             async.waterfall([
                 // put 3 null versions
@@ -432,7 +433,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('should delete the correct version even if other versions or ' +
         'delete markers put directly on aws', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     (err, versionIds) => next(err, versionIds[0])),
@@ -457,7 +458,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('should not return an error deleting a version that was already ' +
         'deleted directly from AWS backend', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putVersionsToAws(s3, bucket, key, [someBody],
                     (err, versionIds) => next(err, versionIds[0])),
@@ -517,7 +518,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
         it('versioning not configured: deleting non-existing object should ' +
         'not return version id or x-amz-delete-marker: true nor create a ' +
         'delete marker in aws ', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => delAndAssertResult(s3, { bucket, key,
                     resultType: nonVersionedDelete }, err => next(err)),
@@ -530,7 +531,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning suspended: should create a delete marker in s3 ' +
         'and aws successfully when deleting non-existing object', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => suspendVersioning(s3, bucket, next),
                 next => delAndAssertResult(s3, { bucket, key, resultType:
@@ -544,7 +545,7 @@ describeSkipIfNotMultiple('AWS backend delete object w. versioning: ' +
 
         it('versioning enabled: should create a delete marker in s3 and ' +
         'aws successfully when deleting non-existing object', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => delAndAssertResult(s3, { bucket, key, resultType:

--- a/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/delete/deleteGcp.js
@@ -6,13 +6,14 @@ const {
     describeSkipIfNotMultiple,
     gcpLocation,
     gcpLocationMismatch,
+    genUniqID,
 } = require('../utils');
 
-const bucket = 'buckettestmultiplebackenddelete-gcp';
-const gcpObject = `gcpObject-${Date.now()}`;
-const emptyObject = `emptyObject-${Date.now()}`;
-const bigObject = `bigObject-${Date.now()}`;
-const mismatchObject = `mismatchObject-${Date.now()}`;
+const bucket = `deletegcp${genUniqID()}`;
+const gcpObject = `gcpObject-${genUniqID()}`;
+const emptyObject = `emptyObject-${genUniqID()}`;
+const bigObject = `bigObject-${genUniqID()}`;
+const mismatchObject = `mismatchObject-${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/get.js
@@ -8,16 +8,17 @@ const {
     fileLocation,
     awsLocation,
     awsLocationMismatch,
+    genUniqID,
 } = require('../utils');
 
-const bucket = 'buckettestmultiplebackendget';
-const memObject = `memobject-${Date.now()}`;
-const fileObject = `fileobject-${Date.now()}`;
-const awsObject = `awsobject-${Date.now()}`;
-const emptyObject = `emptyObject-${Date.now()}`;
-const emptyAwsObject = `emptyObject-${Date.now()}`;
-const bigObject = `bigObject-${Date.now()}`;
-const mismatchObject = `mismatch-${Date.now()}`;
+const bucket = `getaws${genUniqID()}`;
+const memObject = `memobject-${genUniqID()}`;
+const fileObject = `fileobject-${genUniqID()}`;
+const awsObject = `awsobject-${genUniqID()}`;
+const emptyObject = `emptyObject-${genUniqID()}`;
+const emptyAwsObject = `emptyObject-${genUniqID()}`;
+const bigObject = `bigObject-${genUniqID()}`;
+const mismatchObject = `mismatch-${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const bigBodyLen = bigBody.length;
@@ -77,7 +78,7 @@ describe('Multiple backend get object', function testSuite() {
         describeSkipIfNotMultiple('Complete MPU then get object on AWS ' +
         'location with bucketMatch: true ', () => {
             beforeEach(function beforeEachFn(done) {
-                this.currentTest.key = `somekey-${Date.now()}`;
+                this.currentTest.key = `somekey-${genUniqID()}`;
                 bucketUtil = new BucketUtility('default', sigCfg);
                 s3 = bucketUtil.s3;
 
@@ -128,7 +129,7 @@ describe('Multiple backend get object', function testSuite() {
         describeSkipIfNotMultiple('Complete MPU then get object on AWS ' +
         'location with bucketMatch: false ', () => {
             beforeEach(function beforeEachFn(done) {
-                this.currentTest.key = `somekey-${Date.now()}`;
+                this.currentTest.key = `somekey-${genUniqID()}`;
                 bucketUtil = new BucketUtility('default', sigCfg);
                 s3 = bucketUtil.s3;
 

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getAwsVersioning.js
@@ -13,10 +13,11 @@ const {
     putVersionsToAws,
     getAndAssertResult,
     describeSkipIfNotMultiple,
+    genUniqID,
 } = require('../utils');
 
 const someBody = 'testbody';
-const bucket = 'buckettestmultiplebackendgetawsversioning';
+const bucket = `getawsversioning${genUniqID()}`;
 
 function getAndAssertVersions(s3, bucket, key, versionIds, expectedData,
     cb) {
@@ -69,7 +70,7 @@ function testSuite() {
 
         it('should not return version ids when versioning has not been ' +
         'configured via CloudServer', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
             Metadata: { 'scal-location-constraint': awsLocation } },
             (err, data) => {
@@ -83,7 +84,7 @@ function testSuite() {
 
         it('should not return version ids when versioning has not been ' +
         'configured via CloudServer, even when version id specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
             Metadata: { 'scal-location-constraint': awsLocation } },
             (err, data) => {
@@ -97,7 +98,7 @@ function testSuite() {
 
         it('should return version id for null version when versioning ' +
         'has been configured via CloudServer', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
                     Metadata: { 'scal-location-constraint': awsLocation } },
@@ -114,7 +115,7 @@ function testSuite() {
 
         it('should overwrite the null version if putting object twice ' +
         'before versioning is configured', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = ['data1', 'data2'];
             async.waterfall([
                 next => mapToAwsPuts(s3, bucket, key, data, err => next(err)),
@@ -129,7 +130,7 @@ function testSuite() {
 
         it('should overwrite existing null version if putting object ' +
         'after suspending versioning', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = ['data1', 'data2'];
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: data[0],
@@ -150,7 +151,7 @@ function testSuite() {
 
         it('should overwrite null version if putting object when ' +
         'versioning is suspended after versioning enabled', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [...Array(3).keys()].map(i => `data${i}`);
             let firstVersionId;
             async.waterfall([
@@ -186,7 +187,7 @@ function testSuite() {
 
         it('should get correct data from aws backend using version IDs',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [...Array(5).keys()].map(i => i.toString());
             const versionIds = ['null'];
             async.waterfall([
@@ -205,7 +206,7 @@ function testSuite() {
 
         it('should get correct version when getting without version ID',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [...Array(5).keys()].map(i => i.toString());
             const versionIds = ['null'];
             async.waterfall([
@@ -226,7 +227,7 @@ function testSuite() {
         'after putting null versions, putting versions, putting more null ' +
         'versions and then putting more versions',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             const data = [...Array(16).keys()].map(i => i.toString());
             // put three null versions,
             // 5 real versions,
@@ -272,7 +273,7 @@ function testSuite() {
         it('should return the correct data getting versioned object ' +
         'even if object was deleted from AWS (creating a delete marker)',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
@@ -289,7 +290,7 @@ function testSuite() {
         it('should return the correct data getting versioned object ' +
         'even if object is put directly to AWS (creating new version)',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
@@ -306,7 +307,7 @@ function testSuite() {
         it('should return a ServiceUnavailable if trying to get an object ' +
         'that was deleted in AWS but exists in s3 metadata',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: someBody,
@@ -330,7 +331,7 @@ function testSuite() {
         it('should return a ServiceUnavailable if trying to get a version ' +
         'that was deleted in AWS but exists in s3 metadata',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key, Body: someBody,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/get/getGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/get/getGcp.js
@@ -5,13 +5,14 @@ const {
     describeSkipIfNotMultiple,
     gcpLocation,
     gcpLocationMismatch,
+    genUniqID,
 } = require('../utils');
 
-const bucket = 'buckettestmultiplebackendget-gcp';
-const gcpObject = `gcpobject-${Date.now()}`;
-const emptyGcpObject = `emptyObject-${Date.now()}`;
-const bigObject = `bigObject-${Date.now()}`;
-const mismatchObject = `mismatch-${Date.now()}`;
+const bucket = `getgcp${genUniqID()}`;
+const gcpObject = `gcpobject-${genUniqID()}`;
+const emptyGcpObject = `emptyObject-${genUniqID()}`;
+const bigObject = `bigObject-${genUniqID()}`;
+const mismatchObject = `mismatch-${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const bigBodyLen = bigBody.length;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUAzure.js
@@ -3,10 +3,10 @@ const assert = require('assert');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName }
-    = require('../utils');
+const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName,
+    genUniqID } = require('../utils');
 
-const keyName = `somekey-${Date.now()}`;
+const keyName = `somekey-${genUniqID()}`;
 
 const azureContainerName = getAzureContainerName(azureLocation);
 let s3;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/initMPU/initMPUGcp.js
@@ -3,13 +3,13 @@ const assert = require('assert');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { describeSkipIfNotMultiple, gcpClient, gcpBucketMPU, gcpLocation } =
-    require('../utils');
+const { describeSkipIfNotMultiple, gcpClient, gcpBucketMPU, gcpLocation,
+    genUniqID } = require('../utils');
 const { createMpuKey } =
     require('../../../../../../lib/data/external/GCP').GcpUtils;
 
-const bucket = 'buckettestmultiplebackendinitmpu-gcp';
-const keyName = `somekey-${Date.now()}`;
+const bucket = `initmpugcp${genUniqID()}`;
+const keyName = `somekey-${genUniqID()}`;
 
 let s3;
 let bucketUtil;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/listParts/azureListParts.js
@@ -2,8 +2,8 @@ const assert = require('assert');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName }
-    = require('../utils');
+const { describeSkipIfNotMultiple, azureLocation, getAzureContainerName,
+    genUniqID } = require('../utils');
 
 const azureContainerName = getAzureContainerName(azureLocation);
 const firstPartSize = 10;
@@ -17,7 +17,7 @@ let s3;
 describeSkipIfNotMultiple('List parts of MPU on Azure data backend', () => {
     withV4(sigCfg => {
         beforeEach(function beforeEachFn() {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             return s3.createBucketAsync({ Bucket: azureContainerName })

--- a/tests/functional/aws-node-sdk/test/multipleBackend/listParts/listPartsGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/listParts/listPartsGcp.js
@@ -2,10 +2,10 @@ const assert = require('assert');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const { describeSkipIfNotMultiple, gcpLocation }
+const { describeSkipIfNotMultiple, gcpLocation, genUniqID }
     = require('../utils');
 
-const bucket = 'buckettestmultiplebackendlistparts-gcp';
+const bucket = `listpartsgcp${genUniqID()}`;
 const firstPartSize = 10;
 const bodyFirstPart = Buffer.alloc(firstPartSize);
 const secondPartSize = 15;
@@ -17,7 +17,7 @@ let s3;
 describeSkipIfNotMultiple('List parts of MPU on GCP data backend', () => {
     withV4(sigCfg => {
         beforeEach(function beforeEachFn() {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             return s3.createBucketAsync({ Bucket: bucket })

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/abortMPUGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuAbort/abortMPUGcp.js
@@ -4,10 +4,10 @@ const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, gcpClient, gcpBucket, gcpBucketMPU,
-    gcpLocation, uniqName } = require('../utils');
+    gcpLocation, uniqName, genUniqID } = require('../utils');
 
 const keyObject = 'abortgcp';
-const bucket = 'buckettestmultiplebackendabortmpu-gcp';
+const bucket = `abortmpugcp${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const gcpTimeout = 5000;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/azureCompleteMPU.js
@@ -14,6 +14,7 @@ const {
     azureLocationMismatch,
     getAzureClient,
     getAzureContainerName,
+    genUniqID,
 } = require('../utils');
 
 const azureMpuUtils = s3middleware.azureHelper.mpuUtils;
@@ -105,7 +106,7 @@ function testSuite() {
     this.timeout(150000);
     withV4(sigCfg => {
         beforeEach(function beFn() {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             this.currentTest.awsClient = awsS3;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/completeMPUGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/completeMPUGcp.js
@@ -4,10 +4,10 @@ const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, fileLocation, awsS3, awsLocation, awsBucket,
-    gcpClient, gcpBucket, gcpLocation, gcpLocationMismatch } =
+    gcpClient, gcpBucket, gcpLocation, gcpLocationMismatch, genUniqID } =
     require('../utils');
 
-const bucket = 'buckettestmultiplebackendcompletempu-gcp';
+const bucket = `completempugcp${genUniqID()}`;
 const smallBody = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const s3MD5 = 'bfb875032e51cbe2a60c5b6b99a2153f-2';
@@ -91,7 +91,7 @@ function testSuite() {
     this.timeout(150000);
     withV4(sigCfg => {
         beforeEach(function beFn() {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             this.currentTest.awsClient = awsS3;

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuComplete/mpuAwsVersioning.js
@@ -12,12 +12,13 @@ const {
     awsGetLatestVerId,
     getAndAssertResult,
     describeSkipIfNotMultiple,
+    genUniqID,
 } = require('../utils');
 
 const data = ['a', 'b'].map(char => Buffer.alloc(minimumAllowedPartSize, char));
 const concattedData = Buffer.concat(data);
 
-const bucket = 'buckettestmultiplebackendmpuawsversioning';
+const bucket = `mpuawsversioning${genUniqID()}`;
 
 function mpuSetup(s3, key, location, cb) {
     const partArray = [];
@@ -115,7 +116,7 @@ function testSuite() {
 
         it('versioning not configured: should not return version id ' +
         'completing mpu', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             mpuSetup(s3, key, awsLocation, (err, uploadId, partArray) => {
                 completeAndAssertMpu(s3, { bucket, key, uploadId, partArray,
                     expectVersionId: false }, done);
@@ -125,7 +126,7 @@ function testSuite() {
         it('versioning not configured: if complete mpu on already-existing ' +
         'object, metadata should be overwritten but data of previous version' +
         'in AWS should not be deleted', function itF(done) {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putToAwsBackend(s3, bucket, key, '', err => next(err)),
                 next => awsGetLatestVerId(key, '', next),
@@ -151,7 +152,7 @@ function testSuite() {
 
         it('versioning suspended: should not return version id completing mpu',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => suspendVersioning(s3, bucket, next),
                 next => mpuSetup(s3, key, awsLocation, next),
@@ -163,7 +164,7 @@ function testSuite() {
 
         it('versioning enabled: should return version id completing mpu',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => mpuSetup(s3, key, awsLocation, next),

--- a/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/putPartGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/mpuParts/putPartGcp.js
@@ -4,12 +4,13 @@ const async = require('async');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, gcpClient, gcpBucket, gcpBucketMPU,
-    gcpLocation, gcpLocationMismatch, uniqName } = require('../utils');
+    gcpLocation, gcpLocationMismatch, uniqName, genUniqID }
+    = require('../utils');
 const { createMpuKey } =
     require('../../../../../../lib/data/external/GCP').GcpUtils;
 
 const keyObject = 'putgcp';
-const bucket = 'buckettestmultiplebackendputpart-gcp';
+const bucket = `putpartgcp${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/azureObjectCopy.js
@@ -14,6 +14,7 @@ const {
     azureLocation,
     azureLocation2,
     azureLocationMismatch,
+    genUniqID,
 } = require('../utils');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
@@ -21,8 +22,8 @@ const { createEncryptedBucketPromise } =
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName(azureLocation);
 
-const bucket = 'buckettestmultiplebackendobjectcopy';
-const bucketAzure = 'bucketazuretestmultiplebackendobjectcopy';
+const bucket = `objectcopybucket${genUniqID()}`;
+const bucketAzure = `objectcopyazure${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = new Buffer(5 * 1024 * 1024);
 const normalMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -116,8 +117,8 @@ function testSuite() {
     this.timeout(250000);
     withV4(sigCfg => {
         beforeEach(function beFn() {
-            this.currentTest.key = `azureputkey-${Date.now()}`;
-            this.currentTest.copyKey = `azurecopyKey-${Date.now()}`;
+            this.currentTest.key = `azureputkey-${genUniqID()}`;
+            this.currentTest.copyKey = `azurecopyKey-${genUniqID()}`;
             bucketUtil = new BucketUtility('default', sigCfg);
             s3 = bucketUtil.s3;
             process.stdout.write('Creating bucket\n');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopy.js
@@ -9,11 +9,12 @@ const { getRealAwsConfig } = require('../../support/awsConfig');
 const { createEncryptedBucketPromise } =
     require('../../../lib/utility/createEncryptedBucket');
 const { describeSkipIfNotMultiple, awsS3, memLocation, awsLocation,
-    azureLocation, awsLocation2, awsLocationMismatch, awsLocationEncryption } =
-    require('../utils');
-const bucket = 'buckettestmultiplebackendobjectcopy';
-const bucketAws = 'bucketawstestmultiplebackendobjectcopy';
-const awsServerSideEncryptionbucket = 'awsserversideencryptionbucketobjectcopy';
+    azureLocation, awsLocation2, awsLocationMismatch, awsLocationEncryption,
+    genUniqID } = require('../utils');
+
+const bucket = `objectcopybucket${genUniqID()}`;
+const bucketAws = `objectcopyaws${genUniqID()}`;
+const awsServerSideEncryptionbucket = `objectcopyawssse${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';
@@ -23,7 +24,7 @@ let bucketUtil;
 let s3;
 
 function putSourceObj(location, isEmptyObj, bucket, cb) {
-    const key = `somekey-${Date.now()}`;
+    const key = `somekey-${genUniqID()}`;
     const sourceParams = { Bucket: bucket, Key: key,
         Metadata: {
             'test-header': 'copyme',
@@ -166,7 +167,7 @@ function testSuite() {
         'destination bucket location',
         done => {
             putSourceObj(memLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucketAws,
                     Key: copyKey,
@@ -190,7 +191,7 @@ function testSuite() {
         'destination bucket location',
         done => {
             putSourceObj(azureLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucketAws,
                     Key: copyKey,
@@ -214,7 +215,7 @@ function testSuite() {
         'to AWS relying on destination bucket location',
         done => {
             putSourceObj(null, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucketAws,
                     Key: copyKey,
@@ -238,7 +239,7 @@ function testSuite() {
         'bucket location',
         done => {
             putSourceObj(awsLocation, false, bucketAws, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -260,7 +261,7 @@ function testSuite() {
 
         it('should copy an object from mem to AWS', done => {
             putSourceObj(memLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -285,7 +286,7 @@ function testSuite() {
         it('should copy an object from mem to AWS with aws server side ' +
         'encryption', done => {
             putSourceObj(memLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -310,7 +311,7 @@ function testSuite() {
         it('should copy an object from AWS to mem with encryption with ' +
         'REPLACE directive but no location constraint', done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -333,7 +334,7 @@ function testSuite() {
         it('should copy an object on AWS with aws server side encryption',
         done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -359,7 +360,7 @@ function testSuite() {
         'encrypted bucket', done => {
             putSourceObj(awsLocation, false, awsServerSideEncryptionbucket,
             key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: awsServerSideEncryptionbucket,
                     Key: copyKey,
@@ -383,7 +384,7 @@ function testSuite() {
         it('should copy an object from mem to AWS with encryption with ' +
         'REPLACE directive but no location constraint', done => {
             putSourceObj(null, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucketAws,
                     Key: copyKey,
@@ -407,7 +408,7 @@ function testSuite() {
         'directive and aws location metadata',
         done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -431,7 +432,7 @@ function testSuite() {
 
         it('should copy an object on AWS', done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -456,7 +457,7 @@ function testSuite() {
         'false to a different AWS location with bucketMatch equals true',
         done => {
             putSourceObj(awsLocationMismatch, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -483,7 +484,7 @@ function testSuite() {
         done => {
             const awsConfig2 = getRealAwsConfig(awsLocation2);
             const awsS3Two = new AWS.S3(awsConfig2);
-            const copyKey = `copyKey-${Date.now()}`;
+            const copyKey = `copyKey-${genUniqID()}`;
             const awsBucket =
                 config.locationConstraints[awsLocation].details.bucketName;
             async.waterfall([
@@ -522,7 +523,7 @@ function testSuite() {
         'different AWS account without source object READ access',
         done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -541,7 +542,7 @@ function testSuite() {
 
         it('should copy an object on AWS with REPLACE', done => {
             putSourceObj(awsLocation, false, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -565,7 +566,7 @@ function testSuite() {
 
         it('should copy a 0-byte object from mem to AWS', done => {
             putSourceObj(memLocation, true, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -589,7 +590,7 @@ function testSuite() {
 
         it('should copy a 0-byte object on AWS', done => {
             putSourceObj(awsLocation, true, bucket, key => {
-                const copyKey = `copyKey-${Date.now()}`;
+                const copyKey = `copyKey-${genUniqID()}`;
                 const copyParams = {
                     Bucket: bucket,
                     Key: copyKey,
@@ -618,7 +619,7 @@ function testSuite() {
                 awsS3.deleteObject({ Bucket: awsBucket, Key: key }, err => {
                     assert.equal(err, null, 'Error deleting object from AWS: ' +
                         `${err}`);
-                    const copyKey = `copyKey-${Date.now()}`;
+                    const copyKey = `copyKey-${genUniqID()}`;
                     const copyParams = { Bucket: bucket, Key: copyKey,
                         CopySource: `/${bucket}/${key}`,
                         MetadataDirective: 'REPLACE',

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopyAwsVersioning.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectCopy/objectCopyAwsVersioning.js
@@ -14,10 +14,11 @@ const {
     putToAwsBackend,
     awsGetLatestVerId,
     getAndAssertResult,
+    genUniqID,
 } = require('../utils');
 
-const sourceBucketName = 'buckettestobjectcopyawsversioning-source';
-const destBucketName = 'buckettestobjectcopyawsversioning-dest';
+const sourceBucketName = `awsversioningsrc${genUniqID()}`;
+const destBucketName = `awsversioningdst${genUniqID()}`;
 
 const someBody = Buffer.from('I am a body', 'utf8');
 const wrongVersionBody = 'this is not the content you wanted';
@@ -52,7 +53,7 @@ function createBuckets(testParams, cb) {
 
 function putSourceObj(testParams, cb) {
     const { sourceBucket, isEmptyObj } = testParams;
-    const sourceKey = `sourcekey-${Date.now()}`;
+    const sourceKey = `sourcekey-${genUniqID()}`;
     const sourceParams = {
         Bucket: sourceBucket,
         Key: sourceKey,
@@ -81,7 +82,7 @@ function copyObject(testParams, cb) {
     const { sourceBucket, sourceKey, sourceVersionId, sourceVersioningState,
         destBucket, directive, destVersioningState, isEmptyObj }
         = testParams;
-    const destKey = `destkey-${Date.now()}`;
+    const destKey = `destkey-${genUniqID()}`;
     const copyParams = {
         Bucket: destBucket,
         Key: destKey,
@@ -307,7 +308,7 @@ function testSuite() {
         it('versioning not configured: if copy object to a pre-existing ' +
         'object on AWS backend, metadata should be overwritten but data of ' +
         'previous version in AWS should not be deleted', function itF(done) {
-            const destKey = `destkey-${Date.now()}`;
+            const destKey = `destkey-${genUniqID()}`;
             const testParams = {
                 sourceBucket: sourceBucketName,
                 sourceLocation: awsLocation,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectPutCopyPart/objectPutCopyPartAzure.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectPutCopyPart/objectPutCopyPartAzure.js
@@ -7,7 +7,8 @@ const { config } = require('../../../../../../lib/Config');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { uniqName, getAzureClient, azureLocation, azureLocationMismatch,
-  memLocation, awsLocation, awsS3, getOwnerInfo } = require('../utils');
+  memLocation, awsLocation, awsS3, getOwnerInfo, genUniqID }
+  = require('../utils');
 
 const describeSkipIfNotMultiple = config.backends.data !== 'multiple'
     ? describe.skip : describe;
@@ -21,8 +22,8 @@ config.locationConstraints[azureLocation].details.azureContainerName) {
       config.locationConstraints[azureLocation].details.azureContainerName;
 }
 
-const memBucketName = 'membucketnameputcopypartazure';
-const awsBucketName = 'awsbucketnameputcopypartazure';
+const memBucketName = `memputcopypartazure${genUniqID()}`;
+const awsBucketName = `awsputcopypartazure${genUniqID()}`;
 
 const normalBodySize = 11;
 const normalBody = Buffer.from('I am a body', 'utf8');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectPutCopyPart/objectPutCopyPartGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectPutCopyPart/objectPutCopyPartGcp.js
@@ -6,12 +6,12 @@ const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, uniqName, gcpBucketMPU,
     gcpClient, gcpLocation, gcpLocationMismatch, memLocation,
-    awsLocation, awsS3, getOwnerInfo } = require('../utils');
+    awsLocation, awsS3, getOwnerInfo, genUniqID } = require('../utils');
 
-const bucket = 'buckettestmultiplebackendpartcopy-gcp';
+const bucket = `partcopygcp${genUniqID()}`;
 
-const memBucketName = 'membucketnameputcopypartgcp';
-const awsBucketName = 'awsbucketnameputcopypartgcp';
+const memBucketName = `memeputcopypartgcp${genUniqID()}`;
+const awsBucketName = `awsputcopypartgcp${genUniqID()}`;
 
 const normalBodySize = 11;
 const normalBody = Buffer.from('I am a body', 'utf8');

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/objectTagging.js
@@ -4,11 +4,11 @@ const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, awsS3, awsBucket, getAwsRetry,
     getAzureClient, getAzureContainerName, convertMD5, memLocation,
-    fileLocation, awsLocation, azureLocation } = require('../utils');
+    fileLocation, awsLocation, azureLocation, genUniqID } = require('../utils');
 
 const azureClient = getAzureClient();
 const azureContainerName = getAzureContainerName(azureLocation);
-const bucket = 'testmultbackendtagging';
+const bucket = `taggingbucket${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
 const emptyMD5 = 'd41d8cd98f00b204e9800998ecf8427e';
@@ -192,7 +192,7 @@ function testSuite() {
                 const itSkipIfAzure = backend === 'azurebackend' ? it.skip : it;
                 it(`should put an object with tags to ${backend} backend`,
                 done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = Object.assign({ Key: key, Tagging: tagString,
                         Metadata: { 'scal-location-constraint': backend } },
                          putParams);
@@ -205,7 +205,7 @@ function testSuite() {
 
                 it(`should put a 0 byte object with tags to ${backend} backend`,
                 done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = {
                         Bucket: bucket,
                         Key: key,
@@ -221,7 +221,7 @@ function testSuite() {
 
                 it(`should put tags to preexisting object in ${backend} ` +
                 'backend', done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = Object.assign({ Key: key, Metadata:
                         { 'scal-location-constraint': backend } }, putParams);
                     process.stdout.write('Putting object\n');
@@ -239,7 +239,7 @@ function testSuite() {
 
                 it('should put tags to preexisting 0 byte object in ' +
                 `${backend} backend`, done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = {
                         Bucket: bucket,
                         Key: key,
@@ -260,7 +260,7 @@ function testSuite() {
 
                 itSkipIfAzure('should put tags to completed MPU object in ' +
                 `${backend}`, done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = {
                         Bucket: bucket,
                         Key: key,
@@ -282,7 +282,7 @@ function testSuite() {
             'version in AWS, even if a delete marker was created directly ' +
             'on AWS before tags are put',
             done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = Object.assign({ Key: key, Metadata:
                     { 'scal-location-constraint': awsLocation } }, putParams);
                 process.stdout.write('Putting object\n');
@@ -307,7 +307,7 @@ function testSuite() {
             testBackends.forEach(backend => {
                 it(`should get tags from object on ${backend} backend`,
                 done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = Object.assign({ Key: key, Tagging: tagString,
                         Metadata: { 'scal-location-constraint': backend } },
                         putParams);
@@ -322,7 +322,7 @@ function testSuite() {
 
             it('should not return error on getting tags from object that has ' +
             'had a delete marker put directly on AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = Object.assign({ Key: key, Tagging: tagString,
                     Metadata: { 'scal-location-constraint': awsLocation } },
                     putParams);
@@ -343,7 +343,7 @@ function testSuite() {
             testBackends.forEach(backend => {
                 it(`should delete tags from object on ${backend} backend`,
                 done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = Object.assign({ Key: key, Tagging: tagString,
                         Metadata: { 'scal-location-constraint': backend } },
                         putParams);
@@ -361,7 +361,7 @@ function testSuite() {
 
             it('should not return error on deleting tags from object that ' +
             'has had delete markers put directly on AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = Object.assign({ Key: key, Tagging: tagString,
                     Metadata: { 'scal-location-constraint': awsLocation } },
                     putParams);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-delete.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-delete.js
@@ -2,8 +2,6 @@ const async = require('async');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const bucket = 'testawsbackendtaggingdeleteversioned';
-
 const { removeAllVersions } = require('../../../lib/utility/versioning-util');
 const {
     describeSkipIfNotMultiple,
@@ -15,9 +13,11 @@ const {
     putVersionsToAws,
     awsGetLatestVerId,
     tagging,
+    genUniqID,
 } = require('../utils');
-
 const { putTaggingAndAssert, delTaggingAndAssert, awsGetAssertTags } = tagging;
+
+const bucket = `awsversioningtagdel${genUniqID()}`;
 const someBody = 'teststring';
 
 describeSkipIfNotMultiple('AWS backend object delete tagging with versioning ',
@@ -45,7 +45,7 @@ function testSuite() {
 
         it('versioning not configured: should delete a tag set on the ' +
         'latest version if no version is specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => putTaggingAndAssert(s3, { bucket, key, tags,
@@ -58,7 +58,7 @@ function testSuite() {
 
         it('versioning not configured: should delete a tag set on the ' +
         'version if specified (null)', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => putTaggingAndAssert(s3, { bucket, key, tags,
@@ -72,7 +72,7 @@ function testSuite() {
         it('versioning suspended: should delete a tag set on the latest ' +
         'version if no version is specified', done => {
             const data = [undefined, 'test1', 'test2'];
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, data, next),
                 (versionIds, next) => putTaggingAndAssert(s3, { bucket, key,
@@ -85,7 +85,7 @@ function testSuite() {
 
         it('versioning suspended: should delete a tag set on a specific ' +
         'version (null)', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [undefined],
                     next),
@@ -100,7 +100,7 @@ function testSuite() {
 
         it('versioning enabled then suspended: should delete a tag set on ' +
         'a specific (non-null) version if specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -121,7 +121,7 @@ function testSuite() {
 
         it('versioning enabled: should delete a tag set on the latest ' +
         'version if no version is specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -135,7 +135,7 @@ function testSuite() {
 
         it('versioning enabled: should delete a tag set on a specific version',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -150,7 +150,7 @@ function testSuite() {
 
         it('versioning enabled: should delete a tag set on a specific ' +
         'version that is not the latest version', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -173,7 +173,7 @@ function testSuite() {
 
         it('versioning suspended then enabled: should delete a tag set on ' +
         'a specific version (null) if specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [undefined],
                     () => next()),
@@ -194,7 +194,7 @@ function testSuite() {
         it('should return an ServiceUnavailable if trying to delete ' +
         'tags from object that was deleted from AWS directly',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => awsGetLatestVerId(key, '', next),
@@ -208,7 +208,7 @@ function testSuite() {
         it('should return an ServiceUnavailable if trying to delete ' +
         'tags from object that was deleted from AWS directly',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => awsGetLatestVerId(key, '',

--- a/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-putget.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/objectTagging/taggingAwsVersioning-putget.js
@@ -2,7 +2,6 @@ const async = require('async');
 
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
-const bucket = 'testawsbackendtaggingversioned';
 
 const { removeAllVersions } = require('../../../lib/utility/versioning-util');
 const {
@@ -15,10 +14,12 @@ const {
     putVersionsToAws,
     awsGetLatestVerId,
     tagging,
+    genUniqID,
 } = require('../utils');
 
 const { putTaggingAndAssert, getTaggingAndAssert, delTaggingAndAssert,
     awsGetAssertTags } = tagging;
+const bucket = `awsversioningtag${genUniqID()}`;
 const someBody = 'teststring';
 
 describeSkipIfNotMultiple('AWS backend object put/get tagging with versioning',
@@ -46,7 +47,7 @@ function testSuite() {
 
         it('versioning not configured: should put/get a tag set on the ' +
         'latest version if no version is specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => putTaggingAndAssert(s3, { bucket, key, tags,
@@ -60,7 +61,7 @@ function testSuite() {
 
         it('versioning not configured: should put/get a tag set on a ' +
         'specific version if specified (null)', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => putTaggingAndAssert(s3, { bucket, key, tags,
@@ -76,7 +77,7 @@ function testSuite() {
         it('versioning suspended: should put/get a tag set on the latest ' +
         'version if no version is specified', done => {
             const data = [undefined, 'test1', 'test2'];
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, data, next),
                 (versionIds, next) => putTaggingAndAssert(s3, { bucket, key,
@@ -90,7 +91,7 @@ function testSuite() {
 
         it('versioning suspended: should put/get a tag set on a specific ' +
         'version (null)', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [undefined],
                     next),
@@ -106,7 +107,7 @@ function testSuite() {
 
         it('versioning enabled then suspended: should put/get a tag set on ' +
         'a specific (non-null) version if specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -127,7 +128,7 @@ function testSuite() {
 
         it('versioning enabled: should put/get a tag set on the latest ' +
         'version if no version is specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -142,7 +143,7 @@ function testSuite() {
 
         it('versioning enabled: should put/get a tag set on a specific version',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -159,7 +160,7 @@ function testSuite() {
 
         it('versioning enabled: should put/get a tag set on a specific version',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -174,7 +175,7 @@ function testSuite() {
 
         it('versioning enabled: should put/get a tag set on a specific ' +
         'version that is not the latest version', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -198,7 +199,7 @@ function testSuite() {
 
         it('versioning suspended then enabled: should put/get a tag set on ' +
         'a specific version (null) if specified', done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => putNullVersionsToAws(s3, bucket, key, [undefined],
                     () => next()),
@@ -219,7 +220,7 @@ function testSuite() {
         it('should get tags for an object even if it was deleted from ' +
         'AWS directly (we rely on s3 metadata)',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => awsGetLatestVerId(key, '', next),
@@ -236,7 +237,7 @@ function testSuite() {
         it('should return an ServiceUnavailable if trying to put ' +
         'tags from object that was deleted from AWS directly',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => awsGetLatestVerId(key, '', next),
@@ -250,7 +251,7 @@ function testSuite() {
         it('should get tags for an version even if it was deleted from ' +
         'AWS directly (we rely on s3 metadata)',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => enableVersioning(s3, bucket, next),
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
@@ -270,7 +271,7 @@ function testSuite() {
         it('should return an ServiceUnavailable if trying to put ' +
         'tags on version that was deleted from AWS directly',
         done => {
-            const key = `somekey-${Date.now()}`;
+            const key = `somekey-${genUniqID()}`;
             async.waterfall([
                 next => s3.putObject({ Bucket: bucket, Key: key }, next),
                 (putData, next) => awsGetLatestVerId(key, '',

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/put.js
@@ -9,8 +9,9 @@ const { createEncryptedBucketPromise } =
 const { versioningEnabled } = require('../../../lib/utility/versioning-util');
 
 const { describeSkipIfNotMultiple, getAwsRetry, awsLocation,
-    awsLocationEncryption, memLocation, fileLocation } = require('../utils');
-const bucket = 'buckettestmultiplebackendput';
+    awsLocationEncryption, memLocation, fileLocation, genUniqID }
+    = require('../utils');
+const bucket = `putaws${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -104,7 +105,7 @@ describe('MultipleBackend put object', function testSuite() {
 
         it('should return an error to put request without a valid bucket name',
             done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 s3.putObject({ Bucket: '', Key: key }, err => {
                     assert.notEqual(err, null,
                         'Expected failure but got success');
@@ -121,7 +122,7 @@ describe('MultipleBackend put object', function testSuite() {
 
             it('should return an error to put request without a valid ' +
                 'location constraint', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': 'fail-region' } };
@@ -134,7 +135,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put an object to mem', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': memLocation },
@@ -152,7 +153,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put a 0-byte object to mem', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Metadata: { 'scal-location-constraint': memLocation },
                 };
@@ -170,7 +171,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put a 0-byte object to AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Metadata: { 'scal-location-constraint': awsLocation },
                 };
@@ -183,7 +184,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put an object to file', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': fileLocation },
@@ -201,7 +202,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put an object to AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': awsLocation } };
@@ -216,7 +217,7 @@ describe('MultipleBackend put object', function testSuite() {
             it('should encrypt body only if bucket encrypted putting ' +
             'object to AWS',
             done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': awsLocation } };
@@ -229,7 +230,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put an object to AWS with encryption', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint':
@@ -244,7 +245,7 @@ describe('MultipleBackend put object', function testSuite() {
 
             it('should return a version id putting object to ' +
             'to AWS with versioning enabled', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key, Body: body,
                     Metadata: { 'scal-location-constraint': awsLocation } };
                 async.waterfall([
@@ -264,7 +265,7 @@ describe('MultipleBackend put object', function testSuite() {
             });
 
             it('should put a large object to AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: bigBody,
                     Metadata: { 'scal-location-constraint': awsLocation } };
@@ -278,7 +279,7 @@ describe('MultipleBackend put object', function testSuite() {
 
             it('should put objects with same key to AWS ' +
             'then file, and object should only be present in file', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': awsLocation } };
@@ -305,7 +306,7 @@ describe('MultipleBackend put object', function testSuite() {
 
             it('should put objects with same key to file ' +
             'then AWS, and object should only be present on AWS', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': fileLocation } };
@@ -325,7 +326,7 @@ describe('MultipleBackend put object', function testSuite() {
 
             it('should put two objects to AWS with same ' +
             'key, and newest object should be returned', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': awsLocation,
@@ -382,7 +383,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);
                 process.stdout.write('Putting object\n');
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key, Body: body };
                 return s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
@@ -406,7 +407,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);
                 process.stdout.write('Putting object\n');
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key, Body: body };
                 return s3.putObject(params, err => {
                     assert.equal(err, null, 'Expected success, ' +
@@ -430,7 +431,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);
                 process.stdout.write('Putting object\n');
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key, Body: body };
                 return s3.putObject(params, err => {
                     assert.equal(err, null,
@@ -470,7 +471,7 @@ describe('MultipleBackend put based on request endpoint', () => {
             });
             request.send(err => {
                 assert.strictEqual(err, null, `Error creating bucket: ${err}`);
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 s3.putObject({ Bucket: bucket, Key: key, Body: body }, err => {
                     assert.strictEqual(err, null, 'Expected succes, ' +
                         `got error ${JSON.stringify(err)}`);

--- a/tests/functional/aws-node-sdk/test/multipleBackend/put/putGcp.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/put/putGcp.js
@@ -3,9 +3,9 @@ const assert = require('assert');
 const withV4 = require('../../support/withV4');
 const BucketUtility = require('../../../lib/utility/bucket-util');
 const { describeSkipIfNotMultiple, gcpClient, gcpBucket,
-    gcpLocation, fileLocation } = require('../utils');
+    gcpLocation, fileLocation, genUniqID } = require('../utils');
 
-const bucket = 'buckettestmultiplebackendput-gcp';
+const bucket = `putgcp${genUniqID()}`;
 const body = Buffer.from('I am a body', 'utf8');
 const bigBody = Buffer.alloc(10485760);
 const correctMD5 = 'be747eb4b75517bf6b3cf7c5fbb62f3a';
@@ -125,7 +125,7 @@ describeFn() {
                 const { location, Body } = test.input;
                 const { s3MD5, gcpMD5 } = test.output;
                 it(test.msg, done => {
-                    const key = `somekey-${Date.now()}`;
+                    const key = `somekey-${genUniqID()}`;
                     const params = { Bucket: bucket, Key: key, Body,
                         Metadata: { 'scal-location-constraint': location },
                     };
@@ -146,7 +146,7 @@ describeFn() {
 
             it('should put objects with same key to GCP ' +
             'then file, and object should only be present in file', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': gcpLocation } };
@@ -174,7 +174,7 @@ describeFn() {
 
             it('should put objects with same key to file ' +
             'then GCP, and object should only be present on GCP', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': fileLocation } };
@@ -194,7 +194,7 @@ describeFn() {
 
             it('should put two objects to GCP with same ' +
             'key, and newest object should be returned', done => {
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key,
                     Body: body,
                     Metadata: { 'scal-location-constraint': gcpLocation,
@@ -250,7 +250,7 @@ describeSkipIfNotMultiple('MultipleBackend put object based on bucket location',
             }, err => {
                 assert.equal(err, null, `Error creating bucket: ${err}`);
                 process.stdout.write('Putting object\n');
-                const key = `somekey-${Date.now()}`;
+                const key = `somekey-${genUniqID()}`;
                 const params = { Bucket: bucket, Key: key, Body: body };
                 return s3.putObject(params, err => {
                     assert.equal(err, null,

--- a/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
+++ b/tests/functional/aws-node-sdk/test/multipleBackend/utils.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const { errors } = require('arsenal');
 const AWS = require('aws-sdk');
+const uuid = require('uuid/v4');
 
 const async = require('async');
 const azure = require('azure-storage');
@@ -82,6 +83,8 @@ const utils = {
     gcpLocationMismatch,
 };
 
+utils.genUniqID = () => uuid().replace(/-/g, '');
+
 utils.getOwnerInfo = account => {
     let ownerID;
     let ownerDisplayName;
@@ -105,7 +108,7 @@ utils.getOwnerInfo = account => {
     return { ownerID, ownerDisplayName };
 };
 
-utils.uniqName = name => `${name}${new Date().getTime()}`;
+utils.uniqName = name => `${name}-${utils.genUniqID()}`;
 
 utils.getAzureClient = () => {
     const params = {};
@@ -154,19 +157,19 @@ utils.getAzureKeys = () => {
     const keys = [
         {
             describe: 'empty',
-            name: `somekey-${Date.now()}`,
+            name: `somekey-${utils.genUniqID()}`,
             body: '',
             MD5: 'd41d8cd98f00b204e9800998ecf8427e',
         },
         {
             describe: 'normal',
-            name: `somekey-${Date.now()}`,
+            name: `somekey-${utils.genUniqID()}`,
             body: Buffer.from('I am a body', 'utf8'),
             MD5: 'be747eb4b75517bf6b3cf7c5fbb62f3a',
         },
         {
             describe: 'big',
-            name: `bigkey-${Date.now()}`,
+            name: `bigkey-${utils.genUniqID()}`,
             body: Buffer.alloc(10485760),
             MD5: 'f1c9645dbc14efddc7d8a322685f26eb',
         },
@@ -396,6 +399,5 @@ utils.tagging.awsGetAssertTags = (params, cb) => {
         return cb();
     });
 };
-
 
 module.exports = utils;

--- a/tests/functional/raw-node/test/GCP/bucket/get.js
+++ b/tests/functional/raw-node/test/GCP/bucket/get.js
@@ -2,13 +2,13 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 const { listingHardLimit } = require('../../../../../../constants');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 const smallSize = 20;
 const bigSize = listingHardLimit + 1;
 const config = getRealAwsConfig(credentialOne);
@@ -85,7 +85,7 @@ describe('GCP: GET Bucket', function testSuite() {
 
     describe('without existing bucket', () => {
         it('should return 404 and NoSuchBucket', done => {
-            const badBucketName = `nonexistingbucket-${Date.now()}`;
+            const badBucketName = `nonexistingbucket-${genUniqID()}`;
             gcpClient.getBucket({
                 Bucket: badBucketName,
             }, err => {

--- a/tests/functional/raw-node/test/GCP/bucket/getVersioning.js
+++ b/tests/functional/raw-node/test/GCP/bucket/getVersioning.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
@@ -25,7 +25,7 @@ describe('GCP: GET Bucket Versioning', () => {
     const gcpClient = new GCP(config);
 
     beforeEach(function beforeFn(done) {
-        this.currentTest.bucketName = `somebucket-${Date.now()}`;
+        this.currentTest.bucketName = `somebucket-${genUniqID()}`;
         gcpRequestRetry({
             method: 'PUT',
             bucket: this.currentTest.bucketName,

--- a/tests/functional/raw-node/test/GCP/bucket/head.js
+++ b/tests/functional/raw-node/test/GCP/bucket/head.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
@@ -12,7 +12,7 @@ describe('GCP: HEAD Bucket', () => {
 
     describe('without existing bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            this.currentTest.bucketName = `somebucket-${genUniqID()}`;
             return done();
         });
 
@@ -29,7 +29,7 @@ describe('GCP: HEAD Bucket', () => {
 
     describe('with existing bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.bucketName = `somebucket-${Date.now()}`;
+            this.currentTest.bucketName = `somebucket-${genUniqID()}`;
             process.stdout
                 .write(`Creating test bucket ${this.currentTest.bucketName}\n`);
             gcpRequestRetry({

--- a/tests/functional/raw-node/test/GCP/bucket/putVersioning.js
+++ b/tests/functional/raw-node/test/GCP/bucket/putVersioning.js
@@ -3,7 +3,7 @@ const async = require('async');
 const xml2js = require('xml2js');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
@@ -27,7 +27,7 @@ describe('GCP: PUT Bucket Versioning', () => {
     const gcpClient = new GCP(config);
 
     beforeEach(function beforeFn(done) {
-        this.currentTest.bucketName = `somebucket-${Date.now()}`;
+        this.currentTest.bucketName = `somebucket-${genUniqID()}`;
         gcpRequestRetry({
             method: 'PUT',
             bucket: this.currentTest.bucketName,

--- a/tests/functional/raw-node/test/GCP/object/completeMpu.js
+++ b/tests/functional/raw-node/test/GCP/object/completeMpu.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const async = require('async');
 const { GCP, GcpUtils } = require('../../../../../../lib/data/external/GCP');
-const { gcpRequestRetry, setBucketClass, gcpMpuSetup } =
+const { gcpRequestRetry, setBucketClass, gcpMpuSetup, genUniqID } =
     require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
@@ -9,11 +9,11 @@ const { getRealAwsConfig } =
 const credentialOne = 'gcpbackend';
 const bucketNames = {
     main: {
-        Name: `somebucket-${Date.now()}`,
+        Name: `somebucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
     mpu: {
-        Name: `mpubucket-${Date.now()}`,
+        Name: `mpubucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
 };
@@ -91,7 +91,7 @@ describe('GCP: Complete MPU', function testSuite() {
 
     describe('when MPU has 0 parts', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpMpuSetupWrapper.call(this, {
                 gcpClient,
                 bucketNames,
@@ -119,7 +119,7 @@ describe('GCP: Complete MPU', function testSuite() {
 
     describe('when MPU has 1 uploaded part', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpMpuSetupWrapper.call(this, {
                 gcpClient,
                 bucketNames,
@@ -157,7 +157,7 @@ describe('GCP: Complete MPU', function testSuite() {
 
     describe('when MPU has 1024 uploaded parts', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpMpuSetupWrapper.call(this, {
                 gcpClient,
                 bucketNames,

--- a/tests/functional/raw-node/test/GCP/object/copy.js
+++ b/tests/functional/raw-node/test/GCP/object/copy.js
@@ -2,12 +2,12 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 
 describe('GCP: COPY Object', function testSuite() {
     this.timeout(180000);
@@ -42,8 +42,8 @@ describe('GCP: COPY Object', function testSuite() {
 
     describe('without existing object in bucket', () => {
         it('should return 404 and \'NoSuchKey\'', done => {
-            const missingObject = `nonexistingkey-${Date.now()}`;
-            const someKey = `somekey-${Date.now()}`;
+            const missingObject = `nonexistingkey-${genUniqID()}`;
+            const someKey = `somekey-${genUniqID()}`;
             gcpClient.copyObject({
                 Bucket: bucketName,
                 Key: someKey,
@@ -59,9 +59,9 @@ describe('GCP: COPY Object', function testSuite() {
 
     describe('with existing object in bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
-            this.currentTest.copyKey = `copykey-${Date.now()}`;
-            this.currentTest.initValue = `${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
+            this.currentTest.copyKey = `copykey-${genUniqID()}`;
+            this.currentTest.initValue = `${genUniqID()}`;
             makeGcpRequest({
                 method: 'PUT',
                 bucket: bucketName,
@@ -109,7 +109,7 @@ describe('GCP: COPY Object', function testSuite() {
 
         it('should successfully copy with REPLACE directive',
         function testFn(done) {
-            const newValue = `${Date.now()}`;
+            const newValue = `${genUniqID()}`;
             async.waterfall([
                 next => gcpClient.copyObject({
                     Bucket: bucketName,

--- a/tests/functional/raw-node/test/GCP/object/delete.js
+++ b/tests/functional/raw-node/test/GCP/object/delete.js
@@ -2,14 +2,14 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
-const objectKey = `somekey-${Date.now()}`;
-const badObjectKey = `nonexistingkey-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
+const objectKey = `somekey-${genUniqID()}`;
+const badObjectKey = `nonexistingkey-${genUniqID()}`;
 
 describe('GCP: DELETE Object', function testSuite() {
     this.timeout(30000);

--- a/tests/functional/raw-node/test/GCP/object/deleteMpu.js
+++ b/tests/functional/raw-node/test/GCP/object/deleteMpu.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
-const { gcpRequestRetry, setBucketClass, gcpMpuSetup } =
+const { gcpRequestRetry, setBucketClass, gcpMpuSetup, genUniqID } =
     require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
@@ -9,11 +9,11 @@ const { getRealAwsConfig } =
 const credentialOne = 'gcpbackend';
 const bucketNames = {
     main: {
-        Name: `somebucket-${Date.now()}`,
+        Name: `somebucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
     mpu: {
-        Name: `mpubucket-${Date.now()}`,
+        Name: `mpubucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
 };
@@ -89,7 +89,7 @@ describe('GCP: Abort MPU', function testSuite() {
 
     describe('when MPU has 0 parts', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpMpuSetupWrapper.call(this, {
                 gcpClient,
                 bucketNames,
@@ -131,7 +131,7 @@ describe('GCP: Abort MPU', function testSuite() {
 
     describe('when MPU is incomplete', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpMpuSetupWrapper.call(this, {
                 gcpClient,
                 bucketNames,

--- a/tests/functional/raw-node/test/GCP/object/deleteTagging.js
+++ b/tests/functional/raw-node/test/GCP/object/deleteTagging.js
@@ -2,13 +2,14 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry, genDelTagObj } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genDelTagObj, genUniqID } =
+    require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 const { gcpTaggingPrefix } = require('../../../../../../constants');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 const gcpTagPrefix = `x-goog-meta-${gcpTaggingPrefix}`;
 let config;
 let gcpClient;
@@ -69,8 +70,8 @@ describe('GCP: DELETE Object Tagging', function testSuite() {
     });
 
     beforeEach(function beforeFn(done) {
-        this.currentTest.key = `somekey-${Date.now()}`;
-        this.currentTest.specialKey = `veryspecial-${Date.now()}`;
+        this.currentTest.key = `somekey-${genUniqID()}`;
+        this.currentTest.specialKey = `veryspecial-${genUniqID()}`;
         const { headers, expectedTagObj, expectedMetaObj } =
             genDelTagObj(10, gcpTagPrefix);
         this.currentTest.expectedTagObj = expectedTagObj;

--- a/tests/functional/raw-node/test/GCP/object/get.js
+++ b/tests/functional/raw-node/test/GCP/object/get.js
@@ -1,12 +1,12 @@
 const assert = require('assert');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 
 describe('GCP: GET Object', function testSuite() {
     this.timeout(30000);
@@ -41,7 +41,7 @@ describe('GCP: GET Object', function testSuite() {
 
     describe('with existing object in bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             makeGcpRequest({
                 method: 'PUT',
                 bucket: bucketName,
@@ -89,7 +89,7 @@ describe('GCP: GET Object', function testSuite() {
 
     describe('without existing object in bucket', () => {
         it('should return 404 and NoSuchKey', done => {
-            const badObjectKey = `nonexistingkey-${Date.now()}`;
+            const badObjectKey = `nonexistingkey-${genUniqID()}`;
             gcpClient.getObject({
                 Bucket: bucketName,
                 Key: badObjectKey,

--- a/tests/functional/raw-node/test/GCP/object/getTagging.js
+++ b/tests/functional/raw-node/test/GCP/object/getTagging.js
@@ -1,13 +1,14 @@
 const assert = require('assert');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry, genGetTagObj } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genGetTagObj, genUniqID } =
+    require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 const { gcpTaggingPrefix } = require('../../../../../../constants');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 const gcpTagPrefix = `x-goog-meta-${gcpTaggingPrefix}`;
 const tagSize = 10;
 
@@ -31,8 +32,8 @@ describe('GCP: GET Object Tagging', () => {
     });
 
     beforeEach(function beforeFn(done) {
-        this.currentTest.key = `somekey-${Date.now()}`;
-        this.currentTest.specialKey = `veryspecial-${Date.now()}`;
+        this.currentTest.key = `somekey-${genUniqID()}`;
+        this.currentTest.specialKey = `veryspecial-${genUniqID()}`;
         const { tagHeader, expectedTagObj } =
             genGetTagObj(tagSize, gcpTagPrefix);
         this.currentTest.tagObj = expectedTagObj;

--- a/tests/functional/raw-node/test/GCP/object/head.js
+++ b/tests/functional/raw-node/test/GCP/object/head.js
@@ -1,12 +1,12 @@
 const assert = require('assert');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 
 describe('GCP: HEAD Object', function testSuite() {
     this.timeout(30000);
@@ -41,7 +41,7 @@ describe('GCP: HEAD Object', function testSuite() {
 
     describe('with existing object in bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             makeGcpRequest({
                 method: 'PUT',
                 bucket: bucketName,
@@ -89,7 +89,7 @@ describe('GCP: HEAD Object', function testSuite() {
 
     describe('without existing object in bucket', () => {
         it('should return 404', done => {
-            const badObjectkey = `nonexistingkey-${Date.now()}`;
+            const badObjectkey = `nonexistingkey-${genUniqID()}`;
             gcpClient.headObject({
                 Bucket: bucketName,
                 Key: badObjectkey,

--- a/tests/functional/raw-node/test/GCP/object/initiateMpu.js
+++ b/tests/functional/raw-node/test/GCP/object/initiateMpu.js
@@ -2,18 +2,19 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry, setBucketClass } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, setBucketClass, genUniqID } =
+    require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
 const bucketNames = {
     main: {
-        Name: `somebucket-${Date.now()}`,
+        Name: `somebucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
     mpu: {
-        Name: `mpubucket-${Date.now()}`,
+        Name: `mpubucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
 };
@@ -57,8 +58,8 @@ describe('GCP: Initiate MPU', function testSuite() {
     });
 
     it('Should create a multipart upload object', done => {
-        const keyName = `somekey-${Date.now()}`;
-        const specialKey = `special-${Date.now()}`;
+        const keyName = `somekey-${genUniqID()}`;
+        const specialKey = `special-${genUniqID()}`;
         async.waterfall([
             next => gcpClient.createMultipartUpload({
                 Bucket: bucketNames.mpu.Name,

--- a/tests/functional/raw-node/test/GCP/object/put.js
+++ b/tests/functional/raw-node/test/GCP/object/put.js
@@ -1,12 +1,12 @@
 const assert = require('assert');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genUniqID } = require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 
 describe('GCP: PUT Object', function testSuite() {
     this.timeout(30000);
@@ -55,7 +55,7 @@ describe('GCP: PUT Object', function testSuite() {
 
     describe('with existing object in bucket', () => {
         beforeEach(function beforeFn(done) {
-            this.currentTest.key = `somekey-${Date.now()}`;
+            this.currentTest.key = `somekey-${genUniqID()}`;
             gcpRequestRetry({
                 method: 'PUT',
                 bucket: bucketName,
@@ -85,7 +85,7 @@ describe('GCP: PUT Object', function testSuite() {
 
     describe('without existing object in bucket', () => {
         it('should successfully put object', function testFn(done) {
-            this.test.key = `somekey-${Date.now()}`;
+            this.test.key = `somekey-${genUniqID()}`;
             gcpClient.putObject({
                 Bucket: bucketName,
                 Key: this.test.key,

--- a/tests/functional/raw-node/test/GCP/object/putTagging.js
+++ b/tests/functional/raw-node/test/GCP/object/putTagging.js
@@ -2,13 +2,14 @@ const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
 const { makeGcpRequest } = require('../../../utils/makeRequest');
-const { gcpRequestRetry, genPutTagObj } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, genPutTagObj, genUniqID } =
+    require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 const { gcpTaggingPrefix } = require('../../../../../../constants');
 
 const credentialOne = 'gcpbackend';
-const bucketName = `somebucket-${Date.now()}`;
+const bucketName = `somebucket-${genUniqID()}`;
 const gcpTagPrefix = `x-goog-meta-${gcpTaggingPrefix}`;
 
 describe('GCP: PUT Object Tagging', () => {
@@ -31,8 +32,8 @@ describe('GCP: PUT Object Tagging', () => {
     });
 
     beforeEach(function beforeFn(done) {
-        this.currentTest.key = `somekey-${Date.now()}`;
-        this.currentTest.specialKey = `veryspecial-${Date.now()}`;
+        this.currentTest.key = `somekey-${genUniqID()}`;
+        this.currentTest.specialKey = `veryspecial-${genUniqID()}`;
         makeGcpRequest({
             method: 'PUT',
             bucket: bucketName,

--- a/tests/functional/raw-node/test/GCP/object/upload.js
+++ b/tests/functional/raw-node/test/GCP/object/upload.js
@@ -1,18 +1,19 @@
 const assert = require('assert');
 const async = require('async');
 const { GCP } = require('../../../../../../lib/data/external/GCP');
-const { gcpRequestRetry, setBucketClass } = require('../../../utils/gcpUtils');
+const { gcpRequestRetry, setBucketClass, genUniqID } =
+    require('../../../utils/gcpUtils');
 const { getRealAwsConfig } =
     require('../../../../aws-node-sdk/test/support/awsConfig');
 
 const credentialOne = 'gcpbackend';
 const bucketNames = {
     main: {
-        Name: `somebucket-${Date.now()}`,
+        Name: `somebucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
     mpu: {
-        Name: `mpubucket-${Date.now()}`,
+        Name: `mpubucket-${genUniqID()}`,
         Type: 'MULTI_REGIONAL',
     },
 };
@@ -79,7 +80,7 @@ describe('GCP: Upload Object', function testSuite() {
     });
 
     it('should put an object to GCP', done => {
-        const key = `somekey-${Date.now()}`;
+        const key = `somekey-${genUniqID()}`;
         gcpClient.upload({
             Bucket: bucketNames.main.Name,
             MPU: bucketNames.mpu.Name,
@@ -94,7 +95,7 @@ describe('GCP: Upload Object', function testSuite() {
     });
 
     it('should put a large object to GCP', done => {
-        const key = `somekey-${Date.now()}`;
+        const key = `somekey-${genUniqID()}`;
         gcpClient.upload({
             Bucket: bucketNames.main.Name,
             MPU: bucketNames.mpu.Name,

--- a/tests/functional/raw-node/utils/gcpUtils.js
+++ b/tests/functional/raw-node/utils/gcpUtils.js
@@ -1,7 +1,10 @@
 const async = require('async');
 const assert = require('assert');
+const uuid = require('uuid/v4');
 
 const { makeGcpRequest } = require('./makeRequest');
+
+const genUniqID = () => uuid().replace(/-/g, '');
 
 function gcpRequestRetry(params, retry, callback) {
     const maxRetries = 4;
@@ -146,4 +149,5 @@ module.exports = {
     genPutTagObj,
     genGetTagObj,
     genDelTagObj,
+    genUniqID,
 };


### PR DESCRIPTION
a refactor to generate names with `uuid` instead of `date.now` to reduce naming conflicts on external backends during testing on CI