### PR TITLE
bf: ZENKO-332 fix Azure proxy localhost req

### DIFF
--- a/lib/data/external/AzureClient.js
+++ b/lib/data/external/AzureClient.js
@@ -27,12 +27,7 @@ class AzureClient {
             if (!parsedUrl.port) {
                 parsedUrl.port = 80;
             }
-            const proxyParams = {
-                protocol: parsedUrl.protocol,
-                host: parsedUrl.hostname,
-                proxyAuth: parsedUrl.auth,
-                port: parsedUrl.port,
-            };
+            const proxyParams = parsedUrl;
             if (config.proxy.certs) {
                 Object.assign(proxyParams, config.proxy.certs);
             }


### PR DESCRIPTION
This fixes the issue in Federation deployments where Azure backend request would default to localhost when using a proxy.