### PR TITLE
ft: ZENKO-404 lifecycle service account

### DIFF
--- a/lib/api/apiUtils/authorization/aclChecks.js
+++ b/lib/api/apiUtils/authorization/aclChecks.js
@@ -1,15 +1,16 @@
 const constants = require('../../../../constants');
 
-function isReplicationUser(canonicalID) {
+function isBackbeatUser(canonicalID) {
     const canonicalIDArray = canonicalID.split('/');
-    return canonicalIDArray[canonicalIDArray.length - 1] === 'replication';
+    const serviceName = canonicalIDArray[canonicalIDArray.length - 1];
+    return ['replication', 'lifecycle'].includes(serviceName);
 }
 
 function isBucketAuthorized(bucket, requestType, canonicalID) {
     // Check to see if user is authorized to perform a
     // particular action on bucket based on ACLs.
     // TODO: Add IAM checks and bucket policy checks.
-    if (bucket.getOwner() === canonicalID || isReplicationUser(canonicalID)) {
+    if (bucket.getOwner() === canonicalID || isBackbeatUser(canonicalID)) {
         return true;
     } else if (requestType === 'bucketOwnerAction') {
         // only bucket owner can modify or retrieve this property of a bucket
@@ -75,7 +76,7 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
         return true;
     }
 
-    if (isReplicationUser(canonicalID)) {
+    if (isBackbeatUser(canonicalID)) {
         return true;
     }
     // account is authorized if:
@@ -130,5 +131,5 @@ function isObjAuthorized(bucket, objectMD, requestType, canonicalID) {
 module.exports = {
     isBucketAuthorized,
     isObjAuthorized,
-    isReplicationUser,
+    isBackbeatUser,
 };

--- a/lib/api/apiUtils/bucket/bucketCreation.js
+++ b/lib/api/apiUtils/bucket/bucketCreation.js
@@ -9,7 +9,7 @@ const createKeyForUserBucket = require('./createKeyForUserBucket');
 const metadata = require('../../../metadata/wrapper');
 const kms = require('../../../kms/wrapper');
 const isLegacyAWSBehavior = require('../../../utilities/legacyAWSBehavior');
-const { isReplicationUser } = require('../authorization/aclChecks');
+const { isBackbeatUser } = require('../authorization/aclChecks');
 
 const usersBucket = constants.usersBucket;
 const oldUsersBucket = constants.oldUsersBucket;
@@ -218,7 +218,7 @@ function createBucket(authInfo, bucketName, headers,
         const existingBucketMD = results.getAnyExistingBucketInfo;
         if (existingBucketMD instanceof BucketInfo &&
             existingBucketMD.getOwner() !== canonicalID &&
-            !isReplicationUser(canonicalID)) {
+            !isBackbeatUser(canonicalID)) {
             // return existingBucketMD to collect cors headers
             return cb(errors.BucketAlreadyExists, existingBucketMD);
         }


### PR DESCRIPTION
Add support for service account 'service-lifecycle' in addition to
existing 'service-replication'. ACL checks are shunted in both cases,
we may implement more fine-grained access control later.
