### PR TITLE
bf: ZENKO-275 CRR to GCP MPU properties

### DIFF
--- a/lib/data/external/GCP/GcpApis/mpuHelper.js
+++ b/lib/data/external/GCP/GcpApis/mpuHelper.js
@@ -259,10 +259,11 @@ class MpuHelper {
                             err);
                         return next(err);
                     }
-                    return next(null, res.Metadata);
+                    return next(null, res);
                 });
             },
-            (metadata, next) => {
+            (res, next) => {
+                const metadata = res.Metadata;
                 // copy the final object into the main bucket
                 const copyMetadata = Object.assign({}, metadata);
                 copyMetadata['scal-etag'] = aggregateETag;
@@ -272,6 +273,11 @@ class MpuHelper {
                     Metadata: copyMetadata,
                     MetadataDirective: 'REPLACE',
                     CopySource: `${params.MPU}/${copySource}`,
+                    ContentType: res.ContentType,
+                    CacheControl: res.CacheControl,
+                    ContentEncoding: res.ContentEncoding,
+                    ContentDisposition: res.ContentDisposition,
+                    ContentLanguage: res.ContentLanguage,
                 };
                 logger.trace('copyParams', { copyParams });
                 this.retryCopy(copyParams, (err, res) => {


### PR DESCRIPTION
Properties (e.g. ContentType) on the source MPU do not end up as values of the final object when doing CRR to GCP.