### PR TITLE
bf: ZENKO-250 correctly evaluate regex pattern

### DIFF
--- a/lib/api/apiUtils/bucket/parseLikeExpression.js
+++ b/lib/api/apiUtils/bucket/parseLikeExpression.js
@@ -1,0 +1,19 @@
+/**
+ * parse LIKE expressions
+ * @param {string} regex - regex pattern
+ * @return {object} MongoDB search object
+ */
+function parseLikeExpression(regex) {
+    if (typeof regex !== 'string') {
+        return null;
+    }
+    const split = regex.split('/');
+    if (split.length < 3 || split[0] !== '') {
+        return { $regex: regex };
+    }
+    const pattern = split.slice(1, split.length - 1).join('/');
+    const regexOpt = split[split.length - 1];
+    return { $regex: pattern, $options: regexOpt };
+}
+
+module.exports = parseLikeExpression;

--- a/lib/api/apiUtils/bucket/parseWhere.js
+++ b/lib/api/apiUtils/bucket/parseWhere.js
@@ -1,3 +1,4 @@
+const parseLikeExpression = require('./parseLikeExpression');
 
 /*
   This code is based on code from https://github.com/olehch/sqltomongo
@@ -53,7 +54,7 @@ function parseWhere(root) {
         const e2 = parseWhere(root[operator][1]);
 
         // eslint-disable-next-line
-        return { '$and' : [ 
+        return { '$and' : [
             e1,
             e2,
         ] };
@@ -62,15 +63,21 @@ function parseWhere(root) {
         const e2 = parseWhere(root[operator][1]);
 
         // eslint-disable-next-line
-        return  { '$or' : [ 
+        return  { '$or' : [
             e1,
             e2,
         ] };
     }
     const field = root[operator][0];
+    const value = root[operator][1];
     const expr = exprMapper[operator];
     const obj = {};
-    obj[`value.${field}`] = { [expr]: root[operator][1] };
+
+    if (operator === 'LIKE') {
+        obj[`value.${field}`] = parseLikeExpression(value);
+    } else {
+        obj[`value.${field}`] = { [expr]: value };
+    }
 
     return obj;
 }

--- a/tests/unit/api/parseLikeExpression.js
+++ b/tests/unit/api/parseLikeExpression.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const parseLikeExpression =
+    require('../../../lib/api/apiUtils/bucket/parseLikeExpression');
+
+describe('parseLikeExpression', () => {
+    const tests = [
+        {
+            input: '',
+            output: { $regex: '' },
+        },
+        {
+            input: 'ice-cream-cone',
+            output: { $regex: 'ice-cream-cone' },
+        },
+        {
+            input: '/ice-cream-cone/',
+            output: { $regex: 'ice-cream-cone', $options: '' },
+        },
+        {
+            input: '/ice-cream-cone/i',
+            output: { $regex: 'ice-cream-cone', $options: 'i' },
+        },
+        {
+            input: 'an/ice-cream-cone/',
+            output: { $regex: 'an/ice-cream-cone/' },
+        },
+        {
+            input: '///',
+            output: { $regex: '/', $options: '' },
+        },
+    ];
+    tests.forEach(test => it('should return correct MongoDB query object: ' +
+        `"${test.input}" => ${JSON.stringify(test.output)}`, () => {
+        const res = parseLikeExpression(test.input);
+        assert.deepStrictEqual(res, test.output);
+    }));
+    const badInputTests = [
+        {
+            input: null,
+            output: null,
+        },
+        {
+            input: 1235,
+            output: null,
+        },
+    ];
+    badInputTests.forEach(test => it(
+        'should return null if input is not a string ' +
+        `"${test.input}" => ${JSON.stringify(test.output)}`, () => {
+        const res = parseLikeExpression(test.input);
+        assert.deepStrictEqual(res, test.output);
+    }));
+});


### PR DESCRIPTION
Original code will evaluate regex in `/pattern/` syntax incorrectly
Adds parser to have MD search recognize if a regex is in `/pattern/` syntax or
a simple string
