### PR TITLE
bf: lock node-http-mocks module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+      "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
       "requires": {
         "jsonparse": "1.3.1",
         "through": "2.3.8"
@@ -135,9 +135,9 @@
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.6"
@@ -223,9 +223,9 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#19bee770eabb42ca25033e45ab99559b2310b09d",
+      "version": "github:scality/Arsenal#5bf7fef53ca0f409dbba1e19095a25bd3862b0f8",
       "requires": {
-        "JSONStream": "1.3.2",
+        "JSONStream": "1.3.3",
         "ajv": "4.10.0",
         "async": "2.1.5",
         "bson": "2.0.4",
@@ -236,8 +236,8 @@
         "ipaddr.js": "1.2.0",
         "joi": "10.6.0",
         "level": "1.6.0",
-        "level-sublevel": "6.6.1",
-        "mongodb": "3.0.7",
+        "level-sublevel": "6.6.2",
+        "mongodb": "3.0.8",
         "node-forge": "0.7.5",
         "simple-glob": "0.1.0",
         "socket.io": "1.7.4",
@@ -257,11 +257,11 @@
           }
         },
         "mongodb": {
-          "version": "3.0.7",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.7.tgz",
-          "integrity": "sha512-n/14kMJEoARXz1qhpNPhUocqy+z5130jhqgEIX1Tsl8UVpHrndQ8et+VmgC4yPK/I8Tcgc93JEMQCHTekBUnNA==",
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.0.8.tgz",
+          "integrity": "sha512-mj7yIUyAr9xnO2ev8pcVJ9uX7gSum5LLs1qIFoWLxA5Il50+jcojKtaO1/TbexsScZ9Poz00Pc3b86GiSqJ7WA==",
           "requires": {
-            "mongodb-core": "3.0.7"
+            "mongodb-core": "3.0.8"
           }
         }
       }
@@ -712,7 +712,7 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#dbaf8cf911f447640512d0ac86c6974d735708fe",
       "requires": {
-        "arsenal": "github:scality/Arsenal#19bee770eabb42ca25033e45ab99559b2310b09d",
+        "arsenal": "github:scality/Arsenal#5bf7fef53ca0f409dbba1e19095a25bd3862b0f8",
         "werelogs": "github:scality/werelogs#0f97dc5b1d61cd38d618cf215be3c531c0e4e7d5"
       }
     },
@@ -733,10 +733,29 @@
         }
       }
     },
+    "buffer-alloc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
+      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "requires": {
+        "buffer-alloc-unsafe": "0.1.1",
+        "buffer-fill": "0.1.1"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
+      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "buffer-fill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
+      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
     },
     "buffer-from": {
       "version": "1.0.0",
@@ -807,7 +826,7 @@
       "version": "github:scality/cdmiclient#e86b46b2dfa52cd4d701bb0d8734300e47524c49",
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#19bee770eabb42ca25033e45ab99559b2310b09d",
+        "arsenal": "github:scality/Arsenal#5bf7fef53ca0f409dbba1e19095a25bd3862b0f8",
         "async": "1.4.2",
         "werelogs": "github:scality/werelogs#0f97dc5b1d61cd38d618cf215be3c531c0e4e7d5"
       },
@@ -1104,9 +1123,9 @@
       }
     },
     "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1183,12 +1202,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
@@ -1651,9 +1664,9 @@
       "dev": true
     },
     "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
     },
     "extend": {
       "version": "1.2.1",
@@ -1800,16 +1813,15 @@
         "mime-types": "2.1.18"
       }
     },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "dev": true
-    },
     "from": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1834,7 +1846,7 @@
         "signal-exit": "3.0.2",
         "string-width": "1.0.2",
         "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "wide-align": "1.1.3"
       }
     },
     "gcp-metadata": {
@@ -2817,15 +2829,16 @@
       }
     },
     "level-sublevel": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-      "integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
+      "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
       "requires": {
         "bytewise": "1.1.0",
         "levelup": "0.19.1",
         "ltgt": "2.1.3",
+        "pull-defer": "0.2.2",
         "pull-level": "2.0.4",
-        "pull-stream": "3.6.7",
+        "pull-stream": "3.6.8",
         "typewiselite": "1.0.0",
         "xtend": "4.0.1"
       },
@@ -2985,6 +2998,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
@@ -3088,18 +3107,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
-      "dev": true
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "mime": {
@@ -3283,9 +3290,9 @@
       }
     },
     "mongodb-core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.7.tgz",
-      "integrity": "sha512-z6YufO7s40wLiv2ssFshqoLS4+Kf+huhHq6KZ7gDArsKNzXYjAwTMnhEIJ9GQ8fIfBGs5tBLNPfbIDoCKGPmOw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.0.8.tgz",
+      "integrity": "sha512-dFxfhH9N7ohuQnINyIl6dqEF8sYOE0WKuymrFf3L3cipJNrx+S8rAbNOTwa00/fuJCjBMJNFsaA+R2N16//UIw==",
       "requires": {
         "bson": "1.0.6",
         "require_optional": "1.0.1"
@@ -3319,21 +3326,15 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
-    "net": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/net/-/net-1.0.2.tgz",
-      "integrity": "sha1-0XV+yaf7I3HYPPR1XOPifhCCk4g=",
-      "dev": true
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node-abi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.3.0.tgz",
-      "integrity": "sha512-zwm6vU3SsVgw3e9fu48JBaRBCJGIvAgysDsqtf5+vEexFE71bEOtaMWb5zr/zODZNzTPtQlqUUpC79k68Hspow==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.1.tgz",
+      "integrity": "sha512-pUlswqpHQ7zGPI9lGjZ4XDNIEUDbHxsltfIRb7dTnYdhgHWHOcB0MLZKLoCz6UMcGzSPG5wGl1HODZVQAUsH6w==",
       "requires": {
         "semver": "5.4.1"
       }
@@ -3344,20 +3345,13 @@
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "node-mocks-http": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.5.8.tgz",
-      "integrity": "sha512-M0hzy8zR8vPy5WQcfRnFHZ0Rzi+Ru3P7QLa4NZQAnxbFHyiwLgzseuvfnItCfa15Q2sWJNNxjNssjpJiQ+wocA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.5.2.tgz",
+      "integrity": "sha1-U3jG7LwOB3IZqPCYbywZR1sq48M=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.3",
-        "depd": "1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
+        "lodash.assign": "4.2.0",
         "mime": "1.6.0",
-        "net": "1.0.2",
-        "parseurl": "1.3.2",
-        "range-parser": "1.2.0",
         "type-is": "1.6.16"
       },
       "dependencies": {
@@ -3437,7 +3431,7 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
+        "are-we-there-yet": "1.1.5",
         "console-control-strings": "1.1.0",
         "gauge": "2.7.4",
         "set-blocking": "2.0.0"
@@ -3562,12 +3556,6 @@
         "better-assert": "1.0.2"
       }
     },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
-      "dev": true
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3646,18 +3634,18 @@
       "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
         "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.3.0",
+        "node-abi": "2.4.1",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
         "pump": "2.0.1",
-        "rc": "1.2.6",
-        "simple-get": "2.7.0",
-        "tar-fs": "1.16.0",
+        "rc": "1.2.7",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.2",
         "tunnel-agent": "0.6.0",
         "which-pm-runs": "1.0.0"
       }
@@ -3710,6 +3698,11 @@
       "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
       "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
     },
+    "pull-defer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
+      "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
+    },
     "pull-level": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
@@ -3719,7 +3712,7 @@
         "pull-cat": "1.1.11",
         "pull-live": "1.0.1",
         "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.7",
+        "pull-stream": "3.6.8",
         "pull-window": "2.1.4",
         "stream-to-pull-stream": "1.7.2"
       }
@@ -3730,7 +3723,7 @@
       "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "requires": {
         "pull-cat": "1.1.11",
-        "pull-stream": "3.6.7"
+        "pull-stream": "3.6.8"
       }
     },
     "pull-pushable": {
@@ -3739,9 +3732,9 @@
       "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
     },
     "pull-stream": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.7.tgz",
-      "integrity": "sha512-XdE2/o1I2lK7A+sbbA/HjYnd5Xk7wL5CwAKzqHIgcBsluDb0LiKHNTl1K0it3/RKPshQljLf4kl1aJ12YsCCGQ=="
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.8.tgz",
+      "integrity": "sha512-wQUIptQBcM0rFsUhZoEpOT3vUn73DtTGVq3NQ86c4T7iMOSprDzeKWYq2ksXnbwiuExTKvt+8G9fzNLFQuiO+A=="
     },
     "pull-window": {
       "version": "2.1.4",
@@ -3775,18 +3768,12 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
-      "dev": true
-    },
     "rc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-      "integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
+      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
       "requires": {
-        "deep-extend": "0.4.2",
+        "deep-extend": "0.5.1",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -4032,9 +4019,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-json-stringify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.1.0.tgz",
-      "integrity": "sha512-EzBtUaFH9bHYPc69wqjp0efJI/DPNHdFbGE3uIMn4sVbO0zx8vZ8cG4WKxQfOpUOKsQyGBiT2mTqnCw+6nLswA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg=="
     },
     "sax": {
       "version": "1.2.4",
@@ -4097,9 +4084,9 @@
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
     },
     "simple-get": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.7.0.tgz",
-      "integrity": "sha512-RkE9rGPHcxYZ/baYmgJtOSM63vH0Vyq+ma5TijBcLla41SWlh8t6XYIGMR/oeZcmr+/G8k+zrClkkVrtnQ0esg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
         "decompress-response": "3.3.0",
         "once": "1.4.0",
@@ -4330,7 +4317,7 @@
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
         "looper": "3.0.0",
-        "pull-stream": "3.6.7"
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -4447,14 +4434,14 @@
       }
     },
     "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.2.tgz",
+      "integrity": "sha512-LdknWjPEiZC1nOBwhv0JBzfJBGPJar08dZg2rwZe0ZTLQoRGEzgrl7vF3qUEkCHpI/wN9e7RyCuDhMsJUCLPPQ==",
       "requires": {
         "chownr": "1.0.1",
         "mkdirp": "0.5.1",
         "pump": "1.0.3",
-        "tar-stream": "1.5.5"
+        "tar-stream": "1.6.1"
       },
       "dependencies": {
         "pump": {
@@ -4469,13 +4456,16 @@
       }
     },
     "tar-stream": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
         "bl": "1.2.2",
+        "buffer-alloc": "1.1.0",
         "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
         "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -4531,6 +4521,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -4697,7 +4692,7 @@
     "utapi": {
       "version": "github:scality/utapi#2970d13b3fea0ab592afe477133308280b80e984",
       "requires": {
-        "arsenal": "github:scality/Arsenal#19bee770eabb42ca25033e45ab99559b2310b09d",
+        "arsenal": "github:scality/Arsenal#5bf7fef53ca0f409dbba1e19095a25bd3862b0f8",
         "async": "2.5.0",
         "ioredis": "2.4.0",
         "node-schedule": "1.2.0",
@@ -4737,7 +4732,7 @@
     "vaultclient": {
       "version": "github:scality/vaultclient#b00ae12b30075ba87982fcab81844c339927570b",
       "requires": {
-        "arsenal": "github:scality/Arsenal#19bee770eabb42ca25033e45ab99559b2310b09d",
+        "arsenal": "github:scality/Arsenal#5bf7fef53ca0f409dbba1e19095a25bd3862b0f8",
         "commander": "2.9.0",
         "werelogs": "github:scality/werelogs#0f97dc5b1d61cd38d618cf215be3c531c0e4e7d5",
         "xml2js": "0.4.17"
@@ -4783,7 +4778,7 @@
     "werelogs": {
       "version": "github:scality/werelogs#0f97dc5b1d61cd38d618cf215be3c531c0e4e7d5",
       "requires": {
-        "safe-json-stringify": "1.1.0"
+        "safe-json-stringify": "1.2.0"
       }
     },
     "which": {
@@ -4800,9 +4795,9 @@
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
     },
     "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lolex": "^1.4.0",
     "mocha": "^2.3.4",
     "mocha-junit-reporter": "1.11.1",
-    "node-mocks-http": "^1.5.2",
+    "node-mocks-http": "1.5.2",
     "s3blaster": "scality/s3blaster#z/1.0",
     "tv4": "^1.2.7"
   },


### PR DESCRIPTION
node-http-mocks version 1.7.0 has some breaking changes which fails the tests.
Fixing this version for now and we will revisit this when we do npm dependcy updates.