### PR TITLE
MongoDB as metadata and Scality as a data ba…

### DIFF
--- a/dataserver.js
+++ b/dataserver.js
@@ -6,7 +6,9 @@ const logger = require('./lib/utilities/logger');
 
 if (config.backends.data === 'file' ||
     (config.backends.data === 'multiple' &&
-     config.backends.metadata !== 'scality')) {
+     config.backends.metadata !== 'scality') &&
+     (config.backends.auth !== 'scality' &&
+      config.backends.metadata !== 'mongodb')) {
     const dataServer = new arsenal.network.rest.RESTServer(
         { bindAddress: config.dataDaemon.bindAddress,
             port: config.dataDaemon.port,


### PR DESCRIPTION
Allows for the case where both MongoDB and Scality backend is enabled
and therefore would not require dataserver to be started.


The only way I could find to identify a scality backend with mongodb was via the auth. If there is a better way I will gladly update the PR.