### PR TITLE
fix: use existing localCache redis configuration

### DIFF
--- a/lib/utilities/reportHandler.js
+++ b/lib/utilities/reportHandler.js
@@ -75,7 +75,7 @@ function getSystemStats() {
 
 function getCRRStats(log, cb) {
     log.debug('getting CRR stats', { method: 'getCRRStats' });
-    const { replicationEndpoints, redis } = config;
+    const { replicationEndpoints, localCache: redis } = config;
     if (!redis) {
         log.debug('redis connection not configured', { method: 'getCRRStats' });
         return process.nextTick(() => cb(null, {}));


### PR DESCRIPTION
A new “redis” configuration item that can not be set easily in containers while one already exists called localCache which is already configurable