### PR TITLE
bf: append authdata accounts to existing accounts

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -970,16 +970,8 @@ class Config extends EventEmitter {
 
     setAuthDataAccounts(accounts) {
         // append orbit's users instead of replacing existing accounts
-        let allAccounts = this.authData.accounts;
-        if (accounts.every(a => a.source === 'orbit')) {
-            // filter out existing orbit accounts if any
-            allAccounts = allAccounts.reduce((store, a) => {
-                if (a.source !== 'orbit') {
-                    store.push(a);
-                }
-                return store;
-            }, []);
-        }
+        let allAccounts = this.authData.accounts.filter(a =>
+            a.source !== 'orbit');
         allAccounts = allAccounts.concat(accounts);
 
         this.authData.accounts = allAccounts;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -966,7 +966,10 @@ class Config extends EventEmitter {
     }
 
     setAuthDataAccounts(accounts) {
-        this.authData.accounts = accounts;
+        // append orbit's users instead of replacing existing accounts
+        const allAccounts = this.authData.accounts.concat(accounts);
+
+        this.authData.accounts = allAccounts;
         this.emit('authdata-update');
     }
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -914,6 +914,9 @@ class Config extends EventEmitter {
             if (validateAuthConfig(authData)) {
                 throw new Error('bad config: invalid auth config file.');
             }
+            // Add "source" property "file"
+            authData.accounts = authData.accounts.map(a =>
+                Object.assign({}, a, { source: 'file' }));
             this.authData = authData;
         }
         if (process.env.S3DATA) {
@@ -967,7 +970,17 @@ class Config extends EventEmitter {
 
     setAuthDataAccounts(accounts) {
         // append orbit's users instead of replacing existing accounts
-        const allAccounts = this.authData.accounts.concat(accounts);
+        let allAccounts = this.authData.accounts;
+        if (accounts.every(a => a.source === 'orbit')) {
+            // filter out existing orbit accounts if any
+            allAccounts = allAccounts.reduce((store, a) => {
+                if (a.source !== 'orbit') {
+                    store.push(a);
+                }
+                return store;
+            }, []);
+        }
+        allAccounts = allAccounts.concat(accounts);
 
         this.authData.accounts = allAccounts;
         this.emit('authdata-update');

--- a/lib/management/configuration.js
+++ b/lib/management/configuration.js
@@ -75,7 +75,8 @@ function patchConfiguration(instanceId, newConf, log, cb) {
                     const newAccount = buildAuthDataAccount(
                         u.accessKey, secretKey, u.canonicalId, serviceName,
                         u.userName);
-                    accounts.push(newAccount.accounts[0]);
+                    accounts.push(Object.assign({}, newAccount.accounts[0],
+                        { source: 'orbit' }));
                 }
             });
         }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/scality/S3#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#z/1.0",
+    "arsenal": "scality/Arsenal#bf/addOptionalSourcePropToAccounts",
     "async": "~2.5.0",
     "aws-sdk": "2.28.0",
     "azure-storage": "^2.1.0",

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -6,14 +6,32 @@ describe('Config', () => {
         done();
     });
 
-    it('should emit an event when auth data is updated', done => {
+    it('should emit an event when auth data is updated and append new ' +
+    'accounts to existing accounts', done => {
         const { ConfigObject } = require('../../lib/Config');
         const config = new ConfigObject();
+
+        const existingDataCount = config.authData.accounts.length;
         let emitted = false;
+
         config.on('authdata-update', () => {
+            const newCount = config.authData.accounts.length;
+            assert.strictEqual(existingDataCount + 1, newCount);
+
             emitted = true;
         });
-        config.setAuthDataAccounts([]);
+
+        const newAcct = {
+            name: 'Bart2',
+            email: 'sampleaccount1@sampling.com',
+            arn: 'arn:aws:iam::123456789016:root',
+            canonicalID:
+            '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf',
+            shortid: '123456789016',
+            keys: [{ access: 'accessKey1', secret: 'verySecretKey1' }],
+        };
+        config.setAuthDataAccounts([newAcct]);
+
         if (emitted) {
             return done();
         }

--- a/tests/unit/Config.js
+++ b/tests/unit/Config.js
@@ -23,12 +23,12 @@ describe('Config', () => {
 
         const newAcct = {
             name: 'Bart2',
-            email: 'sampleaccount1@sampling.com',
+            email: 'sampleaccount@sampling2.com',
             arn: 'arn:aws:iam::123456789016:root',
             canonicalID:
-            '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf',
+            '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bg',
             shortid: '123456789016',
-            keys: [{ access: 'accessKey1', secret: 'verySecretKey1' }],
+            keys: [{ access: 'accessKey3', secret: 'verySecretKey3' }],
         };
         config.setAuthDataAccounts([newAcct]);
 


### PR DESCRIPTION
Instead of overwriting existing accounts, append new accounts. This is needed to support file backend locally